### PR TITLE
ci: skip already-published files in the PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,3 +51,8 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Don't fail the run if a version's files are already on PyPI (e.g. a
+          # re-run, or a version that was uploaded manually). New versions still
+          # publish normally; only already-present files are skipped.
+          skip-existing: true


### PR DESCRIPTION
Adds `skip-existing: true` to `pypa/gh-action-pypi-publish` so the publish workflow is idempotent. The Release-triggered run failed at upload with `400 File already exists` (0.1.1 was uploaded manually); Trusted Publishing itself works (OIDC + attestations succeeded). New versions publish normally; already-present files are skipped instead of failing the run.

?? Generated with [Claude Code](https://claude.com/claude-code)