### PR TITLE
feat: package PowerMCP as an installable `powermcp` distribution + CLI

### DIFF
--- a/ANDES/andes_mcp.py
+++ b/ANDES/andes_mcp.py
@@ -10,16 +10,22 @@ from contextlib import redirect_stdout, redirect_stderr
 from mcp.server.fastmcp import FastMCP
 from typing import Dict, Any
 
-# Set up storage directory (relative to this script)
-STORE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".andes_runs")
-os.makedirs(STORE_DIR, exist_ok=True)
+# Storage directory resolved lazily (no filesystem writes at import time)
+def _andes_runs_dir():
+    try:
+        from powermcp.paths import runs_dir
+        return str(runs_dir("andes"))
+    except Exception:
+        import os
+        d = os.path.join(os.path.expanduser("~"), ".powermcp", "runs", "andes")
+        os.makedirs(d, exist_ok=True)
+        return d
 
-# Configure logging
+# Configure logging (stream only at import; file handler attached lazily)
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler(os.path.join(STORE_DIR, 'mcp_server.log')),
         logging.StreamHandler()
     ]
 )
@@ -30,6 +36,21 @@ logging.getLogger('andes').setLevel(logging.WARNING)
 logging.getLogger('numpy').setLevel(logging.WARNING)
 logging.getLogger('scipy').setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
+
+# Attach a file handler lazily on first tool use (no log file opened at import)
+_file_handler_added = False
+
+def _ensure_file_logging():
+    global _file_handler_added
+    if _file_handler_added:
+        return
+    try:
+        fh = logging.FileHandler(os.path.join(_andes_runs_dir(), 'mcp_server.log'))
+        fh.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        logging.getLogger().addHandler(fh)
+    except Exception:
+        pass
+    _file_handler_added = True
 
 # Initialize MCP server
 mcp = FastMCP("ANDES MCP Server")
@@ -48,6 +69,7 @@ def run_power_flow(file_path: str) -> Dict[str, Any]:
         Dict containing power flow results and output information
     """
     try:
+        _ensure_file_logging()
         # Convert to absolute path if not already
         abs_file_path = os.path.abspath(file_path)
         if not os.path.exists(abs_file_path):
@@ -57,7 +79,7 @@ def run_power_flow(file_path: str) -> Dict[str, Any]:
             }
 
         # Create a unique directory for this run
-        run_dir = os.path.join(STORE_DIR, f"pf_{Path(abs_file_path).stem}")
+        run_dir = os.path.join(_andes_runs_dir(), f"pf_{Path(abs_file_path).stem}")
         os.makedirs(run_dir, exist_ok=True)
         
         # Copy input file to run directory
@@ -126,16 +148,17 @@ def run_time_domain_simulation(step_size: float = 0.01, t_end: float = 10.0) -> 
         Dict containing simulation results and output information
     """
     try:
+        _ensure_file_logging()
         if 'current_system' not in system_state:
             return {
                 "status": "error",
                 "message": "No power system currently loaded. Run power flow first."
             }
-            
+
         ss = system_state['current_system']
-        
+
         # Create a unique directory for this run
-        run_dir = os.path.join(STORE_DIR, f"tds_{int(t_end)}s")
+        run_dir = os.path.join(_andes_runs_dir(), f"tds_{int(t_end)}s")
         os.makedirs(run_dir, exist_ok=True)
         
         # Save current directory and change to run directory
@@ -202,17 +225,18 @@ def run_eigenvalue_analysis(file_path: str) -> Dict[str, Any]:
         Dict containing the eigenvalue analysis results
     """
     try:
+        _ensure_file_logging()
         # Convert to absolute path if relative
         abs_file_path = os.path.abspath(file_path)
-        
+
         if not os.path.exists(abs_file_path):
             return {
                 "status": "error",
                 "message": f"File not found: {file_path}"
             }
-            
+
         # Create a unique directory for this run
-        run_dir = os.path.join(STORE_DIR, f"eig_{Path(abs_file_path).stem}")
+        run_dir = os.path.join(_andes_runs_dir(), f"eig_{Path(abs_file_path).stem}")
         os.makedirs(run_dir, exist_ok=True)
         
         # Save current directory and change to run directory
@@ -311,5 +335,5 @@ def get_system_info() -> Dict[str, Any]:
 
 if __name__ == "__main__":
     print(f"Starting ANDES MCP Server")
-    print(f"Using storage directory: {STORE_DIR}")
-    mcp.run(transport="stdio") 
+    print(f"Using storage directory: {_andes_runs_dir()}")
+    mcp.run(transport="stdio")

--- a/HOPE/src/hope_mcp_server/core.py
+++ b/HOPE/src/hope_mcp_server/core.py
@@ -18,6 +18,24 @@ import yaml
 DEFAULT_HOPE_REPO_ROOT = Path("/Users/qianzhang/Documents/GitHub/HOPE")
 DEFAULT_JULIA_COMMAND = "julia"
 
+
+def _hope_setting(env_var: str, config_key: str, default: Any) -> Any:
+    """Resolve a HOPE setting in order: env var, powermcp config, hardcoded default.
+
+    The powermcp import is wrapped in try/except so HOPE stays runnable standalone
+    (e.g. ``python -m hope_mcp_server``) without powermcp installed; on any failure
+    we fall back to the historical hardcoded default.
+    """
+    v = os.environ.get(env_var)
+    if v:
+        return v
+    try:
+        from powermcp.config import get_path
+
+        return get_path("hope", config_key, must_exist=False)
+    except Exception:
+        return default
+
 DEFAULT_CASE_ID = "md_gtep_clean"
 LEGACY_CASE_ALIASES = {
     DEFAULT_CASE_ID: "MD_GTEP_clean_case",
@@ -51,11 +69,13 @@ def success_result(**payload: Any) -> dict[str, Any]:
 
 
 def get_repo_root() -> Path:
-    return Path(os.environ.get("HOPE_REPO_ROOT", str(DEFAULT_HOPE_REPO_ROOT))).expanduser()
+    return Path(
+        _hope_setting("HOPE_REPO_ROOT", "repo_root", str(DEFAULT_HOPE_REPO_ROOT))
+    ).expanduser()
 
 
 def configured_julia_command() -> str:
-    return os.environ.get("HOPE_JULIA_BIN", DEFAULT_JULIA_COMMAND)
+    return _hope_setting("HOPE_JULIA_BIN", "julia_bin", DEFAULT_JULIA_COMMAND)
 
 
 def modelcases_root(repo_root: Path) -> Path:
@@ -110,7 +130,9 @@ def setup_command(repo_root: Path, julia_command: str) -> str:
 
 def validate_julia_command(repo_root: Path) -> tuple[str | None, dict[str, Any] | None]:
     julia_command = configured_julia_command()
-    julia_env = os.environ.get("HOPE_JULIA_BIN")
+    # An explicit julia binary (from HOPE_JULIA_BIN or powermcp config) is anything
+    # other than the bare default command, which routes through the PATH lookup below.
+    julia_env = julia_command if julia_command != DEFAULT_JULIA_COMMAND else None
     if julia_env:
         julia_path = Path(julia_env).expanduser()
         if not julia_path.is_file():
@@ -303,9 +325,10 @@ def _launch_job(
 
 def _build_julia_process_env() -> dict[str, str]:
     # Inherit the current process environment, then preserve JULIA_DEPOT_PATH
-    # when Claude Desktop config points Julia to a policy-trusted depot.
+    # when Claude Desktop config (or powermcp config) points Julia to a
+    # policy-trusted depot.
     proc_env = os.environ.copy()
-    julia_depot = os.environ.get("JULIA_DEPOT_PATH")
+    julia_depot = _hope_setting("JULIA_DEPOT_PATH", "julia_depot_path", "")
     if julia_depot:
         proc_env["JULIA_DEPOT_PATH"] = julia_depot
     return proc_env

--- a/LTSpice/ltspice_mcp.py
+++ b/LTSpice/ltspice_mcp.py
@@ -68,23 +68,55 @@ logging.basicConfig(
 # =============================================================================
 #  2. Environment & Path Configuration
 # =============================================================================
-# --- IMPORTANT: USER CONFIGURATION REQUIRED ---
-# The user must set this path to their LTspice executable.
-# Default for Windows:
-LTSPICE_EXECUTABLE_PATH = r"C:\Program Files\LTC\LTspiceXVII\XVIIx64.exe"
-# For macOS/Linux with Wine, it might look like:
-# LTSPICE_EXECUTABLE_PATH = "/Users/username/.wine/drive_c/Users/username/AppData/Local/Programs/ADI/LTspice/LTspice.exe"
-
 # On macOS/Linux, Wine is required to run the Windows version of LTSpice.
 WINE_COMMAND = "wine"
 
-# Define the base directory for all simulation outputs.
-# This script is in the project root, so we can get the directory directly.
-project_root = os.path.dirname(os.path.abspath(__file__))
-BASE_OUTPUT_DIR = os.path.join(project_root, "simulation_output")
 
-# Ensure the base output directory exists on startup.
-os.makedirs(BASE_OUTPUT_DIR, exist_ok=True)
+def _ltspice_exe():
+    """
+    Lazily resolve the LTspice executable path. Resolution order:
+      1. an explicit setting (env ``POWERMCP_LTSPICE_EXE`` or the ~/.powermcp
+         config key ``ltspice.exe``),
+      2. auto-detection of a standard install (modern ADI / legacy LTC / Wine),
+      3. the legacy Windows default (bare clone without powermcp).
+    On macOS/Linux this may be a Wine-wrapped path; that is handled by callers.
+    """
+    import os
+
+    explicit = os.environ.get("POWERMCP_LTSPICE_EXE")
+    if not explicit:
+        try:
+            from powermcp.config import get as _cfg_get
+            explicit = _cfg_get("ltspice", "exe")
+        except Exception:
+            explicit = None
+    if explicit:
+        return os.path.expanduser(explicit)
+
+    try:
+        from powermcp.detect import ltspice_exe as _detect
+        found = _detect()
+        if found:
+            return found
+    except Exception:
+        pass
+
+    return os.path.expanduser(r"C:\Program Files\LTC\LTspiceXVII\XVIIx64.exe")
+
+
+def _output_dir():
+    """
+    Lazily resolve a user-writable base directory for simulation outputs,
+    created on first use. Defaults to ~/.powermcp/runs/ltspice.
+    """
+    try:
+        from powermcp.paths import runs_dir
+        return str(runs_dir("ltspice"))
+    except Exception:
+        import os
+        d = os.path.join(os.path.expanduser("~"), ".powermcp", "runs", "ltspice")
+        os.makedirs(d, exist_ok=True)
+        return d
 
 
 def check_ltspice_executable():
@@ -96,8 +128,9 @@ def check_ltspice_executable():
         if not shutil.which(WINE_COMMAND):
             return False, f"'{WINE_COMMAND}' command not found. Wine is required to run LTspice on this OS."
 
-    if not os.path.exists(os.path.expanduser(LTSPICE_EXECUTABLE_PATH)):
-        return False, f"LTspice executable not found at '{LTSPICE_EXECUTABLE_PATH}'. Please check the path."
+    ltspice_exe = _ltspice_exe()
+    if not os.path.exists(os.path.expanduser(ltspice_exe)):
+        return False, f"LTspice executable not found at '{ltspice_exe}'. Please check the path."
     return True, ""
 
 
@@ -116,7 +149,7 @@ async def create_simulation_session(netlist_text: str) -> dict:
     """
     try:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        session_dir = os.path.join(BASE_OUTPUT_DIR, timestamp)
+        session_dir = os.path.join(_output_dir(), timestamp)
         os.makedirs(session_dir, exist_ok=True)
 
         netlist_path = os.path.join(session_dir, "circuit.net")
@@ -153,10 +186,11 @@ async def run_simulation(netlist_path: str, session_dir: str) -> dict:
 
     try:
         netlist_filename = os.path.basename(netlist_path)
+        ltspice_exe = _ltspice_exe()
         if sys.platform == "win32":
-            cmd = [LTSPICE_EXECUTABLE_PATH, "-b", netlist_filename]
+            cmd = [ltspice_exe, "-b", netlist_filename]
         else:
