### PR TITLE
feat: integrate powerio as the cross-server case exchange substrate

### DIFF
--- a/Egret/egret_mcp.py
+++ b/Egret/egret_mcp.py
@@ -181,5 +181,106 @@ def solve_dc_opf(
             "message": str(e)
         }
 
+# ---------------------------------------------------------------------------
+# powerio bridge: ingest any powerio readable case into egret.
+# powerio converts MATPOWER .m, PSS/E .raw (v33), PowerWorld .aux, PowerModels
+# JSON, or its own JSON transport to egret JSON; the staged file feeds the
+# solver tools above, which only accept case_file paths. powerio is an
+# optional extra, so the tools degrade to a status dict when it is missing.
+# ---------------------------------------------------------------------------
+
+_POWERIO_HINT = "powerio not installed: pip install 'powerio[mcp,matrix]'"
+
+
+def _stage_egret_model(egret_json_text: str):
+    """Validate egret JSON by constructing a ModelData from the parsed dict,
+    stage it to a temp file the solver tools can read, and summarize it."""
+    import json
+    import tempfile
+
+    md = ModelData(json.loads(egret_json_text))
+    fd, path = tempfile.mkstemp(suffix=".json", prefix="egret_case_")
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(egret_json_text)
+    info = {name: len(items) for name, items in md.data.get("elements", {}).items()}
+    return path, info
+
+
+@mcp.tool()
+def load_model_from_any(file_path: str, source_format: Optional[str] = None) -> Dict[str, Any]:
+    """Convert any powerio readable case file into an egret model.
+
+    Reads MATPOWER .m, PSS/E .raw (v33), PowerWorld .aux, PowerModels JSON, or
+    egret JSON via powerio, converts it to egret JSON, validates it as an
+    egret ModelData, and stages it to a temp file. Pass the returned
+    `case_file` path to solve_ac_opf, solve_dc_opf, or
+    solve_unit_commitment_problem. Requires the powerio extra
+    (pip install 'powermcp[powerio]').
+
+    Args:
+        file_path: Path to the case file
+        source_format: Input format name (matpower, powermodels-json,
+            egret-json, psse, powerworld); inferred from the file extension
+            when omitted
+
+    Returns:
+        Dict with status, the staged `case_file` path, model element counts,
+        and powerio's fidelity warnings
+    """
+    try:
+        import powerio
+    except ImportError:
+        return {"status": "error", "message": _POWERIO_HINT}
+    try:
+        conv = powerio.convert_file(file_path, "egret-json", source_format)
+        path, info = _stage_egret_model(conv.text)
+    except FileNotFoundError:
+        return {"status": "error", "message": f"File not found: {file_path}"}
+    except Exception as e:
+        return {"status": "error", "message": str(e)}
+    return {
+        "status": "success",
+        "case_file": path,
+        "model_info": info,
+        "warnings": list(conv.warnings),
+    }
+
+
+@mcp.tool()
+def load_model_from_json(network_json: str) -> Dict[str, Any]:
+    """Convert a powerio JSON transport string into an egret model.
+
+    Accepts the `json` string returned by the powerio server's parse_case or
+    case_to_json tools, so a case parsed once there feeds egret without
+    re-reading the file. Converts it to egret JSON, validates it as an egret
+    ModelData, and stages it to a temp file. Pass the returned `case_file`
+    path to the solver tools. Requires the powerio extra
+    (pip install 'powermcp[powerio]').
+
+    Args:
+        network_json: The JSON transport string from powerio
+
+    Returns:
+        Dict with status, the staged `case_file` path, model element counts,
+        and powerio's fidelity warnings
+    """
+    try:
+        import powerio
+    except ImportError:
+        return {"status": "error", "message": _POWERIO_HINT}
+    try:
+        case = powerio.from_json(network_json)
+        conv = case.to_format("egret-json")
+        path, info = _stage_egret_model(conv.text)
+    except Exception as e:
+        return {"status": "error", "message": str(e)}
+    return {
+        "status": "success",
+        "case_file": path,
+        "model_info": info,
+        "warnings": list(conv.warnings),
+    }
+
+
 if __name__ == "__main__":
-    mcp.run(transport="stdio") 
+    mcp.run(transport="stdio")

--- a/PyPSA/pypsa_mcp.py
+++ b/PyPSA/pypsa_mcp.py
@@ -564,5 +564,221 @@ def export_to_csv_folder(network_name: str, folder_path: str) -> Dict[str, Any]:
         }
 
 
