### PR TITLE
fix(hope): prevent path traversal in hope_read_output filename parameter

### DIFF
--- a/HOPE/src/hope_mcp_server/core.py
+++ b/HOPE/src/hope_mcp_server/core.py
@@ -1176,7 +1176,14 @@ def hope_read_output(
 
     output_dir = output_dir_for_case(case_path)
     # Allow subdirectory paths like "postprocess_snapshot/metadata.yml"
-    csv_path = output_dir / filename
+    csv_path = (output_dir / filename).resolve()
+    if not csv_path.is_relative_to(output_dir.resolve()):
+        return error_result(
+            "path_traversal",
+            "filename must refer to a path inside the case output directory.",
+            case_id=case_id,
+            requested_file=filename,
+        )
     if not csv_path.is_file():
         available = list_top_level_output_csvs(output_dir)
         return error_result(

--- a/HOPE/tests/test_path_traversal.py
+++ b/HOPE/tests/test_path_traversal.py
@@ -1,0 +1,112 @@
+"""Tests for CWE-22 path traversal mitigation in hope_read_output."""
+from __future__ import annotations
+
+import csv
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PACKAGE_ROOT / "src"))
+
+from hope_mcp_server.core import hope_read_output  # noqa: E402
+
+
+def _create_case_tree(tmp: Path) -> Path:
+    """Build a minimal ModelCases/<case>/output/ tree for testing."""
+    case_dir = tmp / "ModelCases" / "test_case"
+    output_dir = case_dir / "output"
+    output_dir.mkdir(parents=True)
+    settings_dir = case_dir / "Settings"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "HOPE_model_settings.yml").write_text(
+        "model_mode: GTEP\nsolver: highs\n"
+    )
+    # Write a small CSV so legitimate reads succeed
+    csv_path = output_dir / "system_cost.csv"
+    with csv_path.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["cost"])
+        writer.writeheader()
+        writer.writerow({"cost": "42"})
+    # Also put a subdir CSV for subdirectory-access test
+    sub = output_dir / "postprocess_snapshot"
+    sub.mkdir()
+    sub_csv = sub / "metadata.csv"
+    with sub_csv.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["key", "value"])
+        writer.writeheader()
+        writer.writerow({"key": "version", "value": "1"})
+    return tmp
+
+
+class TestPathTraversal(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir_obj = tempfile.TemporaryDirectory()
+        tmp = Path(self.tmpdir_obj.name)
+        _create_case_tree(tmp)
+        self.env_patch = mock.patch.dict(
+            "os.environ",
+            {"HOPE_REPO_ROOT": str(tmp)},
+            clear=False,
+        )
+        self.env_patch.start()
+
+    def tearDown(self) -> None:
+        self.env_patch.stop()
+        self.tmpdir_obj.cleanup()
+
+    # ---- Legitimate reads should still work ----
+
+    def test_normal_filename_succeeds(self) -> None:
+        result = hope_read_output(case_id="test_case", filename="system_cost.csv")
+        self.assertTrue(result["ok"], result)
+
+    def test_subdirectory_filename_succeeds(self) -> None:
+        result = hope_read_output(
+            case_id="test_case",
+            filename="postprocess_snapshot/metadata.csv",
+        )
+        self.assertTrue(result["ok"], result)
+
+    # ---- Path traversal attempts MUST be blocked ----
+
+    def test_dot_dot_traversal_is_blocked(self) -> None:
+        result = hope_read_output(
+            case_id="test_case",
+            filename="../../etc/passwd",
+        )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_type"], "path_traversal")
+
+    def test_dot_dot_within_subdir_is_blocked(self) -> None:
+        result = hope_read_output(
+            case_id="test_case",
+            filename="postprocess_snapshot/../../Settings/HOPE_model_settings.yml",
+        )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_type"], "path_traversal")
+
+    def test_absolute_path_is_blocked(self) -> None:
+        result = hope_read_output(
+            case_id="test_case",
+            filename="/etc/passwd",
+        )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_type"], "path_traversal")
+
+    def test_encoded_dot_dot_not_normalised_away(self) -> None:
+        # Depending on OS normalisation this might just be file-not-found,
+        # but must never succeed as a file read outside the output dir.
+        result = hope_read_output(
+            case_id="test_case",
+            filename="..%2F..%2Fetc%2Fpasswd",
+        )
+        # Acceptable outcomes: path_traversal error OR file_not_found —
+        # NOT a successful read.
+        self.assertFalse(result["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The `hope_read_output` MCP tool in `HOPE/src/hope_mcp_server/core.py` is vulnerable to **path traversal (CWE-22)** through its `filename` parameter. An attacker can supply values like `../../etc/passwd` to read arbitrary files on the server's filesystem.

The vulnerable code at line 1179 directly concatenates user-supplied `filename` with the case output directory:

```python
csv_path = output_dir / filename
```

There is no validation that `filename` stays within the intended `output/` directory. Because `pathlib`'s `/` operator happily resolves `..` components, any path containing `../` sequences escapes the output directory and reaches arbitrary files.

## Affected component

**Function:** `hope_read_output()` in `HOPE/src/hope_mcp_server/core.py` (line 1166)  
**Registered MCP tool name:** `hope_read_output`  
**Registered in:** `register_read_tools()` in `HOPE/src/hope_mcp_server/server.py` (line 133)

## Threat model

The `hope-mcp-server-chatgpt` entrypoint (`HOPE/src/hope_mcp_server/chatgpt.py`) runs the MCP server in `streamable-http` mode, designed for remote access. The server accepts a `HOPE_MCP_PUBLIC_HOSTNAME` environment variable for internet-facing deployment. There is no authentication middleware, API key validation, token checking, or session management anywhere in the server code — all registered tools are accessible to any client that can reach the HTTP endpoint.

An unauthenticated attacker with network access to the MCP server can call the `hope_read_output` tool with a traversal payload and read any file readable by the server process.

## Proof of Concept

Given a running HOPE MCP server with at least one valid case (e.g., `md_gtep_clean`):

```python
# Using the MCP client SDK or raw HTTP to the streamable-http endpoint:
# Call the hope_read_output tool with a traversal filename

result = call_mcp_tool(
    "hope_read_output",
    case_id="md_gtep_clean",      # any valid case_id
    filename="../../etc/passwd",   # traversal payload
)
# Before fix: returns contents of /etc/passwd (or any readable file)
# After fix: returns {"ok": false, "error_type": "path_traversal", ...}
```

To verify locally without a running server, the data flow can be demonstrated directly:

```python
from pathlib import Path

output_dir = Path("/path/to/ModelCases/md_gtep_clean/output")
filename = "../../etc/passwd"

# Before fix — resolves outside output directory:
csv_path = output_dir / filename
print(csv_path.resolve())  # /etc/passwd — arbitrary file access

# After fix — caught by validation:
csv_path = (output_dir / filename).resolve()
print(csv_path.is_relative_to(output_dir.resolve()))  # False → blocked
```

## Fix description

The fix adds path containment validation using Python's `pathlib.Path.resolve()` and `is_relative_to()` — the standard pattern for preventing path traversal in Python 3.9+:

```python
csv_path = (output_dir / filename).resolve()
if not csv_path.is_relative_to(output_dir.resolve()):
    return error_result(
        "path_traversal",
        "filename must refer to a path inside the case output directory.",
        case_id=case_id,
        requested_file=filename,
    )
```

This resolves the full path (collapsing all `..`, symlinks, etc.) and then checks that the result is still under the intended output directory. It blocks:

- Relative traversal (`../../etc/passwd`)
- Traversal through subdirectories (`postprocess_snapshot/../../Settings/HOPE_model_settings.yml`)
- Absolute path injection (`/etc/passwd`)

Legitimate reads (e.g., `system_cost.csv`, `postprocess_snapshot/metadata.csv`) continue to work normally.

## Tests

The PR includes `HOPE/tests/test_path_traversal.py` with 6 test cases:

| Test | Description | Result |
|------|-------------|--------|
| `test_normal_filename_succeeds` | Standard CSV read works | ✅ Pass |
| `test_subdirectory_filename_succeeds` | Subdirectory path `postprocess_snapshot/metadata.csv` works | ✅ Pass |
| `test_dot_dot_traversal_is_blocked` | `../../etc/passwd` returns `path_traversal` error | ✅ Pass |
| `test_dot_dot_within_subdir_is_blocked` | Traversal escaping through a subdirectory is blocked | ✅ Pass |
| `test_absolute_path_is_blocked` | `/etc/passwd` returns `path_traversal` error | ✅ Pass |
| `test_encoded_dot_dot_not_normalised_away` | URL-encoded traversal does not succeed | ✅ Pass |

The tests set up a temporary `ModelCases` directory tree with real CSV files and verify both positive (legitimate reads work) and negative (traversal attempts fail) cases.

## Adversarial review

Before submitting, we attempted to disprove this finding. We checked whether any authentication layer, middleware, or framework-level access control exists on the MCP server — there is none. We checked whether `pathlib`'s `/` operator or any downstream function sanitizes the input — it does not. We considered whether the `case_id` validation in `resolve_case()` provides indirect protection — it does not, because `case_id` and `filename` are independent parameters and `filename` is concatenated after `case_id` resolution. The vulnerability is genuine: the precondition (network access to the MCP server) grants access only to case output CSVs via the intended API, while the traversal escalates this to arbitrary file read on the host.