### PR TITLE
release: bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "powermcp"
-version = "0.1.2"
+version = "0.1.3"
 description = "MCP servers for power-system software (PowerWorld, OpenDSS, PSS/E, pandapower, PyPSA, and more)"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Release 0.1.3.

## Changes since 0.1.2
- feat: promote powerio to a core dependency (#43, closes #30)
- refactor(powerio): re-export the canonical `powerio.mcp.server` instead of vendoring (#44)
- feat: adopt powerio 0.2.2, re-export all 12 canonical tools, add the PowerWorld `.pwd` `read_display_file` tool (#45)

Merging this, then publishing the GitHub Release `v0.1.3` triggers the PyPI Trusted Publishing workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)