+# ---------------------------------------------------------------------------
+# powerio bridge: import any powerio readable case as a PyPSA network.
+# powerio parses MATPOWER .m, PSS/E .raw (v33), PowerWorld .aux, PowerModels
+# JSON, and egret JSON; the case becomes a PYPOWER ppc dict, pypsa imports it,
+# and the network is saved to a .nc file whose path the other tools accept as
+# network_name. powerio is an optional extra, so the tools degrade to a status
+# dict when it is missing.
+# ---------------------------------------------------------------------------
+
+_POWERIO_HINT = "powerio not installed: pip install 'powerio[mcp,matrix]'"
+
+# powerio bus kind -> MATPOWER/PYPOWER BUS_TYPE code
+# NOTE: _PPC_BUS_TYPE and _powerio_case_to_ppc are duplicated between
+# pandapower/panda_mcp.py and PyPSA/pypsa_mcp.py (server scripts are
+# standalone); keep the two copies identical and sync any fix to both.
+_PPC_BUS_TYPE = {"PQ": 1.0, "PV": 2.0, "REF": 3.0, "ISOLATED": 4.0}
+
+
+def _powerio_case_to_ppc(case) -> Dict[str, Any]:
+    """Build a PYPOWER ppc dict from a powerio Network.
+
+    Values are MATPOWER style (MW, MVAr, degrees), which is what powerio's
+    parsed source tables carry; in-service loads and shunts are summed into
+    the bus table the way MATPOWER stores them.
+    """
+    import numpy as np
+
+    buses = case.buses
+    row_of = {b["id"]: i for i, b in enumerate(buses)}
+    bus = np.zeros((len(buses), 13))
+    for i, b in enumerate(buses):
+        bus[i, :] = (
+            b["id"], _PPC_BUS_TYPE.get(b["kind"], 1.0), 0.0, 0.0, 0.0, 0.0,
+            b["area"], b["vm"], b["va"], b["base_kv"], b["zone"], b["vmax"], b["vmin"],
+        )
+    for load in case.loads:
+        i = row_of.get(load["bus"])
+        if i is not None and load["in_service"]:
+            bus[i, 2] += load["p"]
+            bus[i, 3] += load["q"]
+    for shunt in case.shunts:
+        i = row_of.get(shunt["bus"])
+        if i is not None and shunt["in_service"]:
+            bus[i, 4] += shunt["g"]
+            bus[i, 5] += shunt["b"]
+
+    gens = case.generators
+    gen = np.zeros((len(gens), 21))
+    for i, g in enumerate(gens):
+        gen[i, :10] = (
+            g["bus"], g["pg"], g["qg"], g["qmax"], g["qmin"], g["vg"],
+            g["mbase"], float(g["in_service"]), g["pmax"], g["pmin"],
+        )
+
+    branches = case.branches
+    branch = np.zeros((len(branches), 13))
+    for i, br in enumerate(branches):
+        branch[i, :] = (
+            br["from_id"], br["to_id"], br["r"], br["x"], br["b"],
+            br["rate_a"], br["rate_b"], br["rate_c"], br["tap"], br["shift"],
+            float(br["in_service"]), br["angmin"], br["angmax"],
+        )
+
+    ppc = {
+        "version": "2",
+        "baseMVA": float(case.base_mva),
+        "bus": bus,
+        "gen": gen,
+        "branch": branch,
+    }
+
+    # gencost rows are [model, startup, shutdown, ncost, coeffs...] with
+    # coefficients left-aligned after ncost, padded to the widest row — the
+    # layout from_ppc reads. MATPOWER requires cost data for all gens or none,
+    # so a partial cost set is dropped rather than padded with fake rows.
+    costs = [g["cost"] for g in gens]
+    if costs and all(c is not None for c in costs):
+        gencost = np.zeros((len(costs), 4 + max(len(c["coeffs"]) for c in costs)))
+        for i, c in enumerate(costs):
+            gencost[i, :4] = (c["model"], c["startup"], c["shutdown"], c["ncost"])
+            gencost[i, 4:4 + len(c["coeffs"])] = c["coeffs"]
+        ppc["gencost"] = gencost
+    return ppc
+
+
+def _import_case_to_netcdf(case, output_path: str, overwrite_zero_s_nom: Optional[float]):
+    """Import a powerio case into a fresh PyPSA network, save it to
+    output_path, and collect warnings about anything the ppc import cannot
+    represent."""
+    ppc = _powerio_case_to_ppc(case)
+    warnings = []
+    isolated = ppc["bus"][:, 1] == 4.0
+    if isolated.any():
+        # import_from_pypower_ppc indexes ["", "PQ", "PV", "Slack"] by bus
+        # type, so type 4 would raise; PyPSA has no isolated bus type.
+        ppc["bus"][isolated, 1] = 1.0
+        warnings.append(f"{int(isolated.sum())} isolated bus(es) imported as PQ")
+    if any(g["cost"] is not None for g in case.generators):
+        warnings.append(
+            "generator cost data is not representable by the PyPSA ppc import and was dropped"
+        )
+    if (ppc["bus"][:, 9] == 0).any():
+        warnings.append("buses with base_kv 0 are assigned v_nom 1 by PyPSA")
+    in_service = ppc["branch"][:, 10] == 1.0
+    if overwrite_zero_s_nom is None and (ppc["branch"][in_service, 5] == 0).any():
+        warnings.append(
+            "branches with rating 0 imported with s_nom 0; pass overwrite_zero_s_nom to set a value"
+        )
+    network = Network()
+    network.import_from_pypower_ppc(ppc, overwrite_zero_s_nom=overwrite_zero_s_nom)
+    network.export_to_netcdf(output_path)
+    info = {
+        "buses": len(network.buses),
+        "generators": len(network.generators),
+        "loads": len(network.loads),
+        "lines": len(network.lines),
+        "transformers": len(network.transformers),
+        "shunt_impedances": len(network.shunt_impedances),
+    }
+    return info, warnings
+
+
+@mcp.tool()
+def import_case_from_any(
+    file_path: str,
+    output_path: str,
+    source_format: Optional[str] = None,
+    overwrite_zero_s_nom: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Import any powerio readable case file as a PyPSA network saved to a
+    NetCDF file.
+
+    Reads MATPOWER .m, PSS/E .raw (v33), PowerWorld .aux, PowerModels JSON, or
+    egret JSON via powerio and writes a PyPSA network to output_path (use a
+    .nc extension); pass that path as network_name to the other tools. PyPSA's
+    ppc import drops generator cost data; anything else it cannot represent is
+    listed in the returned warnings. Branches with rating 0 are imported with
+    s_nom 0 unless overwrite_zero_s_nom supplies a value. Requires the powerio
+    extra (pip install 'powermcp[powerio]').
+
+    Args:
+        file_path: Path to the case file
+        output_path: Where to save the imported network (.nc)
+        source_format: Input format name (matpower, powermodels-json,
+            egret-json, psse, powerworld); inferred from the file extension
+            when omitted
+        overwrite_zero_s_nom: Replacement s_nom for branches with rating 0
+
+    Returns:
+        Dict with status, the saved network_file path, component counts, and
+        warnings about dropped or adjusted data
+    """
+    try:
+        import powerio
+    except ImportError:
+        return {"status": "error", "message": _POWERIO_HINT}
+    try:
+        case = powerio.parse_file(file_path, source_format)
+        info, warnings = _import_case_to_netcdf(case, output_path, overwrite_zero_s_nom)
+    except FileNotFoundError:
+        return {"status": "error", "message": f"File not found: {file_path}"}
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to import case: {str(e)}"}
+    return {
+        "status": "success",
+        "message": f"Network imported and saved to {output_path}",
+        "network_file": output_path,
+        "info": info,
+        "warnings": warnings,
+    }
+
+
+@mcp.tool()
+def import_case_from_json(
+    network_json: str,
+    output_path: str,
+    overwrite_zero_s_nom: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Import a powerio JSON transport string as a PyPSA network saved to a
+    NetCDF file.
+
+    Accepts the `json` string returned by the powerio server's parse_case or
+    case_to_json tools, so a case parsed once there loads here without passing
+    a file around or re-parsing it. Expects source-valued tables (MW, degrees)
+    as parse_case emits them, not the per-unit normalize_case form. Writes the
+    network to output_path (use a .nc extension); pass that path as
+    network_name to the other tools. Requires the powerio extra
+    (pip install 'powermcp[powerio]').
+
+    Args:
+        network_json: The JSON transport string from powerio
+        output_path: Where to save the imported network (.nc)
+        overwrite_zero_s_nom: Replacement s_nom for branches with rating 0
+
+    Returns:
+        Dict with status, the saved network_file path, component counts, and
+        warnings about dropped or adjusted data
+    """
+    try:
+        import powerio
+    except ImportError:
+        return {"status": "error", "message": _POWERIO_HINT}
+    try:
+        case = powerio.from_json(network_json)
+        info, warnings = _import_case_to_netcdf(case, output_path, overwrite_zero_s_nom)
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to import case: {str(e)}"}
+    return {
+        "status": "success",
+        "message": f"Network imported and saved to {output_path}",
+        "network_file": output_path,
+        "info": info,
+        "warnings": warnings,
+    }
+
+
 if __name__ == "__main__":
     mcp.run(transport="stdio")

--- a/README.md
+++ b/README.md
@@ -126,16 +126,20 @@ These tools wrap commercial or locally-installed software, so PowerMCP stores th
 
 ### Case conversion between servers (PowerIO)
 
-The `powerio` extra adds a conversion server backed by [powerio](https://github.com/eigenergy/powerio). It parses MATPOWER `.m`, PSS/E `.raw`, PowerWorld `.aux`, PowerModels JSON, and egret JSON into one format neutral network, converts between those formats with fidelity warnings, and builds the sparse matrices solvers need (B', B'', Y_bus, PTDF, LODF, Laplacian).
+The `powerio` extra adds a conversion server backed by [powerio](https://github.com/eigenergy/powerio). It parses MATPOWER `.m`, PSS/E `.raw`, PowerWorld `.aux`, PowerModels JSON, and egret JSON into one format neutral network, converts between those formats with fidelity warnings, and builds the sparse matrices solvers need (B', B'', Y_bus, PTDF, LODF, Laplacian, LACPF).
 
 Its JSON transport is the exchange format between PowerMCP servers: parse a case once, pass the returned `json` string between tool calls, and load it anywhere.
 
 ```
-parse_case(path="case9.raw")                 # powerio server → {"json": ..., "summary": ...}
-load_network_from_json(network_json=...)     # pandapower server ingests the transport
-load_model_from_json(network_json=...)       # egret server stages it as a solvable case file
-compute_matrix(kind="ptdf", json=...)        # powerio server builds matrices from it
+parse_case(path="case9.raw")                       # powerio server → {"json": ..., "summary": ...}
+load_network_from_json(network_json=...)           # pandapower server ingests the transport
+load_model_from_json(network_json=...)             # egret server stages it as a solvable case file
+import_case_from_json(network_json=..., output_path="case9.nc")  # PyPSA server writes a .nc for its tools
+compute_matrix(kind="ptdf", json=...)              # powerio server builds matrices from it
+save_case(to="psse", out_path="case9.raw", json=...)  # stage a file for path-only servers
 ```
+
+`save_case` covers the servers without a bridge: write the converted case to disk and point their load tools at the file (e.g. convert PowerWorld `.aux` to MATPOWER `.m` for ANDES).
 
 ### Running from a clone (without installing)
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The base install includes the two open-source engines that need no extra setup â
 ```bash
 pip install powermcp[psse]              # add PSS/E support
 pip install powermcp[andes,opendss]     # add several tools at once
-pip install powermcp[opensource]        # all open-source tools (ANDES, Egret, OpenDSS, surge, HOPE, LTSpice)
+pip install powermcp[opensource]        # all open-source tools (ANDES, Egret, OpenDSS, surge, HOPE, LTSpice, PowerIO)
 pip install powermcp[all]               # everything (closed-source tools still need the local software)
 ```
 
@@ -123,6 +123,19 @@ These tools wrap commercial or locally-installed software, so PowerMCP stores th
 | PSCAD | *(none)* | `pip install powermcp[pscad-windows]` provides `mhi-pscad`; PSCAD must be installed |
 
 > The Codex *Desktop* app on Windows has been reported to overwrite `~/.codex/config.toml`; the Codex *CLI* is unaffected. If you use both, re-run `powermcp install` after Desktop edits.
+
+### Case conversion between servers (PowerIO)
+
+The `powerio` extra adds a conversion server backed by [powerio](https://github.com/eigenergy/powerio). It parses MATPOWER `.m`, PSS/E `.raw`, PowerWorld `.aux`, PowerModels JSON, and egret JSON into one format neutral network, converts between those formats with fidelity warnings, and builds the sparse matrices solvers need (B', B'', Y_bus, PTDF, LODF, Laplacian).
+
+Its JSON transport is the exchange format between PowerMCP servers: parse a case once, pass the returned `json` string between tool calls, and load it anywhere.
+
+```
+parse_case(path="case9.raw")                 # powerio server â†’ {"json": ..., "summary": ...}
+load_network_from_json(network_json=...)     # pandapower server ingests the transport
+load_model_from_json(network_json=...)       # egret server stages it as a solvable case file
+compute_matrix(kind="ptdf", json=...)        # powerio server builds matrices from it
+```
 
 ### Running from a clone (without installing)
 

--- a/pandapower/panda_mcp.py
+++ b/pandapower/panda_mcp.py
@@ -255,5 +255,227 @@ def get_network_info() -> Dict[str, Any]:
             "message": f"Failed to get network information: {str(e)}"
         }
 
+# ---------------------------------------------------------------------------
+# powerio bridge: exchange cases with the powerio conversion server.
+# Its parse_case / case_to_json tools emit a JSON transport string that
+# load_network_from_json ingests directly, so a case parsed once there loads
+# here without re-reading the file; export_network_to_format sends the current
+# network back out through powerio. powerio is an optional extra, so each tool
+# degrades to a status dict when it is missing.
+# ---------------------------------------------------------------------------
+
+_POWERIO_HINT = "powerio not installed: pip install 'powerio[mcp,matrix]'"
+
+# powerio bus kind -> MATPOWER/PYPOWER BUS_TYPE code
+_PPC_BUS_TYPE = {"PQ": 1.0, "PV": 2.0, "REF": 3.0, "ISOLATED": 4.0}
+
+
+def _powerio_case_to_ppc(case) -> Dict[str, Any]:
+    """Build a PYPOWER ppc dict from a powerio Network.
+
+    Values are MATPOWER style (MW, MVAr, degrees), which is what powerio's
+    parsed source tables carry; in-service loads and shunts are summed into
+    the bus table the way MATPOWER stores them.
+    """
+    import numpy as np
+
+    buses = case.buses
+    row_of = {b["id"]: i for i, b in enumerate(buses)}
+    bus = np.zeros((len(buses), 13))
+    for i, b in enumerate(buses):
+        bus[i, :] = (
+            b["id"], _PPC_BUS_TYPE.get(b["kind"], 1.0), 0.0, 0.0, 0.0, 0.0,
+            b["area"], b["vm"], b["va"], b["base_kv"], b["zone"], b["vmax"], b["vmin"],
+        )
+    for load in case.loads:
+        i = row_of.get(load["bus"])
+        if i is not None and load["in_service"]:
+            bus[i, 2] += load["p"]
+            bus[i, 3] += load["q"]
+    for shunt in case.shunts:
+        i = row_of.get(shunt["bus"])
+        if i is not None and shunt["in_service"]:
+            bus[i, 4] += shunt["g"]
+            bus[i, 5] += shunt["b"]
+
+    gens = case.generators
+    gen = np.zeros((len(gens), 21))
+    for i, g in enumerate(gens):
+        gen[i, :10] = (
+            g["bus"], g["pg"], g["qg"], g["qmax"], g["qmin"], g["vg"],
+            g["mbase"], float(g["in_service"]), g["pmax"], g["pmin"],
+        )
+
+    branches = case.branches
+    branch = np.zeros((len(branches), 13))
+    for i, br in enumerate(branches):
+        branch[i, :] = (
+            br["from_id"], br["to_id"], br["r"], br["x"], br["b"],
+            br["rate_a"], br["rate_b"], br["rate_c"], br["tap"], br["shift"],
+            float(br["in_service"]), br["angmin"], br["angmax"],
+        )
+
+    ppc = {
+        "version": "2",
+        "baseMVA": float(case.base_mva),
+        "bus": bus,
+        "gen": gen,
+        "branch": branch,
+    }
+
+    # gencost rows are [model, startup, shutdown, ncost, coeffs...] with
+    # coefficients left-aligned after ncost, padded to the widest row — the
+    # layout from_ppc reads. MATPOWER requires cost data for all gens or none,
+    # so a partial cost set is dropped rather than padded with fake rows.
+    costs = [g["cost"] for g in gens]
+    if costs and all(c is not None for c in costs):
+        gencost = np.zeros((len(costs), 4 + max(len(c["coeffs"]) for c in costs)))
+        for i, c in enumerate(costs):
+            gencost[i, :4] = (c["model"], c["startup"], c["shutdown"], c["ncost"])
+            gencost[i, 4:4 + len(c["coeffs"])] = c["coeffs"]
+        ppc["gencost"] = gencost
+    return ppc
+
+
+def _ppc_to_net(ppc) -> pp.pandapowerNet:
+    from pandapower.converter.pypower.from_ppc import from_ppc
+
+    return from_ppc(ppc)
+
+
+def _ppc_to_matpower_text(ppc) -> str:
+    """Serialize PYPOWER input tables as MATPOWER .m text for powerio to parse.
+    Columns beyond the MATPOWER input widths (result columns) are dropped."""
+    width = {"bus": 13, "gen": 21, "branch": 13}
+    out = [
+        "function mpc = ppc_export",
+        "mpc.version = '2';",
+        f"mpc.baseMVA = {float(ppc['baseMVA'])!r};",
+    ]
+    for name in ("bus", "gen", "branch", "gencost"):
+        table = ppc.get(name)
+        if table is None or len(table) == 0:
+            continue
+        w = width.get(name)
+        rows = "\n".join(
+            "\t" + "\t".join(repr(float(v)) for v in (row[:w] if w else row)) + ";"
+            for row in table
+        )
+        out.append(f"mpc.{name} = [\n{rows}\n];")
+    return "\n".join(out) + "\n"
+
+
+def _network_info_response(message: str) -> Dict[str, Any]:
+    return {
+        "status": "success",
+        "message": message,
+        "network_info": {
+            "buses": len(_current_net.bus),
+            "lines": len(_current_net.line),
+            "trafos": len(_current_net.trafo),
+        },
+    }
+
+
+@mcp.tool()
+def load_network_from_any(file_path: str, source_format: Optional[str] = None) -> Dict[str, Any]:
+    """Load a network from any powerio readable case file.
+
+    Reads MATPOWER .m, PSS/E .raw (v33), PowerWorld .aux, PowerModels JSON, or
+    egret JSON via powerio and converts it to a pandapower network, replacing
+    the currently loaded one. Use this for case formats load_network does not
+    accept. Requires the powerio extra (pip install 'powermcp[powerio]').
+
+    Args:
+        file_path: Path to the case file
+        source_format: Input format name (matpower, powermodels-json,
+            egret-json, psse, powerworld); inferred from the file extension
+            when omitted
+
+    Returns:
+        Dict containing status and network information
+    """
+    logger.info(f"Loading network via powerio from: {file_path}")
+    global _current_net
+    try:
+        import powerio
+    except ImportError:
+        return {"status": "error", "message": _POWERIO_HINT}
+    try:
+        case = powerio.parse_file(file_path, source_format)
+        _current_net = _ppc_to_net(_powerio_case_to_ppc(case))
+    except FileNotFoundError:
+        return {"status": "error", "message": f"File not found: {file_path}"}
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to load network: {str(e)}"}
+    return _network_info_response(f"Network loaded successfully from {file_path}")
+
+
+@mcp.tool()
+def load_network_from_json(network_json: str) -> Dict[str, Any]:
+    """Load a network from a powerio JSON transport string.
+
+    Accepts the `json` string returned by the powerio server's parse_case or
+    case_to_json tools, so a case parsed once there loads here without passing
+    a file around or re-parsing it. Expects source-valued tables (MW, degrees)
+    as parse_case emits them, not the per-unit normalize_case form. Replaces
+    the currently loaded network. Requires the powerio extra
+    (pip install 'powermcp[powerio]').
+
+    Args:
+        network_json: The JSON transport string from powerio
+
+    Returns:
+        Dict containing status and network information
+    """
+    logger.info("Loading network from powerio JSON transport")
+    global _current_net
+    try:
+        import powerio
+    except ImportError:
+        return {"status": "error", "message": _POWERIO_HINT}
+    try:
+        case = powerio.from_json(network_json)
+        _current_net = _ppc_to_net(_powerio_case_to_ppc(case))
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to load network: {str(e)}"}
+    return _network_info_response("Network loaded successfully from JSON transport")
+
+
+@mcp.tool()
+def export_network_to_format(to_format: str) -> Dict[str, Any]:
+    """Export the current network to a power system case format via powerio.
+
+    Converts the loaded network to MATPOWER tables and serializes them with
+    powerio. to_format is a powerio format name: matpower (m),
+    powermodels-json (pm), egret-json (egret), psse (raw), powerworld (aux).
+    Requires the powerio extra (pip install 'powermcp[powerio]').
+
+    Args:
+        to_format: Target format name
+
+    Returns:
+        Dict with status, the exported case `text`, and fidelity `warnings`
+        listing anything the target format could not represent
+    """
+    logger.info(f"Exporting network via powerio to format: {to_format}")
+    try:
+        import powerio
+    except ImportError:
+        return {"status": "error", "message": _POWERIO_HINT}
+    try:
+        net = _get_network()
+        from pandapower.converter.pypower.to_ppc import to_ppc
+
+        ppc = to_ppc(net, init="flat")
+        case = powerio.parse_str(_ppc_to_matpower_text(ppc), "matpower")
+        conv = case.to_format(to_format)
+    except RuntimeError as re:
+        return {"status": "error", "message": str(re)}
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to export network: {str(e)}"}
+    return {"status": "success", "text": conv.text, "warnings": list(conv.warnings)}
+
+
 if __name__ == "__main__":
-    mcp.run(transport="stdio") 
+    mcp.run(transport="stdio")

--- a/pandapower/panda_mcp.py
+++ b/pandapower/panda_mcp.py
@@ -267,6 +267,9 @@ def get_network_info() -> Dict[str, Any]:
 _POWERIO_HINT = "powerio not installed: pip install 'powerio[mcp,matrix]'"
 
 # powerio bus kind -> MATPOWER/PYPOWER BUS_TYPE code
+# NOTE: _PPC_BUS_TYPE and _powerio_case_to_ppc are duplicated between
+# pandapower/panda_mcp.py and PyPSA/pypsa_mcp.py (server scripts are
+# standalone); keep the two copies identical and sync any fix to both.
 _PPC_BUS_TYPE = {"PQ": 1.0, "PV": 2.0, "REF": 3.0, "ISOLATED": 4.0}
 
 

--- a/powerio/powerio_mcp.py
+++ b/powerio/powerio_mcp.py
@@ -43,7 +43,7 @@ _EXT = {
 
 _MATRIX_KINDS = (
     "bprime", "bdoubleprime", "ybus_real", "ybus_imag",
-    "adjacency", "ptdf", "lodf", "laplacian",
+    "adjacency", "ptdf", "lodf", "laplacian", "lacpf",
 )
 
 
@@ -166,6 +166,54 @@ def convert_case(
 
 
 @mcp.tool()
+def save_case(
+    to: str,
+    out_path: str,
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    json: Optional[str] = None,
+    format: str = "matpower",
+    overwrite: bool = False,
+) -> Dict[str, Any]:
+    """Convert a case and write the result to a file on disk.
+
+    Use this to stage input for the servers that only accept file paths
+    (PSS/E, PowerWorld, ANDES, surge, PyPSA): convert any case — or the JSON
+    transport from `parse_case` — to the target format and point the other
+    server's load tool at `out_path`. Pick an `out_path` extension matching
+    `to` (`.m`, `.json`, `.raw`, `.aux`).
+
+    `to` is a format name or alias: `matpower` (`m`), `powermodels-json`
+    (`pm`), `egret-json` (`egret`), `psse` (`raw`), `powerworld` (`aux`).
+    Provide exactly one of `path`, `content` (with `format`), or `json` (the
+    transport string). An existing `out_path` is not overwritten unless
+    `overwrite` is true.
+
+    Returns `{"path": <absolute path written>, "bytes_written": <count>,
+    "warnings": [<fidelity notes>]}`.
+    """
+    case = _load(path, content, json, format)
+    try:
+        conv = case.to_format(to)
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"conversion failed: {exc}") from exc
+    try:
+        with open(out_path, "w" if overwrite else "x", encoding="utf-8") as fh:
+            fh.write(conv.text)
+    except FileExistsError:
+        raise ValueError(
+            f"refusing to overwrite existing file: {out_path}; pass overwrite=true"
+        ) from None
+    except OSError as exc:
+        raise ValueError(f"write failed: {exc}") from exc
+    return {
+        "path": os.path.abspath(out_path),
+        "bytes_written": len(conv.text.encode("utf-8")),
+        "warnings": list(conv.warnings),
+    }
+
+
+@mcp.tool()
 def case_summary(
     path: Optional[str] = None,
     content: Optional[str] = None,
@@ -262,8 +310,9 @@ def compute_matrix(
     `kind` is one of: `bprime` (FDPF B', shuntless), `bdoubleprime` (FDPF B''
     with shunts and taps), `ybus_real` / `ybus_imag` (Re/Im of Y_bus),
     `adjacency` (0/1 bus adjacency), `ptdf` (DC PTDF, m×n), `lodf` (DC LODF,
-    m×m), `laplacian` (weighted Laplacian L = A diag(b) Aᵀ). `scheme`
-    ("bx"|"xb") applies to bprime/bdoubleprime; `convention`
+    m×m), `laplacian` (weighted Laplacian L = A diag(b) Aᵀ), `lacpf`
+    (linearized AC 2n×2n block [[G, -B], [-B, -G]], taps and shifts included).
+    `scheme` ("bx"|"xb") applies to bprime/bdoubleprime; `convention`
     ("paper"|"matpower") to ptdf/lodf/laplacian.
 
     Provide exactly one of `path`, `content` (with `format`), or `json` — the
@@ -293,6 +342,8 @@ def compute_matrix(
             m = case.ptdf(convention)
         elif kind == "lodf":
             m = case.lodf(convention)
+        elif kind == "lacpf":
+            m = case.lacpf()
         else:
             m = case.weighted_laplacian(convention)
     except ImportError as exc:

--- a/powerio/powerio_mcp.py
+++ b/powerio/powerio_mcp.py
@@ -1,0 +1,368 @@
+"""A standalone FastMCP server exposing powerio: case conversion, summaries,
+the JSON transport, and sparse matrix views.
+
+powerio parses MATPOWER `.m`, PSS/E `.raw` (v33), PowerWorld `.aux`,
+PowerModels JSON, and egret JSON into one format neutral network, writes back
+byte exact, and converts between formats with fidelity warnings.
+
+The JSON transport returned by `parse_case` / `normalize_case` / `case_to_json`
+is the exchange format between PowerMCP servers: parse a case once here, pass
+the string between tool calls, and feed it to `compute_matrix`, `dense_view`,
+or the powerio bridge tools in the pandapower and egret servers without
+re-parsing the file.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any, Dict, Optional
+
+import powerio
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("PowerIO Conversion Server")
+
+# Format name (and alias) → file extension, for staging inline content to a temp
+# file. `convert_file` is path-only, so inline conversion writes the text to disk
+# first; a matching extension keeps the format obvious even though we always
+# pass `from_` explicitly for inline input.
+_EXT = {
+    "matpower": ".m",
+    "m": ".m",
+    "powermodels-json": ".json",
+    "powermodels": ".json",
+    "pm": ".json",
+    "egret-json": ".json",
+    "egret": ".json",
+    "psse": ".raw",
+    "raw": ".raw",
+    "powerworld": ".aux",
+    "aux": ".aux",
+}
+
+_MATRIX_KINDS = (
+    "bprime", "bdoubleprime", "ybus_real", "ybus_imag",
+    "adjacency", "ptdf", "lodf", "laplacian",
+)
+
+
+def _unlink_quietly(path: str) -> None:
+    """Remove `path`, ignoring a missing or locked file. Cleanup runs next to
+    an in-flight exception (a failed write, a conversion error), so it must
+    never raise and mask the error the caller actually cares about."""
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _stage(content: str, fmt: str) -> str:
+    """Write `content` to a temp file whose extension matches `fmt`.
+
+    Returns the path; the caller is responsible for deleting it. Writes UTF-8
+    regardless of the platform's default text encoding, because the case
+    readers decode as UTF-8. If the write fails, the temp file `mkstemp`
+    already created on disk is removed before re-raising; the caller only
+    learns the path on success, so it can't clean up after a failed stage.
+    """
+    suffix = _EXT.get(fmt.strip().lower(), ".txt")
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+    except Exception:
+        _unlink_quietly(path)
+        raise
+    return path
+
+
+def _one_input(path: Optional[str], content: Optional[str]) -> None:
+    if (path is None) == (content is None):
+        raise ValueError("provide exactly one of `path` or `content`")
+
+
+def _parse(path: Optional[str], content: Optional[str], format: str) -> "powerio.Network":
+    """Parse from exactly one of `path` or inline `content`, mapping powerio
+    and filesystem errors to ValueError so MCP clients see one error shape."""
+    _one_input(path, content)
+    try:
+        if path is not None:
+            return powerio.parse_file(path)
+        return powerio.parse_str(content, format)
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"parse failed: {exc}") from exc
+    except FileNotFoundError as exc:
+        raise ValueError(f"file not found: {exc}") from exc
+
+
+def _load(
+    path: Optional[str], content: Optional[str], json: Optional[str], format: str
+) -> "powerio.Network":
+    """Like `_parse` but also accepts the JSON transport string."""
+    if sum(v is not None for v in (path, content, json)) != 1:
+        raise ValueError("provide exactly one of `path`, `content`, or `json`")
+    if json is None:
+        return _parse(path, content, format)
+    try:
+        return powerio.from_json(json)
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"parse failed: {exc}") from exc
+
+
+def _summary(case: "powerio.Network") -> Dict[str, Any]:
+    return {
+        "name": case.name,
+        "base_mva": case.base_mva,
+        "source_format": case.source_format,
+        "n_buses": case.n_buses,
+        "n_branches": case.n_branches,
+        "n_gens": case.n_gens,
+        "n_loads": case.n_loads,
+        "n_shunts": case.n_shunts,
+        "is_radial": case.is_radial,
+        "n_connected_components": case.n_connected_components,
+        "connectivity_report": case.connectivity_report(),
+    }
+
+
+@mcp.tool()
+def convert_case(
+    to: str,
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    from_: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Convert a power system case file to another format, losslessly where the
+    target allows.
+
+    Provide exactly one of `path` (a file on disk) or `content` (inline file
+    text). `to`/`from_` are format names or aliases: `matpower` (`m`),
+    `powermodels-json` (`pm`), `egret-json` (`egret`), `psse` (`raw`),
+    `powerworld` (`aux`). The input format is inferred from the file extension
+    for `path`; `from_` is REQUIRED with inline `content`.
+
+    Returns `{"text": <converted file>, "warnings": [<fidelity notes: data the
+    target can't represent, defaults synthesized, or blocks mapped to the nearest
+    supported target representation>]}` (empty for a faithful conversion).
+    """
+    _one_input(path, content)
+    if content is not None and not from_:
+        raise ValueError("`from_` is required when converting inline `content`")
+    try:
+        if path is not None:
+            conv = powerio.convert_file(path, to, from_)
+        else:
+            tmp = _stage(content, from_)
+            try:
+                conv = powerio.convert_file(tmp, to, from_)
+            finally:
+                _unlink_quietly(tmp)
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"conversion failed: {exc}") from exc
+    except FileNotFoundError as exc:
+        raise ValueError(f"file not found: {exc}") from exc
+    return {"text": conv.text, "warnings": list(conv.warnings)}
+
+
+@mcp.tool()
+def case_summary(
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    format: str = "matpower",
+) -> Dict[str, Any]:
+    """Summarize a power system case: name, base MVA, source format, element
+    counts, and connectivity.
+
+    Provide exactly one of `path` or `content`. For inline `content`, `format`
+    names the input format (default `matpower`). Pulls in no scipy/numpy.
+    """
+    return _summary(_parse(path, content, format))
+
+
+@mcp.tool()
+def parse_case(
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    format: str = "matpower",
+) -> Dict[str, Any]:
+    """Parse a power system case once and return its JSON transport plus a
+    summary.
+
+    Provide exactly one of `path` or `content`. For inline `content`, `format`
+    names the input format (default `matpower`); formats: `matpower`,
+    `powermodels-json`, `egret-json`, `psse`, `powerworld`.
+
+    The returned `json` string is the cross server exchange format: pass it to
+    `compute_matrix` and `dense_view` here, or to `load_network_from_json` in
+    the pandapower server, instead of re-parsing the file on every call.
+
+    Returns `{"json": <transport string>, "summary": <case_summary fields>}`.
+    """
+    case = _parse(path, content, format)
+    return {"json": case.to_json(), "summary": _summary(case)}
+
+
+@mcp.tool()
+def normalize_case(
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    format: str = "matpower",
+) -> Dict[str, Any]:
+    """Parse a case and return the JSON transport of its normalized form: per
+    unit, radians, out of service elements filtered, buses densely reindexed
+    (1-based), bus types canonicalized.
+
+    Use this instead of `parse_case` when downstream math wants a computation
+    ready case rather than the verbatim source tables. Provide exactly one of
+    `path` or `content` (with `format`).
+
+    Returns `{"json": <transport string>, "summary": <fields of the normalized
+    case>}`; the `json` is accepted everywhere the `parse_case` transport is.
+    """
+    case = _parse(path, content, format)
+    try:
+        norm = case.to_normalized()
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"normalization failed: {exc}") from exc
+    return {"json": norm.to_json(), "summary": _summary(norm)}
+
+
+@mcp.tool()
+def case_to_json(
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    format: str = "matpower",
+) -> Dict[str, Any]:
+    """Convert a case file (or inline text) to the powerio JSON transport
+    string.
+
+    Provide exactly one of `path` or `content` (with `format`). The returned
+    `json` is accepted by `compute_matrix`, `dense_view`, and the powerio
+    bridge tools in the pandapower and egret servers. Use `parse_case` instead
+    if you also want the summary.
+
+    Returns `{"json": <transport string>}`.
+    """
+    return {"json": _parse(path, content, format).to_json()}
+
+
+@mcp.tool()
+def compute_matrix(
+    kind: str,
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    json: Optional[str] = None,
+    format: str = "matpower",
+    scheme: str = "bx",
+    convention: str = "paper",
+) -> Dict[str, Any]:
+    """Build a sparse matrix view of a case and return it in COO form.
+
+    `kind` is one of: `bprime` (FDPF B', shuntless), `bdoubleprime` (FDPF B''
+    with shunts and taps), `ybus_real` / `ybus_imag` (Re/Im of Y_bus),
+    `adjacency` (0/1 bus adjacency), `ptdf` (DC PTDF, m×n), `lodf` (DC LODF,
+    m×m), `laplacian` (weighted Laplacian L = A diag(b) Aᵀ). `scheme`
+    ("bx"|"xb") applies to bprime/bdoubleprime; `convention`
+    ("paper"|"matpower") to ptdf/lodf/laplacian.
+
+    Provide exactly one of `path`, `content` (with `format`), or `json` — the
+    transport string from `parse_case` / `normalize_case` / `case_to_json`,
+    which skips re-parsing.
+
+    Returns `{"format": "coo", "shape": [rows, cols], "nnz": <count>,
+    "data": [...], "row": [...], "col": [...]}` with plain Python lists.
+    Requires scipy (`pip install 'powerio[matrix]'`).
+    """
+    if kind not in _MATRIX_KINDS:
+        raise ValueError(
+            f"unknown matrix kind {kind!r}; expected one of: {', '.join(_MATRIX_KINDS)}"
+        )
+    case = _load(path, content, json, format)
+    try:
+        if kind == "bprime":
+            m = case.bprime(scheme)
+        elif kind == "bdoubleprime":
+            m = case.bdoubleprime(scheme)
+        elif kind in ("ybus_real", "ybus_imag"):
+            parts = case.ybus_parts()
+            m = parts.g if kind == "ybus_real" else parts.b
+        elif kind == "adjacency":
+            m = case.adjacency()
+        elif kind == "ptdf":
+            m = case.ptdf(convention)
+        elif kind == "lodf":
+            m = case.lodf(convention)
+        else:
+            m = case.weighted_laplacian(convention)
+    except ImportError as exc:
+        raise ValueError(str(exc)) from exc
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"matrix build failed: {exc}") from exc
+    coo = m.tocoo()
+    return {
+        "format": "coo",
+        "shape": [int(coo.shape[0]), int(coo.shape[1])],
+        "nnz": int(coo.nnz),
+        "data": coo.data.tolist(),
+        "row": coo.row.tolist(),
+        "col": coo.col.tolist(),
+    }
+
+
+@mcp.tool()
+def dense_view(
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    json: Optional[str] = None,
+    format: str = "matpower",
+) -> Dict[str, Any]:
+    """Dense table view of a case as plain lists and dicts: counts, base MVA,
+    bus ids, branch arrays (from_id, to_id, r, x, b, tap, shift, in_service),
+    generator arrays (bus, pg, pmax, pmin, in_service), nodal demand and shunt
+    arrays, the reference bus, connected component count, and radial flag.
+
+    Provide exactly one of `path`, `content` (with `format`), or `json` (the
+    transport string from `parse_case`). Requires numpy
+    (`pip install 'powerio[matrix]'`).
+    """
+    case = _load(path, content, json, format)
+    try:
+        d = case.to_dense()
+    except ImportError as exc:
+        raise ValueError(str(exc)) from exc
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"dense view failed: {exc}") from exc
+    return {
+        "n": int(d.n),
+        "m": int(d.m),
+        "ng": int(d.ng),
+        "base_mva": float(d.base_mva),
+        "bus_ids": d.bus_ids.tolist(),
+        "branch": {
+            "from_id": d.branch.from_id.tolist(),
+            "to_id": d.branch.to_id.tolist(),
+            "r": d.branch.r.tolist(),
+            "x": d.branch.x.tolist(),
+            "b": d.branch.b.tolist(),
+            "tap": d.branch.tap.tolist(),
+            "shift": d.branch.shift.tolist(),
+            "in_service": d.branch.in_service.tolist(),
+        },
+        "gen": {
+            "bus": d.gen.bus.tolist(),
+            "pg": d.gen.pg.tolist(),
+            "pmax": d.gen.pmax.tolist(),
+            "pmin": d.gen.pmin.tolist(),
+            "in_service": d.gen.in_service.tolist(),
+        },
+        "demand": {"pd": d.demand.pd.tolist(), "qd": d.demand.qd.tolist()},
+        "shunt": {"gs": d.shunt.gs.tolist(), "bs": d.shunt.bs.tolist()},
+        "reference_bus": None if d.reference_bus is None else int(d.reference_bus),
+        "n_components": int(d.n_components),
+        "is_radial": bool(d.is_radial),
+    }
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/powerio/powerio_mcp.py
+++ b/powerio/powerio_mcp.py
@@ -198,7 +198,11 @@ def save_case(
     except powerio.PowerIOError as exc:
         raise ValueError(f"conversion failed: {exc}") from exc
     try:
-        with open(out_path, "w" if overwrite else "x", encoding="utf-8") as fh:
+        # newline="" disables newline translation so the file is byte-identical
+        # to the converter output (and to the CLI) on every platform, and
+        # bytes_written below is exact on Windows.
+        mode = "w" if overwrite else "x"
+        with open(out_path, mode, encoding="utf-8", newline="") as fh:
             fh.write(conv.text)
     except FileExistsError:
         raise ValueError(

--- a/powermcp/registry.py
+++ b/powermcp/registry.py
@@ -130,6 +130,12 @@ TOOLS: dict[str, "Tool"] = {
             ),
             external_solvers=("Julia",),
         ),
+        Tool(
+            "powerio", "PowerIO", "open-source", windows_only=False, extra="powerio",
+            server_dir="powerio", run_kind="script", entry_rel="powerio_mcp.py",
+            probe="powerio",
+            notes="Format-neutral case conversion and matrix builder; the JSON transport is the cross-server exchange format.",
+        ),
         # ---- CLOSED-SOURCE / VENDOR ----
         Tool(
             "powerworld", "PowerWorld", "closed-source", windows_only=_W, extra="powerworld",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ opendss    = ["py_dss_toolkit"]
 ltspice    = ["PyLTSpice", "matplotlib"]
 surge      = ["surge-py>=0.1.5; python_version >= '3.12' and python_version < '3.15'"]
 hope       = ["PyYAML>=6.0"]
+powerio    = ["powerio[mcp,matrix]"]
 # --- closed-source / vendor tool engines ---
 powerworld = ["esa", "numba"]                   # esa auto-discovers a running Simulator via COM.
                                                 # numba is required: esa 1.3.5's no-numba code path
@@ -64,7 +65,7 @@ psse       = []                                 # vendor `psspy` not on PyPI —
 pslf       = ["pandas"]                         # vendor `PSLF_PYTHON` not on PyPI — path captured in config.toml
 powerfactory = ["fastmcp>=2.0", "numpy>=1.26", "matplotlib>=3.8", "pandas>=1.5"]  # vendor `powerfactory` not on PyPI
 # --- convenience groups ---
-opensource = ["powermcp[andes]", "powermcp[egret]", "powermcp[opendss]", "powermcp[ltspice]", "powermcp[surge]", "powermcp[hope]"]
+opensource = ["powermcp[andes]", "powermcp[egret]", "powermcp[opendss]", "powermcp[ltspice]", "powermcp[surge]", "powermcp[hope]", "powermcp[powerio]"]
 windows    = ["powermcp[pscad-windows]", "powermcp[powerworld]", "powermcp[powerfactory]", "powermcp[psse]", "powermcp[pslf]"]
 all        = ["powermcp[opensource]", "powermcp[powerworld]", "powermcp[powerfactory]", "powermcp[pscad-windows]", "powermcp[psse]", "powermcp[pslf]"]
 
@@ -91,6 +92,7 @@ packages = ["powermcp"]
 "surge"        = "powermcp/_servers/surge"
 "OpenDSS"      = "powermcp/_servers/OpenDSS"
 "HOPE"         = "powermcp/_servers/HOPE"
+"powerio"      = "powermcp/_servers/powerio"
 "PSCAD"        = "powermcp/_servers/PSCAD"
 "PSSE"         = "powermcp/_servers/PSSE"
 "PSLF"         = "powermcp/_servers/PSLF"
@@ -103,7 +105,7 @@ packages = ["powermcp"]
 [tool.hatch.build.targets.sdist]
 include = [
     "powermcp",
-    "pandapower", "PyPSA", "ANDES", "Egret", "surge", "OpenDSS", "HOPE",
+    "pandapower", "PyPSA", "ANDES", "Egret", "surge", "OpenDSS", "HOPE", "powerio",
     "PSCAD", "PSSE", "PSLF", "PowerWorld", "PowerFactory", "LTSpice",
     "README.md", "LICENSE", "pyproject.toml",
 ]

--- a/tests/data/case9.m
+++ b/tests/data/case9.m
@@ -1,0 +1,70 @@
+function mpc = case9
+%CASE9    Power flow data for 9 bus, 3 generator case.
+%   Please see CASEFORMAT for details on the case file format.
+%
+%   Based on data from p. 70 of:
+%
+%   Chow, J. H., editor. Time-Scale Modeling of Dynamic Networks with
+%   Applications to Power Systems. Springer-Verlag, 1982.
+%   Part of the Lecture Notes in Control and Information Sciences book
+%   series (LNCIS, volume 46)
+%
+%   which in turn appears to come from:
+%
+%   R.P. Schulz, A.E. Turner and D.N. Ewart, "Long Term Power System
+%   Dynamics," EPRI Report 90-7-0, Palo Alto, California, 1974.
+
+%   MATPOWER
+
+%% MATPOWER Case Format : Version 2
+mpc.version = '2';
+
+%%-----  Power Flow Data  -----%%
+%% system MVA base
+mpc.baseMVA = 100;
+
+%% bus data
+%	bus_i	type	Pd	Qd	Gs	Bs	area	Vm	Va	baseKV	zone	Vmax	Vmin
+mpc.bus = [
+	1	3	0	0	0	0	1	1	0	345	1	1.1	0.9;
+	2	2	0	0	0	0	1	1	0	345	1	1.1	0.9;
+	3	2	0	0	0	0	1	1	0	345	1	1.1	0.9;
+	4	1	0	0	0	0	1	1	0	345	1	1.1	0.9;
+	5	1	90	30	0	0	1	1	0	345	1	1.1	0.9;
+	6	1	0	0	0	0	1	1	0	345	1	1.1	0.9;
+	7	1	100	35	0	0	1	1	0	345	1	1.1	0.9;
+	8	1	0	0	0	0	1	1	0	345	1	1.1	0.9;
+	9	1	125	50	0	0	1	1	0	345	1	1.1	0.9;
+];
+
+%% generator data
+%	bus	Pg	Qg	Qmax	Qmin	Vg	mBase	status	Pmax	Pmin	Pc1	Pc2	Qc1min	Qc1max	Qc2min	Qc2max	ramp_agc	ramp_10	ramp_30	ramp_q	apf
+mpc.gen = [
+	1	72.3	27.03	300	-300	1.04	100	1	250	10	0	0	0	0	0	0	0	0	0	0	0;
+	2	163	6.54	300	-300	1.025	100	1	300	10	0	0	0	0	0	0	0	0	0	0	0;
+	3	85	-10.95	300	-300	1.025	100	1	270	10	0	0	0	0	0	0	0	0	0	0	0;
+];
+
+%% branch data
+%	fbus	tbus	r	x	b	rateA	rateB	rateC	ratio	angle	status	angmin	angmax
+mpc.branch = [
+	1	4	0	0.0576	0	250	250	250	0	0	1	-360	360;
+	4	5	0.017	0.092	0.158	250	250	250	0	0	1	-360	360;
+	5	6	0.039	0.17	0.358	150	150	150	0	0	1	-360	360;
+	3	6	0	0.0586	0	300	300	300	0	0	1	-360	360;
+	6	7	0.0119	0.1008	0.209	150	150	150	0	0	1	-360	360;
+	7	8	0.0085	0.072	0.149	250	250	250	0	0	1	-360	360;
+	8	2	0	0.0625	0	250	250	250	0	0	1	-360	360;
+	8	9	0.032	0.161	0.306	250	250	250	0	0	1	-360	360;
+	9	4	0.01	0.085	0.176	250	250	250	0	0	1	-360	360;
+];
+
+%%-----  OPF Data  -----%%
+%% generator cost data
+%	1	startup	shutdown	n	x1	y1	...	xn	yn
+%	2	startup	shutdown	n	c(n-1)	...	c0
+mpc.gencost = [
+	2	1500	0	3	0.11	5	150;
+	2	2000	0	3	0.085	1.2	600;
+	2	3000	0	3	0.1225	1	335;
+];

--- a/tests/test_powerio_server.py
+++ b/tests/test_powerio_server.py
@@ -1,0 +1,151 @@
+"""Tests for the powerio conversion server and its registry/runner wiring.
+
+The whole module skips when powerio is not installed (it is an opt-in extra).
+The FastMCP-decorated tools stay ordinary callables, so we exercise them
+in-process without a transport. The launch test lives here rather than in
+test_runner.py so it skips with the rest of the module.
+
+tests/data/case9.m is vendored verbatim from
+https://github.com/MATPOWER/matpower/tree/master/data (BSD-3).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("powerio")
+
+import powerio  # noqa: E402
+
+from powermcp.registry import TOOLS  # noqa: E402
+
+_SERVER_DIR = str(TOOLS["powerio"].resolve_server_dir())
+if _SERVER_DIR not in sys.path:
+    sys.path.insert(0, _SERVER_DIR)
+
+import powerio_mcp  # noqa: E402
+
+CASE9 = Path(__file__).resolve().parent / "data" / "case9.m"
+
+
+def test_parse_case_json_round_trips():
+    r = powerio_mcp.parse_case(path=str(CASE9))
+    assert r["summary"]["n_buses"] == 9
+    assert powerio.from_json(r["json"]).n_buses == 9
+
+
+def test_normalize_case_returns_dense_one_based_ids():
+    r = powerio_mcp.normalize_case(path=str(CASE9))
+    case = powerio.from_json(r["json"])
+    assert [b["id"] for b in case.buses] == list(range(1, 10))
+
+
+def test_case_to_json_accepted_downstream():
+    r = powerio_mcp.case_to_json(path=str(CASE9))
+    assert powerio.from_json(r["json"]).n_buses == 9
+
+
+def test_compute_matrix_bprime():
+    m = powerio_mcp.compute_matrix("bprime", path=str(CASE9))
+    assert m["format"] == "coo"
+    assert m["shape"] == [9, 9]
+    assert m["nnz"] > 0
+    assert isinstance(m["nnz"], int)
+    # plain Python scalars, not numpy types
+    assert type(m["data"][0]) is float
+    assert type(m["row"][0]) is int
+    assert type(m["col"][0]) is int
+
+
+def test_compute_matrix_accepts_json_transport():
+    transport = powerio_mcp.parse_case(path=str(CASE9))["json"]
+    from_json = powerio_mcp.compute_matrix("bprime", json=transport)
+    from_path = powerio_mcp.compute_matrix("bprime", path=str(CASE9))
+    assert from_json["shape"] == from_path["shape"]
+    assert from_json["nnz"] == from_path["nnz"]
+
+
+def test_compute_matrix_unknown_kind():
+    with pytest.raises(ValueError):
+        powerio_mcp.compute_matrix("nope", path=str(CASE9))
+
+
+def test_dense_view_counts():
+    d = powerio_mcp.dense_view(path=str(CASE9))
+    assert d["n"] == 9
+    assert d["m"] == 9
+    assert d["base_mva"] == 100.0
+    assert type(d["bus_ids"][0]) is int
+    assert type(d["branch"]["r"][0]) is float
+    assert type(d["is_radial"]) is bool
+
+
+def test_convert_case_powermodels():
+    r = powerio_mcp.convert_case(to="powermodels-json", path=str(CASE9))
+    assert isinstance(r["warnings"], list)
+    assert len(json.loads(r["text"])["bus"]) == 9
+
+
+def test_case_summary_fields():
+    s = powerio_mcp.case_summary(path=str(CASE9))
+    assert s["n_buses"] == 9
+    assert s["base_mva"] == 100.0
+    assert s["source_format"] == "Matpower"
+    assert s["n_connected_components"] == 1
+    for key in (
+        "name", "n_branches", "n_gens", "n_loads", "n_shunts",
+        "is_radial", "connectivity_report",
+    ):
+        assert key in s
+
+
+def test_exactly_one_input_enforced():
+    with pytest.raises(ValueError):
+        powerio_mcp.case_summary()
+    with pytest.raises(ValueError):
+        powerio_mcp.case_summary(path="x", content="y")
+    with pytest.raises(ValueError):
+        powerio_mcp.compute_matrix("bprime")
+    with pytest.raises(ValueError):
+        powerio_mcp.compute_matrix("bprime", path=str(CASE9), json="{}")
+    with pytest.raises(ValueError):
+        powerio_mcp.dense_view(path="x", content="y")
+
+
+def test_inline_content_requires_from():
+    with pytest.raises(ValueError):
+        powerio_mcp.convert_case(to="psse", content=CASE9.read_text())
+
+
+def test_registry_entry():
+    t = TOOLS["powerio"]
+    assert t.kind == "open-source"
+    assert t.extra == "powerio"
+    assert t.run_kind == "script"
+    assert t.windows_only is False
+    assert t.probe == "powerio"
+    assert t.resolve_entry_script().is_file()
+
+
+@pytest.fixture()
+def record_mcp_run(monkeypatch):
+    calls = []
+
+    def fake_run(self, *args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr("mcp.server.fastmcp.FastMCP.run", fake_run, raising=True)
+    return calls
+
+
+def test_launch_powerio_runs_once(record_mcp_run):
+    from powermcp import runner
+
+    runner.launch("powerio")
+    assert len(record_mcp_run) == 1
+    _, kwargs = record_mcp_run[0]
+    assert kwargs.get("transport") == "stdio"

--- a/tests/test_powerio_server.py
+++ b/tests/test_powerio_server.py
@@ -1,4 +1,5 @@
-"""Tests for the powerio conversion server and its registry/runner wiring.
+"""Tests for the powerio conversion server, the PyPSA bridge, and the
+registry/runner wiring.
 
 The whole module skips when powerio is not installed (it is an opt-in extra).
 The FastMCP-decorated tools stay ordinary callables, so we exercise them
@@ -29,7 +30,32 @@ if _SERVER_DIR not in sys.path:
 
 import powerio_mcp  # noqa: E402
 
+_PYPSA_DIR = str(TOOLS["pypsa"].resolve_server_dir())
+if _PYPSA_DIR not in sys.path:
+    sys.path.insert(0, _PYPSA_DIR)
+
+import pypsa  # noqa: E402  (core dependency, like the server itself)
+import pypsa_mcp  # noqa: E402
+
 CASE9 = Path(__file__).resolve().parent / "data" / "case9.m"
+
+# 3-bus case with rating 0 branches, for the overwrite_zero_s_nom tests.
+ZERO_RATE_CASE = """function mpc = zero_rate
+mpc.version = '2';
+mpc.baseMVA = 100.0;
+mpc.bus = [
+\t1 3 0 0 0 0 1 1.0 0.0 230.0 1 1.1 0.9;
+\t2 1 50 10 0 0 1 1.0 0.0 230.0 1 1.1 0.9;
+\t3 1 30 5 0 0 1 1.0 0.0 230.0 1 1.1 0.9;
+];
+mpc.gen = [
+\t1 80 0 50 -50 1.0 100 1 200 0 0 0 0 0 0 0 0 0 0 0 0;
+];
+mpc.branch = [
+\t1 2 0.01 0.05 0.0 0 0 0 0 0 1 -360 360;
+\t2 3 0.01 0.05 0.0 0 0 0 0 0 1 -360 360;
+];
+"""
 
 
 def test_parse_case_json_round_trips():
@@ -119,6 +145,92 @@ def test_exactly_one_input_enforced():
 def test_inline_content_requires_from():
     with pytest.raises(ValueError):
         powerio_mcp.convert_case(to="psse", content=CASE9.read_text())
+
+
+def test_compute_matrix_lacpf():
+    m = powerio_mcp.compute_matrix("lacpf", path=str(CASE9))
+    assert m["format"] == "coo"
+    assert m["shape"] == [18, 18]
+    assert m["nnz"] > 0
+    assert type(m["data"][0]) is float
+    assert type(m["row"][0]) is int
+
+
+def test_save_case_writes_file(tmp_path):
+    out = tmp_path / "case9.json"
+    r = powerio_mcp.save_case(to="powermodels-json", out_path=str(out), path=str(CASE9))
+    assert r["path"] == str(out)
+    assert r["bytes_written"] == out.stat().st_size
+    assert isinstance(r["warnings"], list)
+    assert len(json.loads(out.read_text())["bus"]) == 9
+
+
+def test_save_case_refuses_overwrite(tmp_path):
+    out = tmp_path / "case9.m"
+    out.write_text("existing")
+    with pytest.raises(ValueError, match="overwrite"):
+        powerio_mcp.save_case(to="matpower", out_path=str(out), path=str(CASE9))
+    r = powerio_mcp.save_case(
+        to="matpower", out_path=str(out), path=str(CASE9), overwrite=True
+    )
+    assert r["bytes_written"] == out.stat().st_size
+
+
+def test_save_case_accepts_json_transport(tmp_path):
+    transport = powerio_mcp.parse_case(path=str(CASE9))["json"]
+    out = tmp_path / "case9.m"
+    powerio_mcp.save_case(to="matpower", out_path=str(out), json=transport)
+    assert powerio.parse_file(out).n_buses == 9
+
+
+def test_save_case_exactly_one_input(tmp_path):
+    out = tmp_path / "x.m"
+    with pytest.raises(ValueError):
+        powerio_mcp.save_case(to="matpower", out_path=str(out))
+    with pytest.raises(ValueError):
+        powerio_mcp.save_case(to="matpower", out_path=str(out), path="a", json="{}")
+
+
+def test_pypsa_import_case_from_any(tmp_path):
+    out = tmp_path / "case9.nc"
+    r = pypsa_mcp.import_case_from_any(str(CASE9), str(out))
+    assert r["status"] == "success", r
+    assert out.exists()
+    assert r["network_file"] == str(out)
+    assert r["info"]["buses"] == 9
+    assert len(pypsa.Network(str(out)).buses) == 9
+
+
+def test_pypsa_import_case_from_json(tmp_path):
+    transport = powerio_mcp.parse_case(path=str(CASE9))["json"]
+    out = tmp_path / "case9.nc"
+    r = pypsa_mcp.import_case_from_json(transport, str(out))
+    assert r["status"] == "success", r
+    assert len(pypsa.Network(str(out)).buses) == 9
+
+
+def test_pypsa_import_reports_dropped_gencost(tmp_path):
+    r = pypsa_mcp.import_case_from_any(str(CASE9), str(tmp_path / "c.nc"))
+    assert any("cost" in w for w in r["warnings"]), r["warnings"]
+
+
+def test_pypsa_import_overwrite_zero_s_nom(tmp_path):
+    src = tmp_path / "zero.m"
+    src.write_text(ZERO_RATE_CASE)
+
+    bare = pypsa_mcp.import_case_from_any(str(src), str(tmp_path / "bare.nc"))
+    assert any("rating 0" in w for w in bare["warnings"]), bare["warnings"]
+
+    out = tmp_path / "set.nc"
+    r = pypsa_mcp.import_case_from_any(str(src), str(out), overwrite_zero_s_nom=100.0)
+    assert not any("rating 0" in w for w in r["warnings"]), r["warnings"]
+    assert (pypsa.Network(str(out)).lines.s_nom == 100.0).all()
+
+
+def test_pypsa_import_missing_file(tmp_path):
+    r = pypsa_mcp.import_case_from_any("/nope/missing.m", str(tmp_path / "x.nc"))
+    assert r["status"] == "error"
+    assert "not found" in r["message"].lower()
 
 
 def test_registry_entry():


### PR DESCRIPTION
## What this adds

powerio becomes the format conversion substrate connecting PowerMCP's servers. The integration has three pieces:

**The powerio server** (`powerio/powerio_mcp.py`, registry id `powerio`): a standalone FastMCP script with seven tools. `convert_case` and `case_summary` convert and summarize any powerio readable case (MATPOWER `.m`, PSS/E `.raw` v33, PowerWorld `.aux`, PowerModels JSON, egret JSON). `parse_case`, `normalize_case`, and `case_to_json` emit the powerio JSON transport (`Network.to_json()`). `compute_matrix` returns B', B'', Re/Im(Y_bus), adjacency, PTDF, LODF, or the weighted Laplacian in COO form as plain Python lists; `dense_view` returns the dense table view.

**Bridge tools** in the existing servers (added only; no existing signature changed):
- pandapower: `load_network_from_any`, `load_network_from_json`, `export_network_to_format`. Loading goes powerio → PYPOWER ppc dict → `pandapower.converter.pypower.from_ppc` (`from_mpc` reads only binary `.mat`, so the ppc route is the supported path); export goes `to_ppc` → MATPOWER text → powerio.
- egret: `load_model_from_any`, `load_model_from_json`. powerio converts to egret JSON, the parsed dict constructs a `ModelData` to validate, and the JSON is staged to a temp file whose path feeds the existing solver tools.

**Packaging**: a `powerio` extra (`powerio[mcp,matrix]`), membership in the `opensource` group, the wheel force-include (`powermcp/_servers/powerio`), and the sdist include. `powermcp list` and `powermcp doctor` pick the tool up from the registry entry.

## The exchange pattern

Parse a case once, pass the JSON string between tool calls, load it anywhere:

```
parse_case(path="case9.raw")                 # powerio server → {"json": ..., "summary": ...}
load_network_from_json(network_json=...)     # pandapower server ingests the transport
load_model_from_json(network_json=...)       # egret server stages it as a solvable case file
compute_matrix(kind="ptdf", json=...)        # powerio server builds matrices from it
```

Downstream tools reconstruct with `powerio.from_json(...)`; no re-parse, no shared filesystem needed between servers.

## Graceful degradation

powerio is an optional extra. Every bridge tool catches the ImportError and returns `{"status": "error", "message": "powerio not installed: pip install 'powerio[mcp,matrix]'"}`; the pandapower and egret servers work unchanged without it.

## Tests

`tests/test_powerio_server.py` (13 tests, module level `pytest.importorskip("powerio")`): transport round trip through `powerio.from_json`, normalize returning dense 1-based ids, COO matrix output with plain Python types, dense view counts, conversion to PowerModels JSON, input validation (exactly one of path/content/json; inline content requires `from_`), the registry entry, and a `launch("powerio")` run firing `FastMCP.run` exactly once. `tests/data/case9.m` is vendored verbatim from MATPOWER (BSD-3). Full suite: 74 passed; the one failure (`test_detect.py::test_ltspice_exe_finds_adi`) predates this branch and only fails off Windows (it asserts backslash paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