-            cmd = [WINE_COMMAND, LTSPICE_EXECUTABLE_PATH, "-b", netlist_filename]
+            cmd = [WINE_COMMAND, ltspice_exe, "-b", netlist_filename]
 
         process = subprocess.run(
             cmd, cwd=session_dir, capture_output=True, text=True, check=False
@@ -320,10 +354,11 @@ async def view_netlist_in_ltspice(netlist_path: str) -> dict:
         return {"status": "error", "message": f"Netlist file not found: '{netlist_path}'"}
 
     try:
+        ltspice_exe = _ltspice_exe()
         if sys.platform == "win32":
-            cmd = [LTSPICE_EXECUTABLE_PATH, os.path.abspath(netlist_path)]
+            cmd = [ltspice_exe, os.path.abspath(netlist_path)]
         else:
-            cmd = [WINE_COMMAND, LTSPICE_EXECUTABLE_PATH, os.path.abspath(netlist_path)]
+            cmd = [WINE_COMMAND, ltspice_exe, os.path.abspath(netlist_path)]
         subprocess.Popen(cmd)
         message = (f"🚀 LTspice launched successfully with {os.path.basename(netlist_path)}.\n"
                    f"💡 Note: The circuit is a text netlist, so no visual schematic will appear.")

--- a/PSCAD/pscad_mcp/core/connection_manager.py
+++ b/PSCAD/pscad_mcp/core/connection_manager.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import psutil
 import logging
-from typing import Optional
-import mhi.pscad
+from typing import Optional, TYPE_CHECKING
 from pscad_mcp.core.executor import robust_executor
+
+if TYPE_CHECKING:
+    import mhi.pscad
 
 logger = logging.getLogger("pscad-mcp.connection")
 
@@ -50,6 +54,14 @@ class PSCADConnectionManager:
 
     async def attach_local(self) -> str:
         """Robustly attach to any local PSCAD instance or launch a new one."""
+        try:
+            import mhi.pscad
+        except ImportError as e:
+            raise RuntimeError(
+                "PSCAD support requires Windows, a PSCAD installation, and "
+                "`pip install powermcp[pscad-windows]` (provides mhi-pscad/mhi-psout). "
+                "Original import error: " + repr(e)
+            )
         try:
             self._pscad = await robust_executor.run_safe(mhi.pscad.application)
             return f"Successfully attached to PSCAD {self._pscad.version} (Local)."

--- a/PSCAD/pscad_mcp/tools/app_tools.py
+++ b/PSCAD/pscad_mcp/tools/app_tools.py
@@ -4,7 +4,6 @@ from mcp.server.fastmcp import FastMCP
 from pscad_mcp.core.connection_manager import pscad_manager
 from pscad_mcp.core.executor import robust_executor
 from pscad_mcp.utils.doc_manager import doc_manager
-import mhi.pscad
 
 async def get_local_pscad() -> str:
     """Attach to a running local PSCAD instance or launch a new one."""

--- a/PSCAD/pscad_mcp/tools/data_tools.py
+++ b/PSCAD/pscad_mcp/tools/data_tools.py
@@ -5,13 +5,6 @@ from mcp.server.fastmcp import FastMCP
 from pscad_mcp.core.connection_manager import pscad_manager
 from pscad_mcp.core.executor import robust_executor
 
-# PSOUT availability check
-try:
-    import mhi.psout
-    PSOUT_AVAILABLE = True
-except ImportError:
-    PSOUT_AVAILABLE = False
-
 async def get_project_output(project_name: str) -> str:
     """Get the text output messages from the PSCAD project's runtime."""
     pscad = pscad_manager.pscad
@@ -20,9 +13,11 @@ async def get_project_output(project_name: str) -> str:
 
 async def read_output_file(file_path: str) -> Dict[str, Any]:
     """Read results from a .psout or .out file using mhi.psout."""
-    if not PSOUT_AVAILABLE:
+    try:
+        import mhi.psout
+    except ImportError:
         return {"error": "mhi-psout package not installed."}
-    
+
     try:
         abs_path = os.path.abspath(file_path)
         with mhi.psout.open(abs_path) as psout:

--- a/PSLF/pslf_mcp.py
+++ b/PSLF/pslf_mcp.py
@@ -1,6 +1,5 @@
 import sys
 import os
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import pandas as pd
 import subprocess
 from mcp.server.fastmcp import FastMCP
@@ -9,8 +8,48 @@ from typing import Dict, List, Optional, Tuple, Any, Union
 # Initialize MCP server
 mcp = FastMCP("PSLF Positive Sequence Load Flow Program")
 
-from PSLF_PYTHON import *
-init_pslf(silent=False, working_directory=os.getcwd())
+# ---------------------------------------------------------------------------
+# Lazy, memoized PSLF engine initialization.
+#
+# `from PSLF_PYTHON import *` and init_pslf() used to run at import time, which
+# crashed this module on any machine without PSLF and blocked packaging. The
+# PSLF_PYTHON module is vendor-supplied (not on PyPI); its directory comes from
+# ~/.powermcp/config.toml (key pslf.python_lib) when powermcp is installed and
+# is added to sys.path before the import. The wildcard names (Pslf,
+# CaseParameters, Bus, Flox, ...) are published into this module's globals on
+# first use, so the tool functions below keep referencing them unchanged.
+# ---------------------------------------------------------------------------
+_pslf_ready = False
+
+
+def _resolve_pslf_lib():
+    try:
+        from powermcp.config import get_path
+        return get_path("pslf", "python_lib", must_exist=False)
+    except Exception:
+        return None
+
+
+def _ensure_pslf():
+    """Inject the PSLF_PYTHON dir, import it, and call init_pslf() exactly once."""
+    global _pslf_ready
+    if _pslf_ready:
+        return
+    lib = _resolve_pslf_lib()
+    if lib and lib not in sys.path:
+        sys.path.insert(0, lib)
+    try:
+        import PSLF_PYTHON
+    except Exception as e:
+        raise RuntimeError(
+            "Could not import PSLF_PYTHON. Install PSLF and configure its path: "
+            "`powermcp config set pslf.python_lib <dir containing PSLF_PYTHON>`. "
+            "Original error: " + repr(e)
+        )
+    # Publish the wildcard names (Pslf, CaseParameters, Bus, Flox, init_pslf, ...).
+    globals().update({k: getattr(PSLF_PYTHON, k) for k in dir(PSLF_PYTHON) if not k.startswith("_")})
+    PSLF_PYTHON.init_pslf(silent=False, working_directory=os.getcwd())
+    _pslf_ready = True
 
 @mcp.tool()
 def open_case(case: str) -> Dict[str, Any]:
@@ -25,6 +64,7 @@ def open_case(case: str) -> Dict[str, Any]:
     """
     try:
         
+        _ensure_pslf()
         iret = Pslf.load_case(os.getcwd() + "\\" + case)
         cp = CaseParameters()
         
@@ -67,6 +107,7 @@ def save_case() -> Dict[str, Any]:
     """
     try:
         
+        _ensure_pslf()
         iret = Pslf.save_case(os.getcwd() + "\\temp.sav")
         
         if (iret == 0):
@@ -93,6 +134,7 @@ def solve_case() -> Dict[str, Any]:
     """
     try:
         
+        _ensure_pslf()
         iret = Pslf.solve_case()
         if (iret == 0):
             return {
@@ -151,6 +193,7 @@ def add_bus(busnum: int, busname: str, nominalkv: float, type: int = 1) -> Dict[
     """
     try:
         
+        _ensure_pslf()
         iret = Pslf.add_record(1, 0, busnum, 'type basekv busnam', str(type) + " " + str(nominalkv) + " " + busname)
         cp = CaseParameters()
         
@@ -253,6 +296,7 @@ def add_branch(frombus: int, tobus: int, reactance: float, circuit: str = "1 ", 
     """
     try:
         
+        _ensure_pslf()
         # determine if it is a transformer or transmission line
         index = Pslf.bus_internal_index(frombus)
         if (index < 0):
@@ -375,6 +419,7 @@ def add_generator(bus: int, power_scheduled_mw: float, genid: str = "1 ", power_
     """
     try:
         
+        _ensure_pslf()
         iret = Pslf.add_record(1, 3, str(bus) + " " + str(genid), "st mbase pgen pmax qmax qmin", "1 100 " + str(power_scheduled_mw) + " " + str(power_max) + " " + str(reactive_power_max) + " " + str(reactive_power_min))
         
         cp = CaseParameters()
@@ -452,6 +497,7 @@ def add_load(bus: int, real_power: float, reactive_power: float, loadid: str = "
     """
     try:
         
+        _ensure_pslf()
         iret = Pslf.add_record(1, 4, str(bus) + " " + loadid, "st p q", "1 " + str(real_power) + " " + str(reactive_power))
         
         cp = CaseParameters()
@@ -530,6 +576,7 @@ def add_shunt(bus: int, reactive_power: float, variable_flag: int = 0, reactive_
         Dict with status
     """
     try:
+        _ensure_pslf()
         if (variable_flag == 0):
             # Fixed shunt
             iret = Pslf.add_record(1, 5, str(bus) + " " + shuntid, "st b", "1 " + str(reactive_power / 100.0)) # Divide by system base MVA to get in per unit
@@ -610,8 +657,9 @@ def get_voltage(bus: int) -> Dict[str, Any]:
     """
     try:
         
+        _ensure_pslf()
         index = Pslf.bus_internal_index(bus)
-        
+
         if (index < 0):
             return {
                 'status': 'error bus not found'
@@ -648,6 +696,7 @@ def get_voltage_violations(overvoltage_threshold: float = 1.05, undervoltage_thr
     """
     try:
         
+        _ensure_pslf()
         bus_count = CaseParameters().Nbus
         
         overvoltage = {}
@@ -699,6 +748,7 @@ def get_overload_violations(overload_threshold: float = 1.0) -> Dict[str, Any]:
     """
     try:
         
+        _ensure_pslf()
         branch_count = CaseParameters().Nbrsec
         if (branch_count <= 0):
             return {
@@ -742,6 +792,7 @@ def run_contingency_analysis() -> Dict[str, Any]:
     
     # Save the case into a temporary file
     try:
+        _ensure_pslf()
         iret = Pslf.save_case(os.getcwd() + "\\sstools.sav")
     except Exception as e:
         return {

--- a/PSSE/psse_mcp.py
+++ b/PSSE/psse_mcp.py
@@ -4,25 +4,66 @@ import json
 import io
 from pathlib import Path
 
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from mcp.server.fastmcp import FastMCP
 from typing import Dict, List, Optional, Any
 
 # Initialize MCP server
 mcp = FastMCP("PSSE 35+ Positive Sequence Load Flow Program")
 
-# Import and initialize PSSE Python library
-# You need to change the path to the PSSE Python library and version to the path on your computer.
-sys.path.append(r'C:\Program Files\PTI\PSSE36\36.2\PSSPY311')
-sys.path.append(r'C:\Program Files\PTI\PSSE36\36.2\PSSBIN')
-os.environ['PATH'] = r'C:\Program Files\PTI\PSSE36\36.2\PSSPY311;' + os.environ['PATH']
-os.environ['PATH'] = r'C:\Program Files\PTI\PSSE36\36.2\PSSBIN;' + os.environ['PATH']
-import psse36
+# ---------------------------------------------------------------------------
+# Lazy, memoized PSS/E engine initialization.
+#
+# psspy lives in a local PSS/E install dir and psseinit() starts the engine.
+# Both used to run at import time, which crashed this module on any machine
+# without PSS/E and blocked packaging/discovery. They now run once, on the first
+# tool call. The PSSPYxxx / PSSBIN dirs come from ~/.powermcp/config.toml (keys
+# psse.python_lib, psse.bin) when powermcp is installed, else fall back to the
+# historical hardcoded paths so a raw checkout keeps working.
+# ---------------------------------------------------------------------------
+_PSSE_LEGACY = {
+    "python_lib": r"C:\Program Files\PTI\PSSE36\36.2\PSSPY311",
+    "bin": r"C:\Program Files\PTI\PSSE36\36.2\PSSBIN",
+}
+
+psspy = None  # imported lazily by _ensure_psse()
+_psse_ready = False
 
 
-import psspy
-psspy.psseinit(50)
+def _resolve_psse_paths():
+    """Return (python_lib, bin): config when available, else legacy defaults."""
+    try:
+        from powermcp.config import get_path
+        return (get_path("psse", "python_lib", must_exist=False),
+                get_path("psse", "bin", must_exist=False))
+    except Exception:
+        return _PSSE_LEGACY["python_lib"], _PSSE_LEGACY["bin"]
+
+
+def _ensure_psse():
+    """Inject PSS/E paths, import psspy, and call psseinit(50) exactly once."""
+    global psspy, _psse_ready
+    if _psse_ready:
+        return psspy
+    python_lib, bin_dir = _resolve_psse_paths()
+    for p in (python_lib, bin_dir):
+        if not p:
+            continue
+        if p not in sys.path:
+            sys.path.insert(0, p)
+        os.environ["PATH"] = p + os.pathsep + os.environ.get("PATH", "")
+    try:
+        import psse36  # noqa: F401  (vendor shim that sets up further paths)
+        import psspy as _psspy
+    except Exception as e:
+        raise RuntimeError(
+            "Could not import PSS/E (psspy). Ensure PSS/E is installed and its paths "
+            "are configured: `powermcp config set psse.python_lib <PSSPYxxx dir>` and "
+            "`powermcp config set psse.bin <PSSBIN dir>`. Original error: " + repr(e)
+        )
+    _psspy.psseinit(50)  # 50 = PSS/E 35+ bus mode; do NOT change
+    psspy = _psspy
+    _psse_ready = True
+    return psspy
 
 # Path to JSON command reference files
 JSON_DIR = Path(__file__).parent / "psspy_command_json"
@@ -368,6 +409,7 @@ def open_case(case: str) -> Dict[str, Any]:
         Dict with status and case information
     """
     try:
+        _ensure_psse()
         ierr = psspy.case(case)
         err, bus_data = psspy.abuscount(flag=2)
         err, branch_data = psspy.abrncount(flag=4)
@@ -397,6 +439,7 @@ def solve_case() -> Dict[str, Any]:
         Dict with status and result code
     """
     try:
+        _ensure_psse()
         ierr = psspy.nsol()
         if ierr == 0:
             return {'status': 'success', 'ierr': 0}
@@ -449,6 +492,7 @@ def run_psspy_command(function_name: str, arguments: Optional[Dict[str, Any]] = 
         return {"status": "error", "message": f"Unknown return_type '{return_type}' for '{function_name}'"}
 
     try:
+        _ensure_psse()
         result = handler(spec, arguments)
         # Attach function metadata for AI context
         result["_function"] = function_name

--- a/PowerFactory/Agent_DIgSILENT.py
+++ b/PowerFactory/Agent_DIgSILENT.py
@@ -24,12 +24,32 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 # ── PowerFactory Python path ──────────────────────────────────────
-# Prefer an environment variable so the repository does not hardcode a local
-# PowerFactory installation path.
-_pf_python_path = os.environ.get("POWERFACTORY_PYTHON_PATH") or os.environ.get("PYTHONPATH", "")
-for _path in [part.strip() for part in _pf_python_path.split(os.pathsep) if part.strip()]:
-    if _path not in sys.path:
-        sys.path.append(_path)
+# The bundled vendor `powerfactory` module lives next to the PowerFactory
+# installation. Its directory is resolved lazily (from powermcp config, with an
+# environment-variable fallback) and injected onto sys.path only at the moment
+# of the deferred `import powerfactory`, never at module import time.
+
+def _powerfactory_python_path():
+    import os
+    try:
+        from powermcp.config import get_path
+        p = get_path("powerfactory", "python_path", must_exist=False)
+        if p:
+            return p
+    except Exception:
+        pass
+    return os.environ.get("POWERFACTORY_PYTHON_PATH") or os.environ.get("PYTHONPATH")
+
+
+def _ensure_powerfactory_on_path():
+    """Inject the PowerFactory python_path dir onto sys.path if not present."""
+    raw = _powerfactory_python_path()
+    if not raw:
+        return
+    for _path in [part.strip() for part in raw.split(os.pathsep) if part.strip()]:
+        if _path not in sys.path:
+            sys.path.append(_path)
+
 
 # Deferred import: powerfactory is only available when PowerFactory is running.
 # Importing it at module level would crash the MCP server on startup if PF isn't
@@ -239,6 +259,7 @@ class DIgSILENTAgent:
             global pf
             open_digsilent = bool(getattr(self.cfg, "open_digsilent", 1))
             if pf is None:
+                _ensure_powerfactory_on_path()
                 import powerfactory as pf
             if DIgSILENTAgent._shared_app is None:
                 self.app = pf.GetApplicationExt()
@@ -729,6 +750,7 @@ class DIgSILENTAgent:
         """
         global pf
         if pf is None:
+            _ensure_powerfactory_on_path()
             import powerfactory as pf
 
         if not os.path.isfile(file_path):
@@ -797,6 +819,7 @@ class DIgSILENTAgent:
         """
         global pf
         if pf is None:
+            _ensure_powerfactory_on_path()
             import powerfactory as pf
 
         try:
@@ -1005,6 +1028,7 @@ class DIgSILENTAgent:
         """Run a load flow (ComLdf) on the currently active study case."""
         global pf
         if pf is None:
+            _ensure_powerfactory_on_path()
             import powerfactory as pf
         try:
             if cls._shared_app is None:
@@ -1046,6 +1070,7 @@ class DIgSILENTAgent:
         """Run a short-circuit calculation (ComShc) on the currently active study case."""
         global pf
         if pf is None:
+            _ensure_powerfactory_on_path()
             import powerfactory as pf
         try:
             if cls._shared_app is None:
@@ -1094,6 +1119,7 @@ class DIgSILENTAgent:
         """
         global pf
         if pf is None:
+            _ensure_powerfactory_on_path()
             import powerfactory as pf
 
         try:

--- a/PowerFactory/MCP_PowerFactory.py
+++ b/PowerFactory/MCP_PowerFactory.py
@@ -63,7 +63,31 @@ mcp = FastMCP(
 )
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
-_DEFAULT_CFG = os.path.join(_HERE, "simulation_config.json")
+
+
+def _default_cfg_path():
+    """Resolve the user-writable default config path (lazily, never at import).
+
+    Uses the powermcp config key ``powerfactory.config_path`` when set, otherwise
+    ``~/.powermcp/powerfactory/simulation_config.json``. On first use the bundled
+    ``simulation_config.example.json`` is copied there if the destination does not
+    yet exist (the packaged copy is read-only).
+    """
+    import os, shutil
+    try:
+        from powermcp.config import get_path
+        p = get_path("powerfactory", "config_path", must_exist=False)
+        if p:
+            return p
+    except Exception:
+        pass
+    base = os.path.join(os.path.expanduser("~"), ".powermcp", "powerfactory")
+    os.makedirs(base, exist_ok=True)
+    dest = os.path.join(base, "simulation_config.json")
+    example = os.path.join(os.path.dirname(os.path.abspath(__file__)), "simulation_config.example.json")
+    if not os.path.exists(dest) and os.path.exists(example):
+        shutil.copyfile(example, dest)
+    return dest
 
 # ── Single dedicated thread for ALL PowerFactory API calls ────────────────────
 # PowerFactory's Python API requires every call to originate from the same
@@ -150,7 +174,7 @@ def close_digsilent() -> str:
 @mcp.tool()
 def get_config(cfg_path: str = "") -> str:
     """Return the active simulation_config.json as a JSON string."""
-    path = cfg_path or _DEFAULT_CFG
+    path = cfg_path or _default_cfg_path()
     with open(path, "r", encoding="utf-8") as fh:
         return json.dumps(json.load(fh), indent=2, ensure_ascii=False)
 
@@ -218,7 +242,7 @@ def create_study_case(
         JSON string with success flag and message.
     """
     SimulationConfig, DIgSILENTAgent = _load_modules()
-    path = cfg_path or _DEFAULT_CFG
+    path = cfg_path or _default_cfg_path()
     cfg = SimulationConfig.from_json(path)
     ok, msg = _pf(
         DIgSILENTAgent.create_study_case,
@@ -296,7 +320,7 @@ def run_loadflow(
     output_dir = r"C:\RMS_Results"
     run_label = "run_001"
     if save_csv:
-        path = cfg_path or _DEFAULT_CFG
+        path = cfg_path or _default_cfg_path()
         try:
             cfg = SimulationConfig.from_json(path)
             output_dir = getattr(cfg, "output_dir", output_dir) or output_dir
@@ -364,7 +388,7 @@ def run_simulation(
         and per-step status.
     """
     SimulationConfig, DIgSILENTAgent = _load_modules()
-    path = cfg_path or _DEFAULT_CFG
+    path = cfg_path or _default_cfg_path()
     cfg = SimulationConfig.from_json(path)
     cfg.export_pfd = 1 if export_pfd else 0
     cfg.open_digsilent = 1 if open_digsilent else 0
@@ -438,7 +462,7 @@ def run_custom_case(
         JSON string with pipeline result (same schema as run_simulation).
     """
     SimulationConfig, DIgSILENTAgent = _load_modules()
-    path = cfg_path or _DEFAULT_CFG
+    path = cfg_path or _default_cfg_path()
     cfg = SimulationConfig.from_json(path)
     if create_new_study_case:
         ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
@@ -502,7 +526,7 @@ def read_results_csv(csv_path: str = "", max_rows: int = 2000, as_path: bool = F
     if csv_path:
         target = csv_path
     else:
-        with open(_DEFAULT_CFG, "r", encoding="utf-8") as fh:
+        with open(_default_cfg_path(), "r", encoding="utf-8") as fh:
             cfg_data = json.load(fh)
         base_dir = cfg_data.get("output_dir", _HERE)
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,18 @@ We're building an open-source community focused on accelerating AI adoption in t
 
 ## 🚀 Getting Started with MCP
 
-### 📖 Quick Tutorial
+### 📖 Quick start
 
 > **🚀 New to PowerMCP? Start here!**
 
-📋 **[PowerMCP Tutorial PDF](https://github.com/Power-Agent/PowerMCP/blob/main/PowerMCP_Tutorial.pdf)** - Your complete guide to getting started with PowerMCP
+The recommended way to get started is the `powermcp` package and its installer (see the **Installation** section below):
 
-*This comprehensive tutorial will walk you through everything you need to know to begin using PowerMCP effectively.*
+```bash
+pip install powermcp
+powermcp install        # pick tools, capture local paths, write your MCP client config
+```
+
+> 📋 The **[PowerMCP Tutorial PDF](https://github.com/Power-Agent/PowerMCP/blob/main/PowerMCP_Tutorial.pdf)** documents the original **low-code / manual** setup — cloning the repo and hand-editing the Claude Desktop config. It predates the `powermcp` installer and is **not the recommended path**; use it only if you specifically want the manual approach.
 
 
 ### Video Demos
@@ -59,28 +64,80 @@ Check out these helpful tutorials to get started with MCP:
 - [**Cursor MCP Tutorial**](https://cursor.com/docs/context/mcp): Learn how to use MCP with Cursor.
 - [**Other Protocol**](https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf): Open AI Function Calling Tool
 
-### Testing with your LLMs
+## 📦 Installation
 
-> **Note:** All MCPs should be tested via Claude Desktop before submitting a PR to ensure consistency.
+PowerMCP installs as a single Python package with an interactive CLI. Python 3.10+ is required.
 
-Open `config.json` and add the MCP servers for the power system tools you have installed. For example:
-
-```json
-{
-  "mcpServers": {
-    "pandapower": {
-      "command": "python",
-      "args": ["pandapower/panda_mcp.py"]
-    },
-    "powerworld": {
-      "command": "python",
-      "args": ["PowerWorld/powerworld_mcp.py"]
-    }
-  }
-}
+```bash
+pip install powermcp
 ```
 
-Then, follow the setup instructions and configuration details in **[PowerMCP Tutorial PDF](PowerMCP_Tutorial.pdf)**.
+The base install includes the two open-source engines that need no extra setup — **pandapower** and **PyPSA**. Every other tool is opt-in via an extra:
+
+```bash
+pip install powermcp[psse]              # add PSS/E support
+pip install powermcp[andes,opendss]     # add several tools at once
+pip install powermcp[opensource]        # all open-source tools (ANDES, Egret, OpenDSS, surge, HOPE, LTSpice)
+pip install powermcp[all]               # everything (closed-source tools still need the local software)
+```
+
+### Set up with the interactive installer
+
+```bash
+powermcp install
+```
+
+The wizard lets you pick tools (pandapower + PyPSA pre-selected), captures the local install path for any closed-source/EXE-based tools you choose (PSS/E, PSLF, PowerFactory, PSCAD, LTSpice), installs the right extras, and writes the MCP client configuration for **Claude Desktop**, **Claude Code**, and the **Codex CLI**. Use `--dry-run` to preview the changes, or `--yes` for a non-interactive core install.
+
+In the interactive picker, move with ↑/↓ and **press SPACE to toggle each tool** before ENTER (ENTER alone keeps only the preselected tools). Prefer not to use the checkbox? Choose tools directly:
+
+```bash
+powermcp install --tools psse,andes      # core + the listed tools
+powermcp install --all                   # every tool available on this platform
+```
+
+Re-running `powermcp install` pre-checks the tools you've already installed or configured, so it **preserves and updates** your setup instead of resetting to the core tools. Paths for tools like LTSpice are **auto-detected and pre-filled**, so you can usually just press Enter.
+
+### CLI commands
+
+| Command | Description |
+|---|---|
+| `powermcp install` | Setup wizard — interactive, or `--tools <ids>` / `--all` (also `--dry-run`, `--yes`, `--clients`) |
+| `powermcp run <tool>` | Launch a server over stdio (used by the generated client config) |
+| `powermcp list` | List the available tools, extras, and Windows-only flags |
+| `powermcp doctor` | Check each tool's dependencies and configured paths |
+| `powermcp config show` / `config set <tool>.<key> <path>` | Inspect / set local software paths |
+
+### Closed-source / EXE-based tools
+
+These tools wrap commercial or locally-installed software, so PowerMCP stores the local path in `~/.powermcp/config.toml` (captured by `powermcp install`, or set manually with `powermcp config set`):
+
+| Tool | Config keys | Example |
+|---|---|---|
+| PSS/E | `psse.python_lib`, `psse.bin` | `powermcp config set psse.python_lib "C:\Program Files\PTI\PSSE36\36.2\PSSPY311"` |
+| PSLF | `pslf.python_lib` | `powermcp config set pslf.python_lib "C:\Program Files\GE PSLF\PSLF_PYTHON"` |
+| PowerFactory | `powerfactory.python_path` | `powermcp config set powerfactory.python_path "...\DIgSILENT\PowerFactory 2024\Python\3.11"` |
+| LTSpice | `ltspice.exe` *(auto-detected)* | Found automatically in standard locations — usually no setup needed. Override: `powermcp config set ltspice.exe "C:\Program Files\ADI\LTspice\LTspice.exe"` |
+| HOPE | `hope.repo_root`, `hope.julia_bin` | `powermcp config set hope.repo_root "C:\src\HOPE"` |
+| PowerWorld | *(none)* | `esa` auto-discovers a running, licensed Simulator via COM; the `powerworld` extra also installs `numba` (required by esa) |
+| PSCAD | *(none)* | `pip install powermcp[pscad-windows]` provides `mhi-pscad`; PSCAD must be installed |
+
+> The Codex *Desktop* app on Windows has been reported to overwrite `~/.codex/config.toml`; the Codex *CLI* is unaffected. If you use both, re-run `powermcp install` after Desktop edits.
+
+### Running from a clone (without installing)
+
+Every server is still a standalone script. Clone the repo and run any server directly for use in Claude Desktop:
+
+```bash
+python pandapower/panda_mcp.py
+python PSSE/psse_mcp.py          # uses ~/.powermcp/config.toml if present, else legacy default paths
+```
+
+### Testing with your LLMs
+
+> **Note:** All MCPs should be tested via an MCP client (Claude Desktop, Claude Code, or Codex) before submitting a PR to ensure consistency.
+
+`powermcp install` writes the client configuration for you. The generated entries look like the example in [`config.json`](config.json). (The **[PowerMCP Tutorial PDF](PowerMCP_Tutorial.pdf)** covers the older manual / low-code setup and isn't needed for the package install.)
 
 ## 📚 Documentation
 

--- a/config.json
+++ b/config.json
@@ -1,92 +1,16 @@
 {
   "mcpServers": {
-    "andes": {
-      "command": "cmd",
-      "args": [
-        "/c",
-        "yourpath\\python.exe",
-        "your path\\PowerMCP\\ANDES\\andes_mcp.py"
-      ]
+    "powermcp_pandapower": {
+      "command": "powermcp",
+      "args": ["run", "pandapower"]
     },
-    "egret": {
-      "command": "cmd",
-      "args": [
-        "/c",
-        "yourpath\\python.exe",
-        "yourpath\\PowerMCP\\Egret\\egret_mcp.py"
-      ]
+    "powermcp_pypsa": {
+      "command": "powermcp",
+      "args": ["run", "pypsa"]
     },
-    "opendss": {
-      "command": "cmd",
-      "args": [
-        "/c",
-        "yourpath\\python.exe",
-        "yourpath\\PowerMCP\\OpenDSS\\opendss_mcp.py"
-      ]
-    },
-    "pandapower": {
-      "command": "cmd",
-      "args": [
-        "/c",
-        "yourpath\\python.exe",
-        "yourpath\\PowerMCP\\pandapower\\panda_mcp.py"
-      ]
-    },
-    "powerworld": {
-      "command": "cmd",
-      "args": [
-        "/c",
-        "yourpath\\python.exe",
-        "yourpath\\PowerMCP\\PowerWorld\\powerworld_mcp.py"
-      ]
-    },
-    "pslf": {
-      "command": "cmd",
-      "args": [
-        "/c",
-        "yourpath\\python.exe",
-        "yourpath\\PowerMCP\\PSLF\\pslf_mcp.py"
-      ]
-    },
-    "psse": {
-      "command": "cmd",
-      "args": [
-        "/c",
-        "yourpath\\python.exe",
-        "yourpath\\PowerMCP\\PSSE\\psse_mcp.py"
-      ]
-    },
-    "ltspice": {
-      "command": "cmd",
-      "args": [
-        "/c",
-        "yourpath\\python.exe",
-        "yourpath\\PowerMCP\\LTSpice\\ltspice_mcp.py"
-      ]
-    },
-    "pypsa": {
-      "command": "cmd",
-      "args": [
-        "/c",
-        "yourpath\\python.exe",
-        "yourpath\\PowerMCP\\PyPSA\\pypsa_mcp.py"
-      ]
-    },
-    "surge": {
-      "command": "cmd",
-      "args": [
-        "/c",
-        "yourpath\\python.exe",
-        "yourpath\\PowerMCP\\surge\\surge_mcp.py"
-      ]
-    },
-    "filesystem": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-filesystem",
-        "yourpath\\PowerMCP"
-      ]
+    "powermcp_psse": {
+      "command": "powermcp",
+      "args": ["run", "psse"]
     }
   }
 }

--- a/powermcp/README.md
+++ b/powermcp/README.md
@@ -1,0 +1,321 @@
+# `powermcp` — package & CLI
+
+This folder is the **PowerMCP core package**: the CLI installer (`powermcp install`),
+the launcher (`powermcp run`), the central config (`~/.powermcp/config.toml`), the tool
+registry, and the MCP client-config writers. The actual MCP servers live in the
+top-level tool dirs (`PSSE/`, `pandapower/`, …) and are shipped into the wheel under
+`powermcp/_servers/` at build time.
+
+This guide shows how to **install** and **test** the packaged version.
+
+---
+
+## 1. Install (as a user)
+
+Requires **Python 3.10+**.
+
+```bash
+pip install powermcp
+```
+
+The base install includes only the two zero-setup open-source engines: **pandapower**
+and **PyPSA**. Everything else is opt-in via an extra:
+
+```bash
+pip install "powermcp[psse]"            # one tool
+pip install "powermcp[andes,opendss]"   # several
+pip install "powermcp[opensource]"      # all open-source tools
+pip install "powermcp[all]"             # everything
+```
+
+> On Windows use the `py` launcher if `python` isn't on PATH:
+> `py -m pip install powermcp`. Quote the brackets in PowerShell/zsh: `"powermcp[psse]"`.
+
+### Available extras
+
+| Extra | Tool(s) | Notes |
+|---|---|---|
+| *(none / core)* | pandapower, PyPSA | always installed |
+| `andes` | ANDES | |
+| `egret` | Egret | + needs an external solver (ipopt/Gurobi) |
+| `opendss` | OpenDSS | |
+| `surge` | surge | **Python 3.12–3.14 only** |
+| `hope` | HOPE | + needs Julia at runtime |
+| `ltspice` | LTSpice | executable **auto-detected** (override with `ltspice.exe`) |
+| `powerworld` | PowerWorld | needs licensed Simulator (COM); extra also installs `numba` (required by esa 1.3.5) |
+| `psse`, `pslf`, `powerfactory` | PSS/E, PSLF, PowerFactory | engine loaded from a configured local path |
+| `pscad-windows` | PSCAD | Windows only; pulls `mhi-pscad`/`mhi-psout` |
+| `opensource` | all open-source tools | convenience group |
+| `windows` / `all` | Windows / everything | convenience groups |
+
+---
+
+## 2. Set it up
+
+```bash
+powermcp install
+```
+
+The interactive wizard:
+1. lets you pick tools (pandapower + PyPSA pre-checked; Windows-only tools hidden off Windows),
+2. prompts for the local software path of any closed-source tool you select,
+3. `pip install`s the chosen extras,
+4. writes the MCP client config for **Claude Desktop**, **Claude Code**, and the **Codex CLI**.
+
+> In the interactive picker you must press **SPACE to toggle each tool**, then ENTER to
+> confirm — pressing ENTER alone keeps only the preselected core tools. If your terminal
+> doesn't render the checkbox well, use `--tools`/`--all` below instead.
+
+**Choose tools non-interactively** (recommended when scripting or if the picker misbehaves):
+
+```bash
+powermcp install --tools psse,andes              # core + the listed tools
+powermcp install --all                           # every tool available on this platform
+powermcp install --tools psse --clients claude-desktop
+```
+
+`--tools` takes comma-separated tool ids (see `powermcp list`); core tools are always
+included, and ids not valid on your platform/Python are skipped with a notice.
+
+**Re-running is non-destructive.** The picker pre-checks the tools you've already installed
+or configured (and any already present in the targeted client config), so confirming
+**preserves and updates** your existing setup instead of resetting to core. Paths such as
+LTSpice's are auto-detected and pre-filled, so you can usually just press Enter.
+
+Useful flags: `--dry-run` (preview, write nothing — not even `config.toml`),
+`--yes` (non-interactive core only), `--tools <ids>` / `--all` (pick tools without the
+picker), `--clients claude-desktop,codex` (choose which clients; `none` to skip).
+
+### All CLI commands
+
+```bash
+powermcp install                         # setup wizard
+powermcp run <tool>                      # launch a server over stdio (used by clients)
+powermcp list                            # list tools, extras, windows-only flags
+powermcp doctor                          # check deps + configured paths for every tool
+powermcp config show                     # print ~/.powermcp/config.toml
+powermcp config set <tool>.<key> <path>  # set one path
+powermcp --version
+```
+
+### Closed-source tool paths
+
+These are stored in `~/.powermcp/config.toml` (captured by the wizard, or set manually):
+
+```bash
+powermcp config set psse.python_lib "C:\Program Files\PTI\PSSE36\36.2\PSSPY311"
+powermcp config set psse.bin        "C:\Program Files\PTI\PSSE36\36.2\PSSBIN"
+powermcp config set ltspice.exe     "C:\Program Files\ADI\LTspice\LTspice.exe"
+powermcp config set pslf.python_lib "C:\Program Files\GE PSLF\PSLF_PYTHON"
+powermcp config set powerfactory.python_path "...\DIgSILENT\PowerFactory 2024\Python\3.11"
+powermcp config set hope.repo_root  "C:\src\HOPE"
+```
+
+Resolution order for each key is **environment variable** (`POWERMCP_PSSE_BIN`, …) →
+**config.toml** → **legacy default** → a clear "run `powermcp install`" error.
+
+> **LTSpice is auto-detected** in standard install locations (modern ADI, legacy LTC, Wine),
+> so `ltspice.exe` usually doesn't need to be set at all — the server resolver falls back to
+> detection (env/config → auto-detect → legacy), and the wizard pre-fills the detected path.
+> Set it only for a non-standard install.
+
+### Use PowerMCP in Claude Desktop
+
+Claude Desktop has no CLI — it reads a JSON config file. Let the installer write/merge it:
+
+```bash
+powermcp install --clients claude-desktop
+```
+
+This merges one server per selected tool into `claude_desktop_config.json`, preserving any
+servers you already have (and backing the file up once). The file lives at:
+
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Linux:** `~/.config/Claude/claude_desktop_config.json`
+
+Preview without writing anything: `powermcp install --clients claude-desktop --dry-run`.
+
+**Manual setup** — open that file (in Claude Desktop: **Settings → Developer → Edit Config**)
+and add entries under `mcpServers`. Use the **absolute interpreter path**: Claude Desktop is a
+GUI app and does *not* inherit your shell PATH, so a bare `python`/`powermcp` usually won't be
+found.
+
+```json
+{
+  "mcpServers": {
+    "powermcp_pandapower": {
+      "command": "D:\\PowerMCP\\.venv\\Scripts\\python.exe",
+      "args": ["-m", "powermcp", "run", "pandapower"]
+    },
+    "powermcp_psse": {
+      "command": "D:\\PowerMCP\\.venv\\Scripts\\python.exe",
+      "args": ["-m", "powermcp", "run", "psse"]
+    }
+  }
+}
+```
+
+(JSON needs escaped backslashes on Windows. Find the interpreter with
+`python -c "import sys; print(sys.executable)"`.)
+
+**Apply & verify:** fully **quit and reopen** Claude Desktop — closing the window isn't enough;
+exit it from the system tray / menu bar, then relaunch. The PowerMCP tools then appear under the
+tools (🔨) control in the message box, and **Settings → Developer** lists each server with its
+connection status.
+
+**Closed-source tools:** set the path first (`powermcp config set …`), confirm with
+`powermcp doctor`, then restart Claude Desktop.
+
+### Use PowerMCP in Claude Code
+
+**Option A — let the installer do it (recommended):**
+
+```bash
+powermcp install --clients claude-code
+```
+
+This adds one MCP server per selected tool to the **user scope** of Claude Code
+(the `mcpServers` block of `~/.claude.json`), so they're available in every project.
+Each entry uses the absolute interpreter path (`<python> -m powermcp run <tool>`) so
+Claude Code can always launch it. Re-running is idempotent and prunes tools you deselect.
+
+**Option B — add them manually with the Claude Code CLI:**
+
+```bash
+# --scope user = available everywhere; the `--` separates Claude's flags from the command
+claude mcp add powermcp_pandapower --scope user -- python -m powermcp run pandapower
+claude mcp add powermcp_psse       --scope user -- python -m powermcp run psse
+```
+
+If `python` on PATH isn't the interpreter that has `powermcp` installed (e.g. you
+installed into a venv), use the **full interpreter path** so it always resolves:
+
+```bash
+# Windows (venv) example
+claude mcp add powermcp_pandapower --scope user -- "D:\PowerMCP\.venv\Scripts\python.exe" -m powermcp run pandapower
+```
+
+**Verify and use:**
+
+```bash
+claude mcp list                     # should list the powermcp_* servers (✓ connected)
+claude mcp get powermcp_pandapower  # show one server's details
+```
+
+Inside a Claude Code session, run `/mcp` to see connected servers and their tools, then
+just ask — e.g. *"create an empty pandapower network and run a power flow."*
+
+**Scopes:** `--scope user` (you, everywhere — what the installer uses) ·
+`--scope project` (shared via a checked-in `.mcp.json`, prompts teammates for approval) ·
+`--scope local` (this project only, private to you).
+
+**Closed-source tools:** set the software path first (e.g.
+`powermcp config set psse.python_lib "…\PSSPY311"`) and confirm with `powermcp doctor`
+before adding the server, otherwise the tool will report an actionable error on first call.
+
+**To remove a server:** `claude mcp remove powermcp_pandapower --scope user`.
+
+---
+
+## 3. Run from a clone (no install)
+
+Every server is still a standalone script, so you can clone the repo and run one directly
+for Claude Desktop without `pip install`:
+
+```bash
+python pandapower/panda_mcp.py
+python PSSE/psse_mcp.py     # uses ~/.powermcp/config.toml if present, else legacy paths
+```
+
+---
+
+## 4. Test the package (developers)
+
+The test suite lives in [`../tests`](../tests) (≈62 tests). It needs no licensed software —
+vendor engines are stubbed, and server launches are checked with the stdio loop monkeypatched.
+
+### A. Quick loop — editable install
+
+```bash
+python -m venv .venv
+.venv\Scripts\activate           # Windows;  source .venv/bin/activate elsewhere
+pip install -e . pytest
+pytest -q
+```
+
+`pip install -e .` picks up source edits live, so re-run `pytest` after each change.
+
+### B. Full gate — build the wheel and test the installed artifact
+
+This is what CI should run: it proves the wheel ships correctly and resolves paths in the
+**installed (wheel) layout**, which differs from the editable/checkout layout.
+
+```bash
+# 1) build
+python -m venv build-env && build-env\Scripts\python -m pip install build
+build-env\Scripts\python -m build           # writes dist/powermcp-*.whl (+ sdist)
+
+# 2) install the wheel into a clean venv
+python -m venv test-env
+test-env\Scripts\python -m pip install dist\powermcp-0.1.0-py3-none-any.whl pytest
+
+# 3) run the suite against the INSTALLED package (run from a dir without the repo on the path)
+copy ..\tests to a temp dir, then:  test-env\Scripts\python -m pytest <tempdir>\tests -q
+```
+
+What the build gate confirms:
+- `pip install powermcp` pulls **core only** (no esa/andes/surge/psspy):
+  `test-env\Scripts\python -m pip list`
+- the data files ship (2184 PSS/E JSONs, OpenDSS `13Bus/IEEELineCodes.DSS`, surge schema):
+  inspect the wheel with `python -m zipfile -l dist\powermcp-*.whl`
+
+### C. Manual smoke checks
+
+```bash
+powermcp --version
+powermcp list
+powermcp doctor                                  # status table for all tools
+powermcp install --yes --dry-run                 # preview client config, write nothing
+powermcp config set ltspice.exe C:\tmp\x.exe && powermcp config show
+powermcp run pandapower                          # starts a stdio server; Ctrl-C to stop
+```
+
+`powermcp doctor` is the fastest health check: green = the Python package is importable;
+yellow = a path/config is missing; it also reminds you which tools need external solvers
+(HiGHS, ipopt, Gurobi) or Julia at runtime.
+
+### What the tests cover (mapped to the suite)
+
+| File | Focus |
+|---|---|
+| `test_config.py` | config read/write, `get_path` resolution + actionable errors, Windows-path round-trip |
+| `test_registry.py` | tool metadata consistency, path resolution across layouts |
+| `test_runner.py` | `powermcp run` launches once; no library shadowing; preflight + namespace-package probe; `python -m powermcp` |
+| `test_vendor_import.py` | PSS/E & PSLF import **without** the software and init the engine exactly once |
+| `test_clients.py` | idempotent merge, foreign-server preservation, prune, backup, Codex TOML |
+| `test_wizard.py` | tool selection (`--tools`/`--all`, preselection of installed/configured tools), Windows/surge filtering, non-interactive handling |
+| `test_doctor.py` | dependency/path status, namespace-shadow guard |
+| `test_detect.py` | LTSpice executable auto-detection across install layouts |
+
+> **Licensed tools (PSS/E, PSLF, PowerFactory, PSCAD, PowerWorld, LTSpice)** can't run in CI.
+> The suite verifies they *import safely* and produce actionable errors; running an actual
+> tool requires the software installed and a `powermcp config set …` path, then
+> `powermcp doctor` and a live `powermcp run <tool>` from your MCP client.
+
+---
+
+## 5. Layout
+
+```
+powermcp/
+  cli.py          # `powermcp` entry point (install/run/list/config/doctor)
+  wizard.py       # interactive installer
+  runner.py       # launches a server by tool id
+  registry.py     # the tool registry (single source of truth)
+  config.py       # ~/.powermcp/config.toml  + get_path()
+  paths.py        # ~/.powermcp/runs/<tool> writable dirs
+  doctor.py       # health checks
+  clients/        # claude_desktop / claude_code / codex config writers
+  _servers/       # (wheel only) the tool dirs, shipped verbatim at build time
+```

--- a/powermcp/__init__.py
+++ b/powermcp/__init__.py
@@ -1,0 +1,12 @@
+"""PowerMCP — MCP servers for power-system software.
+
+A single distribution that bundles MCP servers for pandapower, PyPSA, ANDES,
+Egret, surge, OpenDSS, HOPE, PSCAD, PSS/E, PSLF, PowerWorld, PowerFactory and
+LTSpice. Install the core (`pip install powermcp` → pandapower + PyPSA) and add
+tools via extras (`pip install powermcp[psse]`). Configure and wire up MCP
+clients with the `powermcp` CLI (`powermcp install`).
+"""
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/powermcp/__main__.py
+++ b/powermcp/__main__.py
@@ -1,0 +1,13 @@
+"""Enable ``python -m powermcp`` to run the CLI.
+
+The generated MCP client configs launch servers via
+``<python> -m powermcp run <tool>`` (an absolute interpreter is more robust than
+the bare ``powermcp`` console script for GUI hosts that don't inherit the shell
+PATH). Executing a package with ``-m`` runs this module, which delegates to the
+same entry point as the ``powermcp`` console script.
+"""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/powermcp/cli.py
+++ b/powermcp/cli.py
@@ -1,0 +1,162 @@
+"""The ``powermcp`` command-line interface.
+
+Commands
+--------
+- ``powermcp install``       interactive wizard: pick tools, capture vendor paths,
+                             install extras, write MCP client config.
+- ``powermcp run <tool>``    launch a server (used by the generated client config).
+- ``powermcp config show``   print ~/.powermcp/config.toml.
+- ``powermcp config set``    set a single ``tool.key`` path.
+- ``powermcp doctor``        check deps + configured paths per tool.
+- ``powermcp list``          list the known tools and their status.
+
+Heavy modules (registry, runner, wizard, clients) are imported lazily inside the
+command bodies so ``powermcp --help`` stays fast and works even before optional
+pieces are present.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from . import __version__
+
+app = typer.Typer(
+    name="powermcp",
+    help="MCP servers for power-system software.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+config_app = typer.Typer(help="Inspect or modify ~/.powermcp/config.toml.", no_args_is_help=True)
+app.add_typer(config_app, name="config")
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"powermcp {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def _main(
+    version: bool = typer.Option(
+        False, "--version", "-V", help="Show the version and exit.",
+        callback=_version_callback, is_eager=True,
+    ),
+) -> None:
+    """PowerMCP — MCP servers for power-system software."""
+
+
+# --------------------------------------------------------------------------- #
+# install
+# --------------------------------------------------------------------------- #
+@app.command()
+def install(
+    yes: bool = typer.Option(False, "--yes", "-y", help="Non-interactive: install core only (pandapower + PyPSA)."),
+    tools: str = typer.Option(
+        None,
+        "--tools",
+        help="Comma-separated tool ids to set up (e.g. 'psse,andes'); use 'all' for everything "
+        "available on this platform. Skips the interactive picker. Core tools are always included.",
+    ),
+    all_tools: bool = typer.Option(False, "--all", help="Set up every tool available on this platform."),
+    clients: str = typer.Option(
+        "claude-desktop,claude-code,codex",
+        "--clients",
+        help="Comma-separated MCP clients to configure (claude-desktop, claude-code, codex, none).",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Don't write client config; print it."),
+) -> None:
+    """Installer: pick tools (interactively, or with --tools/--all), capture vendor
+    software paths, install the chosen extras, and write the MCP client configuration."""
+    from .wizard import run_wizard
+
+    run_wizard(yes=yes, tools=tools, select_all=all_tools, clients=clients, dry_run=dry_run)
+
+
+# --------------------------------------------------------------------------- #
+# run
+# --------------------------------------------------------------------------- #
+@app.command()
+def run(tool: str = typer.Argument(..., help="Tool id to launch, e.g. 'psse' or 'pandapower'.")) -> None:
+    """Launch a server over stdio. Resolves the tool via the registry and runs
+    the original server file unchanged, so standalone files keep working."""
+    from .runner import launch
+
+    launch(tool)
+
+
+# --------------------------------------------------------------------------- #
+# list
+# --------------------------------------------------------------------------- #
+@app.command(name="list")
+def list_tools() -> None:
+    """List the known tools, their kind, extra, and Windows-only flag."""
+    from rich.console import Console
+    from rich.table import Table
+
+    from .registry import CORE, TOOLS
+
+    table = Table(title="PowerMCP tools")
+    table.add_column("tool")
+    table.add_column("kind")
+    table.add_column("extra")
+    table.add_column("windows-only")
+    table.add_column("default")
+    for t in TOOLS.values():
+        table.add_row(
+            t.name,
+            t.kind,
+            t.extra or "(core)",
+            "yes" if t.windows_only else "",
+            "yes" if t.name in CORE else "",
+        )
+    Console().print(table)
+
+
+# --------------------------------------------------------------------------- #
+# config
+# --------------------------------------------------------------------------- #
+@config_app.command("show")
+def config_show() -> None:
+    """Print the current ~/.powermcp/config.toml."""
+    from . import config as cfg
+
+    typer.echo(cfg.show())
+
+
+@config_app.command("set")
+def config_set(
+    dotted: str = typer.Argument(..., help="A 'tool.key' pair, e.g. psse.bin"),
+    value: str = typer.Argument(..., help="The path or value to store."),
+) -> None:
+    """Set a single config value, e.g. `powermcp config set ltspice.exe C:\\...\\LTspice.exe`."""
+    from . import config as cfg
+
+    if "." not in dotted:
+        raise typer.BadParameter("expected the form tool.key (e.g. psse.bin)")
+    tool, key = dotted.split(".", 1)
+    cfg.set_value(tool, key, value)
+    typer.echo(f"set [{tool}] {key} = {value}")
+
+
+# --------------------------------------------------------------------------- #
+# doctor
+# --------------------------------------------------------------------------- #
+@app.command()
+def doctor(
+    tool: str = typer.Argument(None, help="Optional: check a single tool instead of all."),
+) -> None:
+    """Verify that each selected tool's dependencies and configured paths are ready."""
+    from .doctor import run_doctor
+
+    run_doctor(tool)
+
+
+def main() -> None:
+    """Console-script entry point (``powermcp = powermcp.cli:main``)."""
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/powermcp/clients/__init__.py
+++ b/powermcp/clients/__init__.py
@@ -1,0 +1,29 @@
+"""Pluggable MCP client-config writers.
+
+Each writer module exposes ``NAME``, ``DISPLAY``, ``config_path()`` and
+``write(tools, *, dry_run=False) -> str | None``. ``configure()`` dispatches to
+the selected writers and returns a per-client result (the written path, or None
+on dry-run / skip).
+"""
+
+from __future__ import annotations
+
+from . import claude_code, claude_desktop, codex
+
+WRITERS = {
+    claude_desktop.NAME: claude_desktop,
+    claude_code.NAME: claude_code,
+    codex.NAME: codex,
+}
+
+CLIENT_NAMES = tuple(WRITERS)
+
+
+def configure(client_names, tools, *, dry_run: bool = False) -> dict[str, str | None]:
+    results: dict[str, str | None] = {}
+    for name in client_names:
+        writer = WRITERS.get(name)
+        if writer is None:
+            continue
+        results[name] = writer.write(list(tools), dry_run=dry_run)
+    return results

--- a/powermcp/clients/_common.py
+++ b/powermcp/clients/_common.py
@@ -1,0 +1,86 @@
+"""Shared helpers for the MCP client-config writers.
+
+All generated entries are namespaced with a ``powermcp_`` prefix so that merges
+are idempotent and we only ever touch our own keys — a user's other MCP servers
+are preserved untouched, and tools deselected on a re-run are pruned.
+
+The launch command always uses the ABSOLUTE interpreter path
+(``<python> -m powermcp run <tool>``) rather than a bare ``powermcp`` console
+script, because GUI MCP hosts (Claude Desktop, etc.) do not inherit the user's
+shell PATH and usually cannot find a venv's Scripts/ entry point.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+MANAGED_PREFIX = "powermcp_"
+
+
+def server_key(tool: str) -> str:
+    """The mcpServers / mcp_servers key we manage for a tool."""
+    return MANAGED_PREFIX + tool
+
+
+def is_managed(key: str) -> bool:
+    return key.startswith(MANAGED_PREFIX)
+
+
+def launch_command() -> tuple[str, list[str]]:
+    """(command, base_args) — absolute interpreter + `-m powermcp run`."""
+    return sys.executable, ["-m", "powermcp", "run"]
+
+
+def server_entry(tool: str, *, include_type: bool = False) -> dict:
+    command, base = launch_command()
+    entry: dict = {"command": command, "args": base + [tool]}
+    if include_type:
+        entry = {"type": "stdio", **entry}
+    return entry
+
+
+def merge_mcp_servers(existing: dict, tools: list[str], *, include_type: bool) -> dict:
+    """Idempotently merge our entries into a parsed JSON config dict.
+
+    - sets/overwrites only our ``powermcp_*`` keys,
+    - prunes ``powermcp_*`` keys for tools no longer selected,
+    - leaves every foreign server entry and every other top-level key untouched.
+    """
+    data = dict(existing)
+    servers = dict(data.get("mcpServers") or {})
+    desired = {server_key(t) for t in tools}
+    for key in list(servers):
+        if is_managed(key) and key not in desired:
+            del servers[key]
+    for tool in tools:
+        servers[server_key(tool)] = server_entry(tool, include_type=include_type)
+    data["mcpServers"] = servers
+    return data
+
+
+def write_json_config(path: Path, tools: list[str], *, include_type: bool, dry_run: bool) -> str | None:
+    """Merge our entries into a JSON MCP-client config at ``path``.
+
+    Returns the written path, or None in dry-run mode (after printing the result).
+    Backs the file up once (``*.powermcp.bak``) and writes atomically.
+    """
+    existing: dict = {}
+    if path.exists():
+        text = path.read_text(encoding="utf-8").strip()
+        existing = json.loads(text) if text else {}
+    merged = merge_mcp_servers(existing, tools, include_type=include_type)
+    blob = json.dumps(merged, indent=2)
+    if dry_run:
+        print(f"# would write {path}\n{blob}\n")
+        return None
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        backup = path.with_suffix(path.suffix + ".powermcp.bak")
+        if not backup.exists():
+            backup.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(blob, encoding="utf-8")
+    tmp.replace(path)
+    return str(path)

--- a/powermcp/clients/claude_code.py
+++ b/powermcp/clients/claude_code.py
@@ -1,0 +1,26 @@
+"""Write/merge MCP server entries for Claude Code (user scope).
+
+Claude Code stores user-scope MCP servers at the root ``mcpServers`` object of
+``~/.claude.json`` (the same object the `claude mcp add --scope user` CLI edits).
+We merge directly into that file: this preserves the user's ``projects`` block
+and every other key, is idempotent, supports pruning and dry-run, and does not
+require the `claude` binary to be on PATH. Entries include ``"type": "stdio"``
+per Claude Code's schema.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ._common import write_json_config
+
+NAME = "claude-code"
+DISPLAY = "Claude Code"
+
+
+def config_path() -> Path:
+    return Path.home() / ".claude.json"
+
+
+def write(tools: list[str], *, dry_run: bool = False) -> str | None:
+    return write_json_config(config_path(), tools, include_type=True, dry_run=dry_run)

--- a/powermcp/clients/claude_desktop.py
+++ b/powermcp/clients/claude_desktop.py
@@ -1,0 +1,26 @@
+"""Write/merge MCP server entries into Claude Desktop's config (JSON)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from ._common import write_json_config
+
+NAME = "claude-desktop"
+DISPLAY = "Claude Desktop"
+
+
+def config_path() -> Path:
+    if sys.platform == "win32":
+        import os
+
+        return Path(os.environ["APPDATA"]) / "Claude" / "claude_desktop_config.json"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def write(tools: list[str], *, dry_run: bool = False) -> str | None:
+    # Claude Desktop's classic schema is {command, args}; no "type" field needed.
+    return write_json_config(config_path(), tools, include_type=False, dry_run=dry_run)

--- a/powermcp/clients/codex.py
+++ b/powermcp/clients/codex.py
@@ -1,0 +1,71 @@
+"""Write/merge MCP server entries into the OpenAI Codex CLI config (TOML).
+
+Codex reads stdio MCP servers from ``[mcp_servers.<name>]`` tables in
+``~/.codex/config.toml`` (override dir via ``CODEX_HOME``). We edit the file with
+``tomlkit`` to preserve the user's comments, formatting, and other tables, and
+only touch our own ``powermcp_*`` tables (idempotent + prune). Server names use
+underscores (TOML table-name safe).
+
+Note: the Codex *Desktop* app on Windows has been reported to rewrite
+config.toml and drop user MCP servers on startup (openai/codex#24718); the Codex
+CLI is unaffected. Documented for users who run both.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ._common import MANAGED_PREFIX, is_managed, launch_command, server_key
+
+NAME = "codex"
+DISPLAY = "Codex CLI"
+
+
+def config_path() -> Path:
+    home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    return home / "config.toml"
+
+
+def _build_doc(existing_text: str | None, tools: list[str]):
+    import tomlkit
+
+    doc = tomlkit.parse(existing_text) if existing_text else tomlkit.document()
+    servers = doc.get("mcp_servers")
+    if servers is None:
+        servers = tomlkit.table()
+        doc["mcp_servers"] = servers
+
+    desired = {server_key(t) for t in tools}
+    for name in list(servers.keys()):
+        if is_managed(name) and name not in desired:
+            del servers[name]
+
+    command, base = launch_command()
+    for tool in tools:
+        table = tomlkit.table()
+        table["command"] = command
+        table["args"] = base + [tool]
+        servers[server_key(tool)] = table
+    return doc
+
+
+def write(tools: list[str], *, dry_run: bool = False) -> str | None:
+    import tomlkit
+
+    path = config_path()
+    existing_text = path.read_text(encoding="utf-8") if path.exists() else None
+    doc = _build_doc(existing_text, tools)
+    blob = tomlkit.dumps(doc)
+    if dry_run:
+        print(f"# would write {path}\n{blob}\n")
+        return None
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        backup = path.with_suffix(".toml.powermcp.bak")
+        if not backup.exists():
+            backup.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+    tmp = path.with_suffix(".toml.tmp")
+    tmp.write_text(blob, encoding="utf-8")
+    tmp.replace(path)
+    return str(path)

--- a/powermcp/config.py
+++ b/powermcp/config.py
@@ -1,0 +1,115 @@
+"""Central PowerMCP configuration at ``~/.powermcp/config.toml``.
+
+This replaces the per-server hardcoded software paths. Vendor servers call
+:func:`get_path` (before importing their vendor module) to learn where the local
+software lives; the resolution order is:
+
+1. environment variable ``POWERMCP_<TOOL>_<KEY>`` (handy for CI / overrides),
+2. ``~/.powermcp/config.toml`` ``[tool].key``,
+3. the historical hardcoded default declared in the registry (last resort),
+4. otherwise raise :class:`ConfigError` with an actionable message.
+
+The config dir can be relocated for tests via the ``POWERMCP_HOME`` env var.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+import tomli_w
+
+
+class ConfigError(RuntimeError):
+    """Raised with a clear, user-facing message when a required path is missing."""
+
+
+def config_dir() -> Path:
+    """The ~/.powermcp directory (override with the POWERMCP_HOME env var)."""
+    return Path(os.environ.get("POWERMCP_HOME", Path.home() / ".powermcp"))
+
+
+def config_path() -> Path:
+    return config_dir() / "config.toml"
+
+
+def load() -> dict[str, Any]:
+    """Read the whole config. Returns ``{}`` if the file does not exist."""
+    path = config_path()
+    if not path.exists():
+        return {}
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def save(data: dict[str, Any]) -> None:
+    """Atomically write the whole config (creates ~/.powermcp/ as needed)."""
+    directory = config_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    path = config_path()
+    tmp = path.with_suffix(".toml.tmp")
+    with tmp.open("wb") as fh:
+        tomli_w.dump(data, fh)
+    tmp.replace(path)  # atomic on the same filesystem
+
+
+def get(tool: str, key: str, default: Any = None) -> Any:
+    """Low-level getter for a single ``[tool].key`` value."""
+    return load().get(tool, {}).get(key, default)
+
+
+def set_value(tool: str, key: str, value: Any) -> None:
+    """Set a single ``[tool].key`` value and persist the file."""
+    data = load()
+    data.setdefault(tool, {})[key] = str(value)
+    save(data)
+
+
+def _env_key(tool: str, key: str) -> str:
+    return "POWERMCP_" + tool.upper().replace("-", "_") + "_" + key.upper().replace(".", "_")
+
+
+def get_path(tool: str, key: str, *, must_exist: bool = True) -> str:
+    """Resolve a captured software path for ``tool``/``key``.
+
+    Raises :class:`ConfigError` (with an actionable message) when the value is
+    unset or points at a path that no longer exists.
+    """
+    env_name = _env_key(tool, key)
+    value = os.environ.get(env_name) or get(tool, key)
+    source = "config"
+    if not value:
+        from .registry import legacy_default  # lazy import: avoids any import cycle
+
+        value = legacy_default(tool, key)
+        source = "legacy default"
+    if not value:
+        raise ConfigError(
+            f"[{tool}] required path '{key}' is not configured.\n"
+            f"  Set it with one of:\n"
+            f"    powermcp install                       (interactive wizard)\n"
+            f"    powermcp config set {tool}.{key} <path>\n"
+            f"    set {env_name}=<path>                   (environment override)"
+        )
+    resolved = Path(value).expanduser()
+    if must_exist and not resolved.exists():
+        raise ConfigError(
+            f"[{tool}] path '{key}' ({source}) does not exist:\n"
+            f"    {resolved}\n"
+            f"  Fix it with:  powermcp config set {tool}.{key} <correct-path>"
+        )
+    return str(resolved)
+
+
+def show() -> str:
+    """A printable view of the current config for ``powermcp config show``."""
+    data = load()
+    if not data:
+        return f"(no config yet at {config_path()} — run `powermcp install`)"
+    return f"# {config_path()}\n" + tomli_w.dumps(data)

--- a/powermcp/detect.py
+++ b/powermcp/detect.py
@@ -1,0 +1,62 @@
+"""Best-effort auto-detection of locally-installed tool software paths.
+
+Used to prefill the install wizard (so users rarely type a path by hand) and as a
+runtime fallback for servers, so a tool installed in a standard location works
+even before it's explicitly configured.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _first_existing(paths) -> str | None:
+    for p in paths:
+        if p and Path(os.path.expanduser(p)).exists():
+            return str(Path(os.path.expanduser(p)))
+    return None
+
+
+def ltspice_exe() -> str | None:
+    """Locate the LTspice executable across the common install layouts:
+    modern Analog Devices LTspice, legacy LTC LTspice XVII/IV, macOS, and Wine."""
+    pf = os.environ.get("ProgramFiles", r"C:\Program Files")
+    pf86 = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
+    local = os.environ.get("LOCALAPPDATA")
+    if sys.platform == "win32":
+        cands = [
+            rf"{pf}\ADI\LTspice\LTspice.exe",
+            rf"{pf86}\ADI\LTspice\LTspice.exe",
+            rf"{local}\Programs\ADI\LTspice\LTspice.exe" if local else None,
+            rf"{pf}\LTC\LTspiceXVII\XVIIx64.exe",
+            rf"{pf86}\LTC\LTspiceXVII\XVIIx64.exe",
+            rf"{pf86}\LTC\LTspiceIV\scad3.exe",
+        ]
+        return _first_existing(cands)
+    if sys.platform == "darwin":
+        return _first_existing(["/Applications/LTspice.app/Contents/MacOS/LTspice"])
+    # Linux / Wine
+    home = os.path.expanduser("~")
+    return _first_existing([
+        f"{home}/.wine/drive_c/Program Files/ADI/LTspice/LTspice.exe",
+        f"{home}/.wine/drive_c/Program Files/LTC/LTspiceXVII/XVIIx64.exe",
+    ])
+
+
+# Detectors keyed by "<tool>.<config_key>". Extend as other tools gain detection.
+_DETECTORS = {
+    "ltspice.exe": ltspice_exe,
+}
+
+
+def detect(tool: str, key: str) -> str | None:
+    """Return an auto-detected path for a tool/config key, or None."""
+    fn = _DETECTORS.get(f"{tool}.{key}")
+    if fn is None:
+        return None
+    try:
+        return fn()
+    except Exception:
+        return None

--- a/powermcp/doctor.py
+++ b/powermcp/doctor.py
@@ -1,0 +1,88 @@
+"""`powermcp doctor` — check each tool's dependencies and configured paths.
+
+Dependency checks use ``importlib.util.find_spec`` (which locates a module
+without executing it) so the doctor never triggers a vendor engine's import-time
+side effects (e.g. PSS/E ``psseinit``) and never crashes on a broken DLL. Vendor
+engines that load from a captured directory (PSS/E, PSLF, PowerFactory) are not
+import-probed at all — they are reported via their configured paths and verified
+for real only at runtime.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from . import config as cfg
+from .registry import Tool, all_tools, get_tool
+from .runner import probe_installed
+
+# Engines imported from a captured local dir (not from PyPI). Do not import-probe.
+_PATH_LOADED = {"psse", "pslf", "powerfactory"}
+
+
+def _surge_supported() -> bool:
+    return (3, 12) <= sys.version_info[:2] < (3, 15)
+
+
+def _dep_status(t: Tool) -> tuple[str, str]:
+    """Return (style, message) for the dependency column."""
+    if t.windows_only and sys.platform != "win32":
+        return "dim", "skipped — Windows-only"
+    if t.name == "surge" and not _surge_supported():
+        return "yellow", f"needs Python 3.12–3.14 (have {sys.version_info.major}.{sys.version_info.minor})"
+    if t.name in _PATH_LOADED:
+        return "cyan", "vendor engine — loaded from configured path"
+    if t.probe:
+        if probe_installed(t.probe):
+            return "green", "ok"
+        return "red", f"missing — pip install powermcp[{t.extra}]"
+    return "green", "ok"
+
+
+def _path_status(t: Tool) -> tuple[str, str]:
+    """Return (style, message) for the configured-paths column."""
+    required = [ck for ck in t.config_keys if ck.required]
+    optional = [ck for ck in t.config_keys if not ck.required]
+    if not t.config_keys:
+        return "dim", "—"
+    missing = []
+    for ck in required:
+        try:
+            cfg.get_path(t.name, ck.key)
+        except cfg.ConfigError:
+            missing.append(f"{t.name}.{ck.key}")
+    if missing:
+        return "yellow", "set: " + ", ".join(missing)
+    label = "configured"
+    if optional:
+        label += f" ({len(optional)} optional)"
+    return "green", label
+
+
+def run_doctor(tool: str | None = None) -> None:
+    tools = [get_tool(tool)] if tool else all_tools()
+    table = Table(title="PowerMCP doctor")
+    table.add_column("tool")
+    table.add_column("dependencies")
+    table.add_column("config paths")
+    solver_notes: list[str] = []
+    for t in tools:
+        dep_style, dep_msg = _dep_status(t)
+        path_style, path_msg = _path_status(t)
+        table.add_row(t.name, f"[{dep_style}]{dep_msg}[/]", f"[{path_style}]{path_msg}[/]")
+        if t.external_solvers and not (t.windows_only and sys.platform != "win32"):
+            solver_notes.append(f"  • {t.display}: needs {', '.join(t.external_solvers)} available at runtime")
+
+    console = Console()
+    console.print(table)
+    if solver_notes:
+        console.print(
+            "\n[dim]Note: some tools also need external solvers/runtimes on PATH "
+            "(a green check above only means the Python package is present):[/]"
+        )
+        for note in solver_notes:
+            console.print(f"[dim]{note}[/]")
+    console.print(f"\n[dim]Config file: {cfg.config_path()}[/]")

--- a/powermcp/paths.py
+++ b/powermcp/paths.py
@@ -1,0 +1,45 @@
+"""Writable locations and sys.path helpers.
+
+Servers must not write next to their installed source (a wheel in site-packages
+is typically read-only). Runtime artifacts go under ``~/.powermcp/`` instead, and
+are created lazily — never at import time.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from .config import config_dir as powermcp_home  # ~/.powermcp (honours POWERMCP_HOME)
+
+__all__ = ["powermcp_home", "runs_dir", "tool_data_dir", "inject_sys_path"]
+
+
+def runs_dir(tool: str, *, create: bool = True) -> Path:
+    """Per-tool directory for run artifacts, e.g. ~/.powermcp/runs/andes."""
+    d = powermcp_home() / "runs" / tool
+    if create:
+        d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def tool_data_dir(tool: str, *, create: bool = True) -> Path:
+    """Per-tool directory for user data/config copies, e.g. ~/.powermcp/powerfactory."""
+    d = powermcp_home() / tool
+    if create:
+        d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def inject_sys_path(*paths: str | None, prepend_env_path: bool = False) -> None:
+    """Prepend vendor directories to ``sys.path`` (and optionally to ``PATH`` for
+    Windows DLL discovery). Skips empty/None entries; idempotent on ``sys.path``."""
+    for raw in paths:
+        if not raw:
+            continue
+        p = str(Path(raw).expanduser())
+        if p not in sys.path:
+            sys.path.insert(0, p)
+        if prepend_env_path:
+            os.environ["PATH"] = p + os.pathsep + os.environ.get("PATH", "")

--- a/powermcp/registry.py
+++ b/powermcp/registry.py
@@ -1,0 +1,224 @@
+"""The PowerMCP tool registry — the single source of truth for every server.
+
+Everything else (CLI, runner, wizard, doctor, client-config writers) reads tool
+metadata from here: how to launch each server, which pip extra provides it,
+whether it is Windows-only, and which local software paths it needs captured in
+``~/.powermcp/config.toml``.
+"""
+
+from __future__ import annotations
+
+import importlib.resources as resources
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# In an editable install or a raw git checkout, the powermcp package lives at
+# <repo>/powermcp, so its parent is the repo root that holds PSSE/, pandapower/...
+# In an installed wheel the server dirs live under powermcp/_servers/ instead
+# (see resolve_server_dir).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class ConfigKey:
+    """A local software path a tool needs captured at install time."""
+
+    key: str  # stored as [tool].<key> in config.toml
+    prompt: str  # shown by the install wizard
+    validate: str = "dir"  # "dir" | "file" | "any"
+    required: bool = True
+    legacy_default: str | None = None  # historical hardcoded path, used as last resort
+
+
+@dataclass(frozen=True)
+class Tool:
+    """A single MCP server bundled in the distribution."""
+
+    name: str  # CLI id: `powermcp run <name>`
+    display: str
+    kind: str  # "open-source" | "closed-source"
+    windows_only: bool
+    extra: str | None  # pip extra that installs it; None for core (pandapower/pypsa)
+    server_dir: str  # top-level dir name, e.g. "PSSE"
+    run_kind: str  # "script" | "module"
+    entry_rel: str | None = None  # for run_kind=="script": path under server_dir
+    module: str | None = None  # for run_kind=="module": dotted module run with -m
+    module_root_rel: str | None = None  # dir (under server_dir) to add to sys.path for the module
+    probe: str | None = None  # importable linchpin dependency, for doctor
+    config_keys: tuple[ConfigKey, ...] = field(default_factory=tuple)
+    external_solvers: tuple[str, ...] = field(default_factory=tuple)  # informational
+    notes: str = ""
+
+    # -- path resolution --------------------------------------------------- #
+    def resolve_server_dir(self) -> Path:
+        """Return the on-disk server directory, working in all three layouts:
+        installed wheel (powermcp/_servers/<dir>), editable install, raw checkout."""
+        # 1) installed wheel: shipped under the package as powermcp/_servers/<dir>
+        try:
+            packaged = Path(str(resources.files("powermcp"))) / "_servers" / self.server_dir
+            if packaged.exists():
+                return packaged
+        except (ModuleNotFoundError, TypeError, OSError):
+            pass
+        # 2) editable install / raw checkout: <repo>/<dir>
+        checkout = REPO_ROOT / self.server_dir
+        if checkout.exists():
+            return checkout
+        raise FileNotFoundError(
+            f"Cannot locate server directory '{self.server_dir}' for tool '{self.name}'. "
+            f"Looked under the installed package and at {checkout}."
+        )
+
+    def resolve_entry_script(self) -> Path:
+        if self.run_kind != "script" or not self.entry_rel:
+            raise ValueError(f"{self.name} is not a script-launched tool")
+        return self.resolve_server_dir() / self.entry_rel
+
+    def resolve_module_root(self) -> Path:
+        base = self.resolve_server_dir()
+        return base / self.module_root_rel if self.module_root_rel else base
+
+
+# Tools whose path is genuinely Windows-only commercial software.
+_W = True
+
+TOOLS: dict[str, "Tool"] = {
+    t.name: t
+    for t in (
+        # ---- CORE (always installed) ----
+        Tool(
+            "pandapower", "pandapower", "open-source", windows_only=False, extra=None,
+            server_dir="pandapower", run_kind="script", entry_rel="panda_mcp.py",
+            probe="pandapower",
+        ),
+        Tool(
+            "pypsa", "PyPSA", "open-source", windows_only=False, extra=None,
+            server_dir="PyPSA", run_kind="script", entry_rel="pypsa_mcp.py",
+            probe="pypsa", external_solvers=("HiGHS", "CBC", "GLPK", "Gurobi"),
+        ),
+        # ---- OPEN-SOURCE EXTRAS ----
+        Tool(
+            "andes", "ANDES", "open-source", windows_only=False, extra="andes",
+            server_dir="ANDES", run_kind="script", entry_rel="andes_mcp.py",
+            probe="andes",
+        ),
+        Tool(
+            "egret", "Egret", "open-source", windows_only=False, extra="egret",
+            server_dir="Egret", run_kind="script", entry_rel="egret_mcp.py",
+            probe="egret", external_solvers=("ipopt", "Gurobi"),
+        ),
+        Tool(
+            "surge", "surge", "open-source", windows_only=False, extra="surge",
+            server_dir="surge", run_kind="script", entry_rel="surge_mcp.py",
+            probe="surge", external_solvers=("HiGHS", "Ipopt"),
+            notes="Requires Python 3.12-3.14 (pyo3/maturin).",
+        ),
+        Tool(
+            "opendss", "OpenDSS", "open-source", windows_only=False, extra="opendss",
+            server_dir="OpenDSS", run_kind="script", entry_rel="opendss_mcp.py",
+            probe="py_dss_toolkit",
+        ),
+        Tool(
+            "hope", "HOPE", "open-source", windows_only=False, extra="hope",
+            server_dir="HOPE", run_kind="module",
+            module="hope_mcp_server", module_root_rel="src",
+            probe="yaml",
+            config_keys=(
+                ConfigKey("repo_root", "Path to the HOPE git repository root", "dir"),
+                ConfigKey("julia_bin", "Path to the Julia executable", "file"),
+                ConfigKey("julia_depot_path", "JULIA_DEPOT_PATH (optional, Enter to skip)", "dir", required=False),
+            ),
+            external_solvers=("Julia",),
+        ),
+        # ---- CLOSED-SOURCE / VENDOR ----
+        Tool(
+            "powerworld", "PowerWorld", "closed-source", windows_only=_W, extra="powerworld",
+            server_dir="PowerWorld", run_kind="script", entry_rel="powerworld_mcp.py",
+            probe="esa",
+            notes="esa (Easy SimAuto) auto-discovers a running, licensed PowerWorld Simulator via COM; no path to capture.",
+        ),
+        Tool(
+            "psse", "PSS/E", "closed-source", windows_only=_W, extra="psse",
+            server_dir="PSSE", run_kind="script", entry_rel="psse_mcp.py",
+            probe=None,  # psspy loads from a captured path, not pip; checked at runtime
+            config_keys=(
+                ConfigKey(
+                    "python_lib", r"Path to the PSSE PSSPYxxx dir (e.g. ...\PSSE36\36.2\PSSPY311)",
+                    "dir", legacy_default=r"C:\Program Files\PTI\PSSE36\36.2\PSSPY311",
+                ),
+                ConfigKey(
+                    "bin", r"Path to the PSSE PSSBIN dir",
+                    "dir", legacy_default=r"C:\Program Files\PTI\PSSE36\36.2\PSSBIN",
+                ),
+                ConfigKey("version", "PSSE version string, e.g. 36.2 (optional)", "any", required=False),
+            ),
+        ),
+        Tool(
+            "pslf", "PSLF", "closed-source", windows_only=_W, extra="pslf",
+            server_dir="PSLF", run_kind="script", entry_rel="pslf_mcp.py",
+            probe=None,  # PSLF_PYTHON is vendor-supplied, not importable until path injected
+            config_keys=(
+                ConfigKey("python_lib", "Directory containing the PSLF_PYTHON module", "dir"),
+            ),
+        ),
+        Tool(
+            "powerfactory", "PowerFactory", "closed-source", windows_only=_W, extra="powerfactory",
+            server_dir="PowerFactory", run_kind="script", entry_rel="MCP_PowerFactory.py",
+            probe="fastmcp",
+            config_keys=(
+                ConfigKey(
+                    "python_path",
+                    r"Path to PowerFactory's bundled Python dir (e.g. ...\DIgSILENT\PowerFactory 2024\Python\3.11)",
+                    "dir",
+                ),
+                ConfigKey(
+                    "config_path", "Path to simulation_config.json (optional; defaults to ~/.powermcp/powerfactory/)",
+                    "file", required=False,
+                ),
+            ),
+        ),
+        Tool(
+            "pscad", "PSCAD", "closed-source", windows_only=_W, extra="pscad-windows",
+            server_dir="PSCAD", run_kind="module",
+            module="pscad_mcp.main", module_root_rel=None,  # parent of pscad_mcp is the server dir itself
+            probe="mhi.pscad",
+            notes="mhi-pscad/mhi-psout come from the `pscad-windows` extra; PSCAD must be installed.",
+        ),
+        Tool(
+            "ltspice", "LTSpice", "closed-source", windows_only=False, extra="ltspice",
+            server_dir="LTSpice", run_kind="script", entry_rel="ltspice_mcp.py",
+            probe="PyLTSpice",
+            config_keys=(
+                ConfigKey(
+                    "exe", r"Path to the LTspice executable (e.g. ...\LTspiceXVII\XVIIx64.exe)",
+                    "file", legacy_default=r"C:\Program Files\LTC\LTspiceXVII\XVIIx64.exe",
+                ),
+            ),
+        ),
+    )
+}
+
+# Tools installed by a bare `pip install powermcp` and pre-checked in the wizard.
+CORE: tuple[str, ...] = ("pandapower", "pypsa")
+
+
+def get_tool(name: str) -> "Tool":
+    try:
+        return TOOLS[name]
+    except KeyError:
+        raise KeyError(f"unknown tool '{name}'. Known tools: {', '.join(TOOLS)}") from None
+
+
+def all_tools() -> list["Tool"]:
+    return list(TOOLS.values())
+
+
+def legacy_default(tool: str, key: str) -> str | None:
+    """Return the historical hardcoded path for a tool/key, if any."""
+    t = TOOLS.get(tool)
+    if not t:
+        return None
+    for ck in t.config_keys:
+        if ck.key == key:
+            return ck.legacy_default
+    return None

--- a/powermcp/runner.py
+++ b/powermcp/runner.py
@@ -1,0 +1,92 @@
+"""Launch a bundled MCP server by tool id.
+
+``powermcp run <tool>`` resolves the tool via the registry and executes the
+original, unmodified server file — so the same code keeps working when run
+standalone from a checkout. Two launch styles (declared per tool in the
+registry):
+
+- ``script``: run the entry .py as ``__main__`` (its own ``mcp.run(...)`` fires),
+  after putting the server dir and its parent on ``sys.path`` so existing
+  relative imports (PyPSA's ``sys.path.append`` parent, OpenDSS's
+  ``from core.server import ...``) resolve exactly as in standalone use.
+- ``module``: put the module root on ``sys.path`` and ``runpy.run_module`` the
+  package's ``__main__`` (PSCAD's ``pscad_mcp.main``, HOPE's ``hope_mcp_server``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import runpy
+import sys
+
+from .registry import Tool, get_tool
+
+
+class LaunchError(RuntimeError):
+    """Raised with an actionable message when a server cannot be launched."""
+
+
+def probe_installed(probe: str | None) -> bool:
+    """True if ``probe`` resolves to a real (importable) module/package.
+
+    Uses find_spec on the FULL dotted name (no module execution). Two cases this
+    must get right:
+    - ``surge`` (top-level): the repo's ``surge/`` folder is a PEP 420 namespace
+      portion (origin None) and must NOT be mistaken for the installed library —
+      so we require a real ``origin``.
+    - ``mhi.pscad`` (subpackage of a namespace): ``mhi`` itself is a namespace
+      package shared by the ``mhi-pscad``/``mhi-psout`` distributions, so probing
+      the top-level ``mhi`` would wrongly look "missing". Probing the full
+      ``mhi.pscad`` resolves the real subpackage (which has an origin).
+    """
+    if not probe:
+        return True
+    try:
+        spec = importlib.util.find_spec(probe)
+    except Exception:
+        return False
+    return spec is not None and spec.origin is not None
+
+
+def launch(name: str) -> None:
+    tool = get_tool(name)
+    _preflight(tool)
+    if tool.run_kind == "module":
+        _launch_module(tool)
+    else:
+        _launch_script(tool)
+
+
+def _preflight(tool: Tool) -> None:
+    if tool.windows_only and sys.platform != "win32":
+        raise LaunchError(
+            f"{tool.display} requires Windows-only software and cannot run on '{sys.platform}'."
+        )
+    # Only probe pip-provided linchpins. Vendor engines (PSS/E psspy, PSLF) have
+    # probe=None: they live behind a captured path and report their own
+    # actionable error from the server's lazy init.
+    if tool.probe and not probe_installed(tool.probe):
+        raise LaunchError(
+            f"{tool.display}: required package '{tool.probe.split('.')[0]}' is not installed.\n"
+            f"  Install it with:  pip install powermcp[{tool.extra}]"
+        )
+
+
+def _launch_script(tool: Tool) -> None:
+    script = tool.resolve_entry_script()
+    # Emulate `python <script>`: only the script's own directory goes on sys.path
+    # (runpy.run_path does not add it). We deliberately do NOT add the parent —
+    # the parent holds dirs named exactly like libraries (pandapower/, surge/),
+    # and each server already does its own sys.path setup (PyPSA appends its
+    # parent; OpenDSS inserts its root for `from core.server import ...`).
+    server_dir = str(script.parent)
+    if server_dir not in sys.path:
+        sys.path.insert(0, server_dir)
+    runpy.run_path(str(script), run_name="__main__")
+
+
+def _launch_module(tool: Tool) -> None:
+    root = str(tool.resolve_module_root())
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    runpy.run_module(tool.module, run_name="__main__", alter_sys=True)

--- a/powermcp/wizard.py
+++ b/powermcp/wizard.py
@@ -1,0 +1,344 @@
+"""Interactive install wizard for `powermcp install`.
+
+Flow: select tools (pandapower + PyPSA pre-checked) → capture local software
+paths for closed-source tools → pip-install the chosen extras → write the
+selected MCP client configs. Windows-only tools are hidden off Windows, and
+surge is hidden on Python versions it doesn't support.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from rich.console import Console
+
+from . import config as cfg
+from .clients import CLIENT_NAMES, configure
+from .registry import CORE, TOOLS, Tool
+
+console = Console()
+
+DEFAULT_CLIENTS = ",".join(CLIENT_NAMES)
+
+
+def _tty() -> bool:
+    """True only when we can actually run interactive prompts."""
+    try:
+        return sys.stdin.isatty() and sys.stdout.isatty()
+    except Exception:
+        return False
+
+
+def _surge_supported() -> bool:
+    return (3, 12) <= sys.version_info[:2] < (3, 15)
+
+
+def _platform_ok(tool: Tool) -> bool:
+    if tool.windows_only and sys.platform != "win32":
+        return False
+    if tool.name == "surge" and not _surge_supported():
+        return False
+    return True
+
+
+def selectable_tools() -> list[Tool]:
+    return [t for t in TOOLS.values() if _platform_ok(t)]
+
+
+def _parse_clients(clients: str) -> list[str]:
+    return [c.strip() for c in clients.split(",") if c.strip() and c.strip().lower() != "none"]
+
+
+def _is_installed_or_configured(t: Tool) -> bool:
+    """Whether the tool is already set up on this machine.
+
+    Tools that need a local software path (PSS/E, PSLF, PowerFactory, LTSpice,
+    HOPE) count as set up only when those required paths are configured — not
+    merely because some Python dep is importable (e.g. PyYAML being present must
+    not make HOPE look ready). Tools with no required path count as set up when
+    their dependency is importable.
+    """
+    required = [ck for ck in t.config_keys if ck.required]
+    if required:
+        return all(cfg.get(t.name, ck.key) for ck in required)
+    from .runner import probe_installed
+
+    return bool(t.probe) and probe_installed(t.probe)
+
+
+def _existing_managed_tools(client_names: list[str]) -> set[str]:
+    """Tool ids already registered as powermcp_* servers in the targeted clients,
+    so re-running the wizard preserves them instead of pruning them."""
+    from .clients import WRITERS
+    from .clients._common import MANAGED_PREFIX
+
+    found: set[str] = set()
+    for name in client_names:
+        writer = WRITERS.get(name)
+        if writer is None:
+            continue
+        try:
+            path = writer.config_path()
+            if not path.exists():
+                continue
+            text = path.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        keys: list[str] = []
+        try:
+            if name == "codex":
+                try:
+                    import tomllib
+                except ModuleNotFoundError:  # py3.10
+                    import tomli as tomllib  # type: ignore
+                keys = list((tomllib.loads(text).get("mcp_servers") or {}).keys())
+            else:
+                import json
+
+                keys = list((json.loads(text or "{}").get("mcpServers") or {}).keys())
+        except Exception:
+            keys = []
+        for key in keys:
+            if key.startswith(MANAGED_PREFIX):
+                found.add(key[len(MANAGED_PREFIX):])
+    return found
+
+
+def _preselected_names(client_names: list[str]) -> set[str]:
+    """Tools to pre-check in the picker: core, already-configured-in-a-client, or
+    already installed/configured on this machine."""
+    existing = _existing_managed_tools(client_names)
+    return {
+        t.name
+        for t in selectable_tools()
+        if t.name in CORE or t.name in existing or _is_installed_or_configured(t)
+    }
+
+
+def run_wizard(
+    *,
+    yes: bool,
+    tools: str | None = None,
+    select_all: bool = False,
+    clients: str = DEFAULT_CLIENTS,
+    dry_run: bool = False,
+) -> None:
+    client_names = _parse_clients(clients)
+    selected = _resolve_selection(yes=yes, tools=tools, select_all=select_all, client_names=client_names)
+    if not selected:
+        console.print("[yellow]No tools selected — nothing to do.[/]")
+        return
+    console.print("[bold]Selected:[/] " + ", ".join(t.name for t in selected))
+    if not yes and not dry_run:  # --dry-run writes nothing, including config.toml
+        _capture_paths(selected)
+    _pip_install(selected, assume_yes=yes, dry_run=dry_run)
+    _write_clients(selected, client_names, dry_run)
+    console.print(f"\n[green]Done.[/] PowerMCP config: {cfg.config_path()}")
+
+
+def _resolve_selection(
+    *, yes: bool, tools: str | None, select_all: bool, client_names: list[str]
+) -> list[Tool]:
+    """Decide which tools to set up. The core tools are always included.
+
+    Precedence: explicit ``--tools`` list (or ``all``) > ``--all`` flag >
+    ``--yes`` (core only) > the interactive checkbox.
+    """
+    available = {t.name: t for t in selectable_tools()}
+
+    if tools:
+        requested = [s.strip().lower() for s in tools.split(",") if s.strip()]
+        if "all" in requested:
+            chosen = list(available)
+        else:
+            chosen, unknown, unavailable = [], [], []
+            for name in requested:
+                if name in available:
+                    chosen.append(name)
+                elif name in TOOLS:  # exists but not usable on this platform/Python
+                    unavailable.append(name)
+                else:
+                    unknown.append(name)
+            if unknown:
+                console.print(
+                    f"[red]Unknown tool id(s) ignored:[/] {', '.join(unknown)} "
+                    f"(run `powermcp list` for valid ids)"
+                )
+            if unavailable:
+                console.print(
+                    f"[yellow]Not available on this platform/Python, skipped:[/] {', '.join(unavailable)}"
+                )
+        names = sorted(set(chosen) | set(CORE))
+        return [TOOLS[n] for n in names]
+
+    if select_all:
+        names = sorted(set(available) | set(CORE))
+        return [TOOLS[n] for n in names]
+
+    if yes:
+        return [TOOLS[n] for n in CORE]
+
+    return _interactive_select(client_names)
+
+
+def _interactive_select(client_names: list[str]) -> list[Tool]:
+    if not _tty():
+        console.print(
+            "[yellow]No interactive terminal detected — defaulting to the core tools "
+            "(pandapower, PyPSA). Re-run with `--tools <ids>` or `--all` to choose more.[/]"
+        )
+        return [TOOLS[n] for n in CORE]
+    import questionary
+
+    # Pre-check tools already set up (core, configured in a client, or installed),
+    # so re-running preserves and updates your existing setup instead of resetting.
+    preselect = _preselected_names(client_names)
+    choices = [
+        questionary.Choice(
+            title=f"{t.display}  ({t.kind}{', windows-only' if t.windows_only else ''})",
+            value=t.name,
+            checked=(t.name in preselect),
+        )
+        for t in selectable_tools()
+    ]
+    try:
+        picked = questionary.checkbox(
+            "Select power-system tools to install:",
+            choices=choices,
+            instruction="(↑/↓ move · SPACE toggles a tool · ENTER confirms — pandapower & PyPSA are preselected)",
+        ).ask()
+    except Exception as exc:
+        console.print(
+            f"[yellow]Interactive picker unavailable ({exc}); defaulting to core tools. "
+            f"Use `--tools <ids>` or `--all`.[/]"
+        )
+        return [TOOLS[n] for n in CORE]
+    if picked is None:  # Ctrl-C
+        console.print("[yellow]Selection cancelled.[/]")
+        return []
+    names = sorted(set(picked) | set(CORE))  # always include the core tools
+    return [TOOLS[n] for n in names]
+
+
+def _capture_paths(selected: list[Tool]) -> None:
+    """Prompt for each closed-source tool's local software path(s). Accumulate
+    everything and persist the config file in a single write at the end."""
+    keyed = [t for t in selected if t.config_keys]
+    if not keyed:
+        return
+    if not _tty():
+        # No interactive terminal: tell the user how to set the required paths.
+        for t in keyed:
+            for ck in t.config_keys:
+                if ck.required:
+                    console.print(
+                        f"[yellow]Set {t.name}.{ck.key} with:[/] "
+                        f"powermcp config set {t.name}.{ck.key} <path>"
+                    )
+        return
+    import questionary
+
+    from .detect import detect
+
+    data = cfg.load()
+    changed = False
+    for t in keyed:
+        for ck in t.config_keys:
+            existing = (data.get(t.name, {}) or {}).get(ck.key, "")
+            # Prefill with the existing value, else an auto-detected install path,
+            # so the user can usually just press Enter to accept.
+            default = existing or detect(t.name, ck.key) or ""
+            label = f"[{t.display}] {ck.prompt}"
+            if default and not existing:
+                console.print(f"[dim]  detected: {default}[/]")
+            try:
+                answer = questionary.path(label, default=default).ask()
+            except Exception as exc:  # prompt backend unavailable
+                console.print(
+                    f"[yellow]Could not prompt for {t.name}.{ck.key} ({exc}); "
+                    f"set it later with `powermcp config set {t.name}.{ck.key} <path>`.[/]"
+                )
+                answer = None
+            if answer is None:  # cancelled / unavailable
+                continue
+            answer = answer.strip()
+            if not answer:
+                if ck.required:
+                    console.print(
+                        f"[yellow]{t.name}.{ck.key} left unset — {t.display} will report an "
+                        f"actionable error until it is configured.[/]"
+                    )
+                continue
+            path = Path(answer).expanduser()
+            valid = (
+                path.is_dir() if ck.validate == "dir"
+                else path.is_file() if ck.validate == "file"
+                else path.exists()
+            )
+            if not valid:
+                try:
+                    keep = questionary.confirm(
+                        f"'{path}' does not exist as a {ck.validate}. Save anyway?", default=False
+                    ).ask()
+                except Exception:
+                    keep = True  # can't prompt — keep the path the user explicitly typed
+                if not keep:
+                    continue
+            data.setdefault(t.name, {})[ck.key] = str(path)
+            changed = True
+    if changed:
+        cfg.save(data)
+
+
+def _pip_install(selected: list[Tool], *, assume_yes: bool = False, dry_run: bool = False) -> None:
+    extras = sorted({t.extra for t in selected if t.extra})
+    spec = "powermcp" + (f"[{','.join(extras)}]" if extras else "")
+    if dry_run:
+        console.print(f"[cyan](dry-run)[/] would run: pip install {spec}")
+        return
+    if assume_yes:
+        proceed = True
+    elif not _tty():
+        console.print(f"[yellow]Non-interactive — skipping dependency install. Run:[/] pip install {spec}")
+        return
+    else:
+        import questionary
+
+        try:
+            proceed = bool(
+                questionary.confirm(f"Install dependencies now?  pip install {spec}", default=True).ask()
+            )
+        except Exception:
+            proceed = False
+    if not proceed:
+        console.print(f"[yellow]Skipped. Install later with:[/] pip install {spec}")
+        return
+    console.print(f"[cyan]Installing[/] {spec} ...")
+    result = subprocess.run([sys.executable, "-m", "pip", "install", spec], check=False)
+    if result.returncode != 0:
+        console.print(f"[red]pip install failed (exit {result.returncode}).[/] Install manually: pip install {spec}")
+
+
+def _write_clients(selected: list[Tool], client_names: list[str], dry_run: bool) -> None:
+    if not client_names:
+        return
+    for t in selected:
+        for ck in t.config_keys:
+            if not ck.required:
+                continue
+            try:
+                cfg.get_path(t.name, ck.key)
+            except cfg.ConfigError:
+                console.print(
+                    f"[yellow]Note:[/] {t.display} is configured for your MCP client(s) but "
+                    f"{t.name}.{ck.key} is not set yet — set it with `powermcp config set {t.name}.{ck.key} <path>`."
+                )
+    tool_names = [t.name for t in selected]
+    results = configure(client_names, tool_names, dry_run=dry_run)
+    for client, path in results.items():
+        if path:
+            console.print(f"[green]Configured {client}:[/] {path}")
+        elif not dry_run:
+            console.print(f"[yellow]Skipped {client} (unknown client name).[/]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,113 @@
+# PowerMCP — single pip-installable distribution that bundles every power-system
+# MCP server. The server source lives in the existing top-level dirs (PSSE/,
+# pandapower/, ...) and stays runnable standalone; this build maps those dirs
+# verbatim into the wheel under powermcp/_servers/ via hatchling force-include
+# (zero source mutation, preserves data files like PSSE's 2184 JSON command specs
+# and OpenDSS's case-sensitive .DSS files).
+[build-system]
+requires = ["hatchling>=1.21"]
+build-backend = "hatchling.build"
+
+[project]
+name = "powermcp"
+version = "0.1.0"
+description = "MCP servers for power-system software (PowerWorld, OpenDSS, PSS/E, pandapower, PyPSA, and more)"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+authors = [{ name = "PowerMCP contributors" }]
+keywords = ["mcp", "power systems", "energy", "simulation", "pandapower", "pypsa", "powerworld", "opendss", "pss/e"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+]
+
+# CORE — always installed by `pip install powermcp`.
+# Only pandapower + PyPSA engines (per project decision); the rest is the MCP
+# runtime plus the CLI/installer toolkit.
+dependencies = [
+    "pandapower",
+    "pypsa>=0.25.0",
+    "numpy>=1.24",
+    "pandas>=2.0",
+    "mcp>=1.0",
+    # CLI / installer toolkit:
+    "typer>=0.12",
+    "questionary>=2.0",
+    "rich>=13",
+    "tomli-w>=1.0",
+    "tomlkit>=0.13",
+    "tomli>=2.0; python_version < '3.11'",
+]
+
+[project.optional-dependencies]
+# --- open-source tool engines ---
+andes      = ["andes"]
+egret      = ["gridx-egret", "pyomo"]          # PyPI dist is `gridx-egret`; imports as `egret`
+opendss    = ["py_dss_toolkit"]
+ltspice    = ["PyLTSpice", "matplotlib"]
+surge      = ["surge-py>=0.1.5; python_version >= '3.12' and python_version < '3.15'"]
+hope       = ["PyYAML>=6.0"]
+# --- closed-source / vendor tool engines ---
+powerworld = ["esa", "numba"]                   # esa auto-discovers a running Simulator via COM.
+                                                # numba is required: esa 1.3.5's no-numba code path
+                                                # is broken (NameError in _performance_jit), so the
+                                                # JIT accelerator must be present for `import esa`.
+pscad      = ["psutil"]                         # mhi-pscad pulled by the `pscad-windows` extra
+pscad-windows = ["psutil", "mhi-pscad; sys_platform == 'win32'", "mhi-psout; sys_platform == 'win32'"]
+psse       = []                                 # vendor `psspy` not on PyPI — path captured in config.toml
+pslf       = ["pandas"]                         # vendor `PSLF_PYTHON` not on PyPI — path captured in config.toml
+powerfactory = ["fastmcp>=2.0", "numpy>=1.26", "matplotlib>=3.8", "pandas>=1.5"]  # vendor `powerfactory` not on PyPI
+# --- convenience groups ---
+opensource = ["powermcp[andes]", "powermcp[egret]", "powermcp[opendss]", "powermcp[ltspice]", "powermcp[surge]", "powermcp[hope]"]
+windows    = ["powermcp[pscad-windows]", "powermcp[powerworld]", "powermcp[powerfactory]", "powermcp[psse]", "powermcp[pslf]"]
+all        = ["powermcp[opensource]", "powermcp[powerworld]", "powermcp[powerfactory]", "powermcp[pscad-windows]", "powermcp[psse]", "powermcp[pslf]"]
+
+[project.urls]
+Homepage = "https://github.com/Power-Agent/PowerMCP"
+Repository = "https://github.com/Power-Agent/PowerMCP"
+
+[project.scripts]
+powermcp = "powermcp.cli:main"
+
+# ---------------------------------------------------------------------------
+# Wheel: ship the powermcp core package, then force-include each server dir
+# verbatim under powermcp/_servers/<Dir> so it resolves via
+# importlib.resources.files("powermcp") in an installed wheel.
+# ---------------------------------------------------------------------------
+[tool.hatch.build.targets.wheel]
+packages = ["powermcp"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"pandapower"   = "powermcp/_servers/pandapower"
+"PyPSA"        = "powermcp/_servers/PyPSA"
+"ANDES"        = "powermcp/_servers/ANDES"
+"Egret"        = "powermcp/_servers/Egret"
+"surge"        = "powermcp/_servers/surge"
+"OpenDSS"      = "powermcp/_servers/OpenDSS"
+"HOPE"         = "powermcp/_servers/HOPE"
+"PSCAD"        = "powermcp/_servers/PSCAD"
+"PSSE"         = "powermcp/_servers/PSSE"
+"PSLF"         = "powermcp/_servers/PSLF"
+"PowerWorld"   = "powermcp/_servers/PowerWorld"
+"PowerFactory" = "powermcp/_servers/PowerFactory"
+"LTSpice"      = "powermcp/_servers/LTSpice"
+
+# The sdist must contain the server dirs at the repo root so that the
+# build-wheel-from-sdist step (used by `python -m build`) can force-include them.
+[tool.hatch.build.targets.sdist]
+include = [
+    "powermcp",
+    "pandapower", "PyPSA", "ANDES", "Egret", "surge", "OpenDSS", "HOPE",
+    "PSCAD", "PSSE", "PSLF", "PowerWorld", "PowerFactory", "LTSpice",
+    "README.md", "LICENSE", "pyproject.toml",
+]
+exclude = [
+    "**/__pycache__", "**/*.py[cod]", "**/.pytest_cache",
+    "PSCAD/tests", "HOPE/tests",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared pytest fixtures for the PowerMCP test suite."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_config(tmp_path, monkeypatch):
+    """Point ~/.powermcp at a throwaway dir and clear any POWERMCP_* env vars so
+    config tests never read or write the developer's real configuration."""
+    monkeypatch.setenv("POWERMCP_HOME", str(tmp_path))
+    for var in list(__import__("os").environ):
+        if var.startswith("POWERMCP_") and var != "POWERMCP_HOME":
+            monkeypatch.delenv(var, raising=False)
+    return tmp_path

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,0 +1,92 @@
+"""Tier-2 tests for the MCP client-config writers (no real clients needed)."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from powermcp.clients import _common, claude_code, claude_desktop, codex, configure
+
+
+def test_server_entry_uses_absolute_interpreter():
+    entry = _common.server_entry("psse")
+    assert entry["command"] == sys.executable
+    assert entry["args"] == ["-m", "powermcp", "run", "psse"]
+    typed = _common.server_entry("psse", include_type=True)
+    assert typed["type"] == "stdio"
+
+
+def test_merge_preserves_foreign_and_prunes_managed():
+    existing = {
+        "mcpServers": {
+            "filesystem": {"command": "npx", "args": ["-y", "server-filesystem"]},
+            "powermcp_andes": {"command": "old", "args": ["x"]},  # managed but will be deselected
+        },
+        "otherTopLevelKey": {"keep": True},
+    }
+    merged = _common.merge_mcp_servers(existing, ["pandapower", "pypsa"], include_type=False)
+    servers = merged["mcpServers"]
+    assert "filesystem" in servers  # foreign preserved
+    assert "powermcp_andes" not in servers  # stale managed pruned
+    assert "powermcp_pandapower" in servers and "powermcp_pypsa" in servers
+    assert merged["otherTopLevelKey"] == {"keep": True}  # other keys untouched
+    # idempotent
+    assert _common.merge_mcp_servers(merged, ["pandapower", "pypsa"], include_type=False) == merged
+
+
+def test_write_json_config_backup_and_roundtrip(tmp_path):
+    path = tmp_path / "claude_desktop_config.json"
+    path.write_text(json.dumps({"mcpServers": {"filesystem": {"command": "npx", "args": []}}}), encoding="utf-8")
+    out = _common.write_json_config(path, ["pandapower"], include_type=False, dry_run=False)
+    assert out == str(path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert "filesystem" in data["mcpServers"]
+    assert "powermcp_pandapower" in data["mcpServers"]
+    # a one-time backup was created
+    assert (tmp_path / "claude_desktop_config.json.powermcp.bak").exists()
+    # second write is idempotent and does not create a second backup variant
+    _common.write_json_config(path, ["pandapower"], include_type=False, dry_run=False)
+    assert json.loads(path.read_text(encoding="utf-8")) == data
+
+
+def test_write_json_config_dry_run_writes_nothing(tmp_path, capsys):
+    path = tmp_path / "cfg.json"
+    out = _common.write_json_config(path, ["pandapower"], include_type=True, dry_run=True)
+    assert out is None
+    assert not path.exists()
+    assert "powermcp_pandapower" in capsys.readouterr().out
+
+
+def test_codex_build_doc_preserves_comments_tables_and_prunes():
+    existing = (
+        '# my codex config\n'
+        'model = "gpt-5"\n\n'
+        '[mcp_servers.other]\n'
+        'command = "node"\n'
+        'args = ["server.js"]\n\n'
+        '[mcp_servers.powermcp_stale]\n'
+        'command = "x"\n'
+        'args = ["y"]\n'
+    )
+    import tomlkit
+
+    doc = codex._build_doc(existing, ["pandapower"])
+    out = tomlkit.dumps(doc)
+    assert "# my codex config" in out
+    assert 'model = "gpt-5"' in out
+    assert "[mcp_servers.other]" in out  # foreign server preserved
+    assert "powermcp_stale" not in out  # stale managed pruned
+    assert "[mcp_servers.powermcp_pandapower]" in out
+
+
+def test_configure_dispatch_writes_all_three(tmp_path, monkeypatch):
+    monkeypatch.setattr(claude_desktop, "config_path", lambda: tmp_path / "desktop.json")
+    monkeypatch.setattr(claude_code, "config_path", lambda: tmp_path / "claude.json")
+    monkeypatch.setattr(codex, "config_path", lambda: tmp_path / "codex.toml")
+    results = configure(["claude-desktop", "claude-code", "codex"], ["pandapower"], dry_run=False)
+    assert set(results) == {"claude-desktop", "claude-code", "codex"}
+    desktop = json.loads((tmp_path / "desktop.json").read_text(encoding="utf-8"))
+    assert "powermcp_pandapower" in desktop["mcpServers"]
+    claude = json.loads((tmp_path / "claude.json").read_text(encoding="utf-8"))
+    assert claude["mcpServers"]["powermcp_pandapower"]["type"] == "stdio"
+    assert "powermcp_pandapower" in (tmp_path / "codex.toml").read_text(encoding="utf-8")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,72 @@
+"""Unit tests for powermcp.config (no real software required)."""
+
+from __future__ import annotations
+
+import pytest
+
+from powermcp import config as cfg
+
+
+def test_load_empty_when_no_file(isolated_config):
+    assert cfg.load() == {}
+    assert "no config yet" in cfg.show()
+
+
+def test_set_and_get_roundtrip(isolated_config):
+    cfg.set_value("psse", "version", "36.2")
+    assert cfg.get("psse", "version") == "36.2"
+    # persisted to disk and re-readable
+    assert cfg.load()["psse"]["version"] == "36.2"
+    assert "36.2" in cfg.show()
+
+
+def test_windows_backslash_path_roundtrip(isolated_config):
+    win = r"C:\Program Files\PTI\PSSE36\36.2\PSSPY311"
+    cfg.set_value("psse", "python_lib", win)
+    assert cfg.get("psse", "python_lib") == win  # survives TOML write+read intact
+
+
+def test_get_path_unset_raises_actionable(isolated_config):
+    # pslf.python_lib has no legacy default, so nothing resolves it.
+    with pytest.raises(cfg.ConfigError) as exc:
+        cfg.get_path("pslf", "python_lib")
+    msg = str(exc.value)
+    assert "powermcp install" in msg
+    assert "powermcp config set pslf.python_lib" in msg
+    assert "POWERMCP_PSLF_PYTHON_LIB" in msg
+
+
+def test_get_path_env_override_wins(isolated_config, tmp_path, monkeypatch):
+    target = tmp_path / "ltspice.exe"
+    target.write_text("")
+    monkeypatch.setenv("POWERMCP_LTSPICE_EXE", str(target))
+    assert cfg.get_path("ltspice", "exe") == str(target)
+
+
+def test_get_path_config_value_used(isolated_config, tmp_path):
+    target = tmp_path / "PSSPY311"
+    target.mkdir()
+    cfg.set_value("psse", "python_lib", str(target))
+    assert cfg.get_path("psse", "python_lib") == str(target)
+
+
+def test_get_path_missing_path_raises(isolated_config):
+    cfg.set_value("psse", "bin", r"C:\does\not\exist\PSSBIN")
+    with pytest.raises(cfg.ConfigError) as exc:
+        cfg.get_path("psse", "bin")
+    assert "does not exist" in str(exc.value)
+
+
+def test_get_path_must_exist_false_skips_check(isolated_config):
+    cfg.set_value("psse", "bin", r"C:\does\not\exist\PSSBIN")
+    assert cfg.get_path("psse", "bin", must_exist=False).endswith("PSSBIN")
+
+
+def test_get_path_falls_back_to_legacy_default(isolated_config, tmp_path, monkeypatch):
+    # Point the registry's legacy default at an existing dir to prove the fallback path.
+    from powermcp import registry
+
+    existing = tmp_path / "legacy"
+    existing.mkdir()
+    monkeypatch.setattr(registry, "legacy_default", lambda t, k: str(existing))
+    assert cfg.get_path("psse", "python_lib") == str(existing)

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,0 +1,40 @@
+"""Tests for powermcp.detect (auto-detection of tool software paths)."""
+
+from __future__ import annotations
+
+import sys
+
+from powermcp import detect
+
+
+def test_first_existing(tmp_path):
+    a, b = tmp_path / "a", tmp_path / "b"
+    b.write_text("")
+    assert detect._first_existing([str(a), str(b)]) == str(b)
+    assert detect._first_existing([str(a)]) is None
+    assert detect._first_existing([None, ""]) is None
+
+
+def test_ltspice_exe_finds_adi(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("ProgramFiles", str(tmp_path))
+    exe = tmp_path / "ADI" / "LTspice" / "LTspice.exe"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("")
+    assert detect.ltspice_exe() == str(exe)
+
+
+def test_ltspice_exe_none_when_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("ProgramFiles", str(tmp_path / "pf"))
+    monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "pf86"))
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    assert detect.ltspice_exe() is None
+
+
+def test_detect_dispatch(monkeypatch):
+    assert detect.detect("nope", "nope") is None
+    monkeypatch.setitem(detect._DETECTORS, "ltspice.exe", lambda: "X")
+    assert detect.detect("ltspice", "exe") == "X"
+    monkeypatch.setitem(detect._DETECTORS, "ltspice.exe", lambda: (_ for _ in ()).throw(OSError()))
+    assert detect.detect("ltspice", "exe") is None  # detector errors are swallowed

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,76 @@
+"""Tier-2 tests for `powermcp doctor` status logic (no real software)."""
+
+from __future__ import annotations
+
+import sys
+
+from powermcp import doctor
+from powermcp.registry import get_tool
+
+
+def test_core_deps_report_ok():
+    # pandapower + pypsa are installed in the test venv.
+    for name in ("pandapower", "pypsa"):
+        style, msg = doctor._dep_status(get_tool(name))
+        assert (style, msg) == ("green", "ok")
+
+
+def test_missing_extra_reports_install_hint(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")  # keep andes visible regardless
+    style, msg = doctor._dep_status(get_tool("andes"))
+    # andes is not installed in the core test venv
+    assert style == "red"
+    assert "pip install powermcp[andes]" in msg
+
+
+def test_path_loaded_engines_not_import_probed(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    for name in ("psse", "pslf", "powerfactory"):
+        style, msg = doctor._dep_status(get_tool(name))
+        assert "vendor engine" in msg
+
+
+def test_windows_only_skipped_off_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    style, msg = doctor._dep_status(get_tool("psse"))
+    assert "Windows-only" in msg
+
+
+def test_surge_python_gate(monkeypatch):
+    monkeypatch.setattr(doctor, "_surge_supported", lambda: False)
+    style, msg = doctor._dep_status(get_tool("surge"))
+    assert style == "yellow" and "3.12" in msg
+
+
+def test_path_status_missing_and_configured(isolated_config):
+    from powermcp import config as cfg
+
+    # ltspice.exe unset -> reported as needing config
+    style, msg = doctor._path_status(get_tool("ltspice"))
+    assert style == "yellow" and "ltspice.exe" in msg
+
+    # set it (must_exist is enforced; point at a real file)
+    target = isolated_config / "LTspice.exe"
+    target.write_text("")
+    cfg.set_value("ltspice", "exe", str(target))
+    style, msg = doctor._path_status(get_tool("ltspice"))
+    assert style == "green"
+
+
+def test_namespace_shadow_not_false_positive():
+    # surge-py is NOT installed in the core test venv. The repo's lowercase
+    # surge/ directory must not be mistaken for the installed library (PEP 420
+    # namespace shadow), so the dependency must report missing, not ok.
+    style, msg = doctor._dep_status(get_tool("surge"))
+    assert style == "red", f"expected surge missing, got {style}: {msg}"
+
+
+def test_tools_without_paths_show_dash():
+    style, msg = doctor._path_status(get_tool("pandapower"))
+    assert msg == "—"
+
+
+def test_run_doctor_smoke(capsys):
+    doctor.run_doctor()  # should not raise
+    out = capsys.readouterr().out
+    assert "PowerMCP doctor" in out

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,78 @@
+"""Unit tests for the powermcp.registry single source of truth."""
+
+from __future__ import annotations
+
+import pytest
+
+from powermcp import registry
+from powermcp.registry import CORE, TOOLS, Tool
+
+
+def test_core_tools_present_and_have_no_extra():
+    assert set(CORE) == {"pandapower", "pypsa"}
+    for name in CORE:
+        assert TOOLS[name].extra is None
+
+
+def test_every_noncore_tool_has_an_extra():
+    for t in TOOLS.values():
+        if t.name not in CORE:
+            assert t.extra, f"{t.name} should declare a pip extra"
+
+
+def test_run_kind_consistency():
+    for t in TOOLS.values():
+        assert t.run_kind in ("script", "module")
+        if t.run_kind == "script":
+            assert t.entry_rel and not t.module
+        else:
+            assert t.module and not t.entry_rel
+
+
+def test_closed_source_path_tools_declare_config_keys():
+    # PSSE/PSLF/PowerFactory/LTSpice capture a local software path; PowerWorld/PSCAD do not.
+    for name in ("psse", "pslf", "powerfactory", "ltspice"):
+        assert TOOLS[name].config_keys, f"{name} should declare config keys"
+    assert TOOLS["powerworld"].config_keys == ()
+    assert TOOLS["pscad"].config_keys == ()
+
+
+def test_windows_only_flags():
+    for name in ("psse", "pslf", "powerfactory", "pscad", "powerworld"):
+        assert TOOLS[name].windows_only is True
+    for name in ("pandapower", "pypsa", "andes", "egret", "surge", "opendss", "hope", "ltspice"):
+        assert TOOLS[name].windows_only is False
+
+
+def test_resolve_server_dir_exists_for_all_tools():
+    for t in TOOLS.values():
+        d = t.resolve_server_dir()
+        assert d.is_dir(), f"{t.name}: {d} is not a directory"
+
+
+def test_resolve_entry_script_exists_for_script_tools():
+    for t in TOOLS.values():
+        if t.run_kind == "script":
+            script = t.resolve_entry_script()
+            assert script.is_file(), f"{t.name}: missing entry {script}"
+
+
+def test_module_tools_have_resolvable_roots():
+    for t in TOOLS.values():
+        if t.run_kind == "module":
+            root = t.resolve_module_root()
+            assert root.is_dir()
+            # the module's top package dir must exist under the root
+            top = t.module.split(".")[0]
+            assert (root / top).is_dir(), f"{t.name}: {root / top} missing"
+
+
+def test_legacy_default_lookup():
+    assert registry.legacy_default("ltspice", "exe").endswith("XVIIx64.exe")
+    assert registry.legacy_default("pslf", "python_lib") is None
+    assert registry.legacy_default("nope", "nope") is None
+
+
+def test_get_tool_unknown_raises():
+    with pytest.raises(KeyError):
+        registry.get_tool("does-not-exist")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,95 @@
+"""Tests for powermcp.runner — launching servers without starting a real server.
+
+We monkeypatch FastMCP.run so the server module executes its full import + tool
+registration but the stdio loop is a no-op (records the call instead).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from powermcp import runner
+
+
+@pytest.fixture()
+def record_mcp_run(monkeypatch):
+    calls = []
+
+    def fake_run(self, *args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr("mcp.server.fastmcp.FastMCP.run", fake_run, raising=True)
+    return calls
+
+
+def test_launch_pandapower_runs_once(record_mcp_run):
+    runner.launch("pandapower")
+    assert len(record_mcp_run) == 1
+    _, kwargs = record_mcp_run[0]
+    assert kwargs.get("transport") == "stdio"
+
+
+def test_launch_pypsa_runs_once(record_mcp_run):
+    runner.launch("pypsa")
+    assert len(record_mcp_run) == 1
+
+
+def test_launch_does_not_shadow_installed_library(record_mcp_run):
+    # After launching, `import pandapower` must still resolve to the installed
+    # library (a real package with pandapowerNet), not the server directory.
+    runner.launch("pandapower")
+    import pandapower as pp
+
+    assert hasattr(pp, "create_empty_network")
+
+
+def test_preflight_missing_pip_dep_raises():
+    # andes is an opt-in extra and is not installed in the test venv.
+    with pytest.raises(runner.LaunchError) as exc:
+        runner.launch("andes")
+    assert "powermcp[andes]" in str(exc.value)
+
+
+def test_preflight_windows_only_rejected_off_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    with pytest.raises(runner.LaunchError) as exc:
+        runner.launch("psse")
+    assert "Windows-only" in str(exc.value)
+
+
+def test_unknown_tool_raises():
+    with pytest.raises(KeyError):
+        runner.launch("nope")
+
+
+def test_probe_installed_handles_namespace_parent(tmp_path, monkeypatch):
+    # Reproduces the mhi.pscad case: `ns` is a PEP 420 namespace (no __init__),
+    # `ns.sub` is a real package. Probing the full dotted name must succeed even
+    # though the top-level parent is a namespace; a bare namespace must not.
+    (tmp_path / "ns" / "sub").mkdir(parents=True)
+    (tmp_path / "ns" / "sub" / "__init__.py").write_text("")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for m in ("ns", "ns.sub"):
+        sys.modules.pop(m, None)
+    try:
+        assert runner.probe_installed("ns.sub") is True   # real subpackage (like mhi.pscad)
+        assert runner.probe_installed("ns") is False       # bare namespace (like the surge shadow)
+        assert runner.probe_installed("definitely_absent_pkg_xyz") is False
+    finally:
+        for m in ("ns", "ns.sub"):
+            sys.modules.pop(m, None)
+
+
+def test_python_dash_m_powermcp_works():
+    # Regression: MCP client configs launch via `python -m powermcp run <tool>`,
+    # which requires powermcp/__main__.py. Exercise that exact entry path.
+    import subprocess
+
+    r = subprocess.run(
+        [sys.executable, "-m", "powermcp", "--version"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "powermcp" in r.stdout

--- a/tests/test_vendor_import.py
+++ b/tests/test_vendor_import.py
@@ -1,0 +1,71 @@
+"""Tier-3 regression guard for the vendor-engine refactors.
+
+The key invariant: importing a vendor server module on a machine WITHOUT the
+vendor software must succeed and must NOT initialize the engine. The engine is
+touched only by the memoized _ensure_*() helper, exactly once, on first use.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+
+from powermcp.registry import get_tool
+
+
+def _load(mod_name: str, path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(mod_name, str(path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_psse_import_side_effect_free_then_inits_once(monkeypatch):
+    init_calls = []
+    fake_psspy = types.ModuleType("psspy")
+    fake_psspy.psseinit = lambda n: init_calls.append(n)
+    monkeypatch.setitem(sys.modules, "psspy", fake_psspy)
+    monkeypatch.setitem(sys.modules, "psse36", types.ModuleType("psse36"))
+
+    path = get_tool("psse").resolve_entry_script()
+    mod = _load("psse_mcp_under_test", path)
+
+    # Importing the module must NOT initialize the PSS/E engine.
+    assert init_calls == []
+    assert mod.psspy is None
+
+    # First use initializes exactly once; second use is memoized.
+    mod._ensure_psse()
+    mod._ensure_psse()
+    assert init_calls == [50]
+    assert mod.psspy is fake_psspy
+
+    monkeypatch.delitem(sys.modules, "psse_mcp_under_test", raising=False)
+
+
+def test_pslf_import_side_effect_free_then_inits_once(monkeypatch):
+    init_calls = []
+    fake = types.ModuleType("PSLF_PYTHON")
+    fake.init_pslf = lambda **kw: init_calls.append(kw)
+    fake.Pslf = object()
+    fake.CaseParameters = object()
+    fake.Bus = []
+    fake.Flox = []
+    monkeypatch.setitem(sys.modules, "PSLF_PYTHON", fake)
+
+    path = get_tool("pslf").resolve_entry_script()
+    mod = _load("pslf_mcp_under_test", path)
+
+    # Importing must NOT call init_pslf and must NOT require PSLF_PYTHON names yet.
+    assert init_calls == []
+
+    mod._ensure_pslf()
+    mod._ensure_pslf()
+    assert len(init_calls) == 1
+    # The wildcard names are published into the module globals on first use.
+    assert getattr(mod, "Pslf", None) is fake.Pslf
+    assert hasattr(mod, "CaseParameters")
+
+    monkeypatch.delitem(sys.modules, "pslf_mcp_under_test", raising=False)

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,0 +1,144 @@
+"""Tier-2 tests for the install wizard's tool selection / platform filtering."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from powermcp import wizard
+from powermcp.registry import CORE
+
+
+def test_yes_mode_selects_core_only():
+    selected = wizard._resolve_selection(yes=True, tools=None, select_all=False, client_names=[])
+    assert [t.name for t in selected] == list(CORE)
+
+
+def test_tools_flag_includes_requested_plus_core(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")  # make psse available
+    names = {t.name for t in wizard._resolve_selection(yes=False, tools="psse,andes", select_all=False, client_names=[])}
+    assert {"psse", "andes"} <= names  # explicit picks present
+    assert set(CORE) <= names          # core always included
+
+
+def test_tools_all_keyword_and_all_flag(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(wizard, "_surge_supported", lambda: True)
+    via_keyword = {t.name for t in wizard._resolve_selection(yes=False, tools="all", select_all=False, client_names=[])}
+    via_flag = {t.name for t in wizard._resolve_selection(yes=False, tools=None, select_all=True, client_names=[])}
+    assert via_keyword == via_flag
+    assert {"psse", "pslf", "powerfactory", "pscad", "ltspice", "andes"} <= via_keyword
+
+
+def test_tools_unknown_id_ignored_not_fatal():
+    names = {t.name for t in wizard._resolve_selection(yes=False, tools="pandapower,bogustool", select_all=False, client_names=[])}
+    assert "pandapower" in names
+    assert "bogustool" not in names
+
+
+def test_tools_unavailable_off_platform_skipped(monkeypatch):
+    # psse is Windows-only: requesting it on Linux drops it, leaving core only.
+    monkeypatch.setattr(sys, "platform", "linux")
+    names = {t.name for t in wizard._resolve_selection(yes=False, tools="psse", select_all=False, client_names=[])}
+    assert "psse" not in names
+    assert set(CORE) <= names
+
+
+def test_windows_only_hidden_off_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    names = {t.name for t in wizard.selectable_tools()}
+    for win_tool in ("psse", "pslf", "powerfactory", "pscad", "powerworld"):
+        assert win_tool not in names
+    for ok_tool in ("pandapower", "pypsa", "andes", "egret", "opendss", "hope", "ltspice"):
+        assert ok_tool in names
+
+
+def test_windows_only_shown_on_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(wizard, "_surge_supported", lambda: True)
+    names = {t.name for t in wizard.selectable_tools()}
+    assert {"psse", "pslf", "powerfactory", "pscad", "powerworld"} <= names
+
+
+def test_surge_hidden_when_python_unsupported(monkeypatch):
+    monkeypatch.setattr(wizard, "_surge_supported", lambda: False)
+    assert "surge" not in {t.name for t in wizard.selectable_tools()}
+
+
+def test_is_installed_or_configured(isolated_config):
+    from powermcp import config as cfg
+
+    # pandapower is installed in the test venv → counts as set up.
+    assert wizard._is_installed_or_configured(wizard.TOOLS["pandapower"]) is True
+    # psse has no pip probe; unset paths → not set up, then set them → set up.
+    assert wizard._is_installed_or_configured(wizard.TOOLS["psse"]) is False
+    cfg.set_value("psse", "python_lib", r"C:\x\PSSPY311")
+    cfg.set_value("psse", "bin", r"C:\x\PSSBIN")
+    assert wizard._is_installed_or_configured(wizard.TOOLS["psse"]) is True
+
+
+def test_existing_managed_tools_reads_client_config(tmp_path, monkeypatch):
+    import json
+
+    from powermcp.clients import claude_desktop
+
+    cfg_file = tmp_path / "claude_desktop_config.json"
+    cfg_file.write_text(
+        json.dumps({"mcpServers": {
+            "powermcp_andes": {"command": "x", "args": []},
+            "filesystem": {"command": "y", "args": []},   # foreign, ignored
+        }}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(claude_desktop, "config_path", lambda: cfg_file)
+    assert wizard._existing_managed_tools(["claude-desktop"]) == {"andes"}
+
+
+def test_preselected_includes_core_installed_and_existing(tmp_path, monkeypatch, isolated_config):
+    import json
+
+    from powermcp.clients import claude_desktop
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    cfg_file = tmp_path / "claude_desktop_config.json"
+    cfg_file.write_text(
+        json.dumps({"mcpServers": {"powermcp_andes": {"command": "x", "args": []}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(claude_desktop, "config_path", lambda: cfg_file)
+    pre = wizard._preselected_names(["claude-desktop"])
+    assert set(CORE) <= pre              # core always
+    assert "andes" in pre                # already in the client config
+    assert "pslf" not in pre             # not installed, not configured, not in client
+
+
+def test_interactive_select_non_tty_returns_core(monkeypatch):
+    monkeypatch.setattr(wizard, "_tty", lambda: False)
+    assert [t.name for t in wizard._interactive_select([])] == list(CORE)
+
+
+def test_capture_paths_non_tty_does_not_prompt(monkeypatch, capsys):
+    # No TTY: must not import/use questionary, must not raise, and should tell the
+    # user how to set the path manually.
+    monkeypatch.setattr(wizard, "_tty", lambda: False)
+    monkeypatch.setitem(sys.modules, "questionary", None)  # any use would raise
+    wizard._capture_paths([wizard.TOOLS["psse"]])
+    out = capsys.readouterr().out
+    assert "powermcp config set psse.python_lib" in out
+
+
+def test_interactive_select_ctrl_c_returns_empty(monkeypatch):
+    # TTY present but the user aborts the picker (questionary returns None).
+    monkeypatch.setattr(wizard, "_tty", lambda: True)
+    fake_q = types.ModuleType("questionary")
+
+    class _Q:
+        def ask(self):
+            return None
+
+    fake_q.Choice = lambda **kw: kw
+    fake_q.checkbox = lambda *a, **k: _Q()
+    monkeypatch.setitem(sys.modules, "questionary", fake_q)
+    assert wizard._interactive_select([]) == []


### PR DESCRIPTION
Add a single pip-installable package `powermcp` with an interactive installer, while keeping every server runnable standalone from a clone.

- pyproject: one distribution; core = pandapower + PyPSA; per-tool extras plus `opensource`/`windows`/`all` groups. Server dirs are shipped verbatim into the wheel via hatchling force-include (preserves data files, e.g. PSS/E's 2184 command JSONs and OpenDSS cases).
- New `powermcp/` core package: config (~/.powermcp/config.toml + get_path), registry (single source of truth), runner (`powermcp run`), wizard (`powermcp install` with --tools/--all, preselection of installed/configured tools), doctor, paths, LTSpice path auto-detection (detect.py), and client-config writers for Claude Desktop, Claude Code, and the Codex CLI.
- Vendor servers refactored to lazy, memoized engine init + config-driven paths (PSS/E, PSLF, PowerFactory), writable run dirs moved out of the package tree (ANDES, LTSpice), guarded vendor imports (PSCAD `mhi`), and config-driven defaults (HOPE) — each still runs standalone via `python <dir>/<entry>.py`.
- PowerWorld extra also installs numba (works around esa 1.3.5's broken no-numba import path).
- 62 tests (config, registry, runner, vendor-import, clients, wizard, doctor, detect); README + per-package README updated; config.json shows the new form.