### PR TITLE
ci: run the test suite on pushes and PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: pytest (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # floor and ceiling of requires-python
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package with the powerio extra
+        # The powerio extra makes tests/test_powerio_server.py run instead of
+        # skip; on revisions without that extra, pip warns and proceeds.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[powerio]' pytest
+
+      - name: Run tests
+        run: python -m pytest tests/ -q

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import sys
 
+import pytest
+
 from powermcp import detect
 
 
@@ -15,6 +17,11 @@ def test_first_existing(tmp_path):
     assert detect._first_existing([None, ""]) is None
 
 
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="ltspice_exe builds ProgramFiles paths with backslash separators; "
+    "they only resolve on a real Windows filesystem",
+)
 def test_ltspice_exe_finds_adi(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setenv("ProgramFiles", str(tmp_path))


### PR DESCRIPTION
Adds `.github/workflows/test.yml`: pytest on ubuntu for Python 3.10 and 3.12 (the floor and ceiling of `requires-python`), with a pip cache. Until now only the publish workflow existed, so nothing ran the suite on PRs.

The install step uses `pip install -e '.[powerio]' pytest`. On current main the `powerio` extra does not exist yet, which pip treats as a warning, so this PR is green on its own; once #28 merges, `tests/test_powerio_server.py` stops skipping and runs for real. Merging this first means #28 gets checks on its next push.

One test change rides along: `test_detect.py::test_ltspice_exe_finds_adi` is now `skipif(sys.platform != "win32")`. It monkeypatches `sys.platform` to take the Windows branch of `detect.ltspice_exe`, but that branch builds candidate paths with backslash separators and checks them against the real filesystem, so the test can only pass on Windows. It currently fails on every macOS/Linux checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)