### PR TITLE
test: fix Python 3.10 Tests CI (surge namespace-shadow test)

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -57,10 +57,14 @@ def test_path_status_missing_and_configured(isolated_config):
     assert style == "green"
 
 
-def test_namespace_shadow_not_false_positive():
-    # surge-py is NOT installed in the core test venv. The repo's lowercase
-    # surge/ directory must not be mistaken for the installed library (PEP 420
-    # namespace shadow), so the dependency must report missing, not ok.
+def test_namespace_shadow_not_false_positive(monkeypatch):
+    # surge-py is NOT installed in the test venv. The repo's lowercase surge/
+    # directory must not be mistaken for the installed library (PEP 420 namespace
+    # shadow), so the dependency must report missing, not ok. Bypass surge's
+    # Python-version gate (it is 3.12-3.14 only) so this exercises the probe path
+    # on every Python version — otherwise on 3.10/3.11 _dep_status short-circuits
+    # to the "needs Python 3.12-3.14" warning before reaching the probe.
+    monkeypatch.setattr(doctor, "_surge_supported", lambda: True)
     style, msg = doctor._dep_status(get_tool("surge"))
     assert style == "red", f"expected surge missing, got {style}: {msg}"
 


### PR DESCRIPTION
Fixes the failing `Tests` workflow on the **py3.10** matrix leg.

`test_namespace_shadow_not_false_positive` expected surge to report `red` (missing), but on Python 3.10/3.11 `_dep_status` short-circuits to the `needs Python 3.12-3.14` gate (`yellow`) before reaching the namespace-shadow probe - so the assertion failed on 3.10 while passing on 3.12. The test now bypasses the gate via monkeypatch so it exercises the probe path on every Python version. The generic `probe_installed` namespace logic remains covered by `test_runner.py`.

?? Generated with [Claude Code](https://claude.com/claude-code)