### PR TITLE
release: bump version to 0.1.1

### DIFF
--- a/powermcp/__init__.py
+++ b/powermcp/__init__.py
@@ -7,6 +7,6 @@ tools via extras (`pip install powermcp[psse]`). Configure and wire up MCP
 clients with the `powermcp` CLI (`powermcp install`).
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "powermcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "MCP servers for power-system software (PowerWorld, OpenDSS, PSS/E, pandapower, PyPSA, and more)"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Picks up the powerio case-conversion server (and the PyPSA powerio bridge tools) into the published distribution. No code changes beyond the version.

Verified: full suite 85 passed with powerio installed; wheel ships powermcp/_servers/powerio/powerio_mcp.py and the powerio[matrix,mcp] extra; twine check passed.