### PR TITLE
release: bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "powermcp"
-version = "0.1.1"
+version = "0.1.2"
 description = "MCP servers for power-system software (PowerWorld, OpenDSS, PSS/E, pandapower, PyPSA, and more)"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Release 0.1.2.

## Changes since 0.1.1
- feat(powerio): expose pandapower-json, PyPSA CSV folder, and gridfm Parquet formats (#41)
- fix(hope): prevent path traversal in `hope_read_output` (#32)
- feat: ANDES powerio bridge + powerio 0.1.1 pin (#35)

Merging this, then publishing the GitHub Release `v0.1.2` triggers the PyPI Trusted Publishing workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)