### PR TITLE
Integrate PowerIO 1.0 and Tellegen

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,17 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      # Remove this step once PowerIO 1.0.0 is published on PyPI.
+      - name: Install PowerIO 1.0 candidate
+        run: >-
+          python -m pip install
+          "powerio[mcp,matrix] @ git+https://github.com/eigenergy/powerio.git@e39afc9d669349df5133ff6140598010a498cdb1"
+
       - name: Install package
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e . pytest
+        run: python -m pip install -e . pytest
 
       - name: Run tests
         run: python -m pytest tests/ -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Environments
 .venv/
+.venv-*/
 env/
 venv/
 ENV/

--- a/ANDES/README.md
+++ b/ANDES/README.md
@@ -57,8 +57,8 @@ Configure in your MCP client (e.g., Cursor, Claude Desktop):
   - `success`: whether ANDES's `EIG.run()` reported success.
   - `n_eigenvalues`, `eigenvalues`: the pre-0.3.0 fields, retained so existing callers keep working. The old `eigenvectors` and `state_variables` fields are gone: they read attributes the `EIG` routine has never had, so they only ever returned `[]`.
 - **get_system_info()**: Get information about the currently loaded power system.
-- **load_network_from_any(...)**: Convert any PowerIO-readable case or one selected `.pio.json` package state into the ANDES run format.
-- **load_network_from_json(...)**: Convert PowerIO model JSON or one selected `.pio.json` package state without staging the source input.
+- **load_network_from_any(...)**: Convert a balanced case PowerIO can read, or a static `.pio.json` module, into the ANDES run format. The result includes structured `diagnostics` and, for stored input, `module` context.
+- **load_network_from_json(...)**: Convert PowerIO balanced model JSON or a static `.pio.json` module without staging the source input. Inspect collections with PowerIO `list_states` and pass an `export_state` result to this tool.
 
 ## License note
 

--- a/ANDES/andes_mcp.py
+++ b/ANDES/andes_mcp.py
@@ -1,4 +1,5 @@
 import andes
+import powerio
 import logging
 import os
 import io
@@ -16,7 +17,11 @@ _repo_root_added = _repo_root not in sys.path
 if _repo_root_added:
     sys.path.insert(0, _repo_root)
 try:
-    from powermcp.solver_case import resolve_solver_case
+    from powermcp.solver_case import (
+        diagnostic_records,
+        powerio_error_response,
+        resolve_solver_case,
+    )
     from powermcp.sandbox import (
         PathNotAllowed,
         checked_path,
@@ -486,8 +491,8 @@ def get_system_info() -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# PowerIO interchange: resolve one balanced state, then stage MATPOWER text for
-# ANDES to load natively through run_power_flow.
+# PowerIO interchange: resolve one balanced module, then stage MATPOWER text
+# for ANDES to load natively through run_power_flow.
 # ---------------------------------------------------------------------------
 
 
@@ -495,25 +500,24 @@ def get_system_info() -> Dict[str, Any]:
 def load_network_from_json(
     network_json: str,
     out_path: str,
-    operating_point: Optional[int] = None,
-    study_commit: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Stage PowerIO model JSON or one package state as MATPOWER for ANDES.
+    """Stage PowerIO model JSON or one static module as MATPOWER for ANDES.
 
-    Accepts the ``json`` string returned by the powerio server's parse tool.
+    Accepts balanced model JSON or a static ``.pio.json`` module exported by
+    PowerIO. Inspect collection modules with PowerIO ``list_states`` and reduce
+    them with ``export_state`` before they cross the solver boundary.
     Converts the network to MATPOWER format, writes it to out_path (use a .m
     extension), and returns the path along with component
-    counts. Pass out_path to run_power_flow to run the simulation. powerio is a
+    counts. Pass out_path to run_power_flow to run the simulation. PowerIO is a
     core dependency, so this is always available.
 
     Args:
-        network_json: The JSON transport string from powerio
+        network_json: PowerIO balanced model JSON or stored module JSON
         out_path: Destination for the MATPOWER case file (.m)
-        operating_point: Optional package operating-point index to materialize
-        study_commit: Optional package study-commit index to materialize
 
     Returns:
-        Dict with status, case_file path, component counts, and fidelity warnings
+        Dict with status, case_file path, component counts, structured
+        diagnostics
     """
     try:
         out_path = checked_path(out_path, purpose="out_path", for_write=True)
@@ -522,14 +526,14 @@ def load_network_from_json(
     try:
         prepared = resolve_solver_case(
             network_json=network_json,
-            operating_point=operating_point,
-            study_commit=study_commit,
         )
         case = prepared.network
-        conv = case.to_format("matpower")
+        conversion = prepared.module.emit("matpower")
         abs_out = os.path.abspath(out_path)
         with open(abs_out, "w") as fh:
-            fh.write(conv.text)
+            fh.write(conversion.text)
+    except powerio.PowerIOError as exc:
+        return powerio_error_response(exc)
     except Exception as e:
         return {"status": "error", "message": str(e)}
     return {
@@ -539,10 +543,11 @@ def load_network_from_json(
         "info": {
             "buses": case.n_buses,
             "branches": case.n_branches,
-            "generators": case.n_gens,
+            "generators": case.n_generators,
         },
-        "warnings": list(prepared.warnings) + list(conv.warnings),
-        **({"package": prepared.package} if prepared.package is not None else {}),
+        "diagnostics": list(
+            diagnostic_records(prepared.diagnostics, conversion.diagnostics)
+        ),
     }
 
 
@@ -551,26 +556,25 @@ def load_network_from_any(
     file_path: str,
     out_path: str,
     source_format: Optional[str] = None,
-    operating_point: Optional[int] = None,
-    study_commit: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Stage any powerio readable case as a MATPOWER file for ANDES.
+    """Stage any case PowerIO can read as a MATPOWER file for ANDES.
 
     Reads MATPOWER .m, PSS/E .raw (v33), PowerWorld .aux, PowerModels JSON, or
-    egret JSON via powerio and writes a MATPOWER file to out_path (use a .m
-    extension). Pass out_path to run_power_flow to run the simulation. powerio
-    is a core dependency, so this is always available.
+    Egret JSON via PowerIO and writes a MATPOWER file to out_path (use a .m
+    extension). Pass out_path to run_power_flow to run the simulation. PowerIO
+    is a core dependency, so this is always available. Inspect collection
+    modules with PowerIO ``list_states`` and reduce them with ``export_state``
+    first.
 
     Args:
         file_path: Path to the source case file
         out_path: Destination for the MATPOWER case file (.m)
         source_format: Input format name (matpower, powermodels-json, egret-json,
             psse, powerworld); inferred from the file extension when omitted
-        operating_point: Optional package operating-point index to materialize
-        study_commit: Optional package study-commit index to materialize
 
     Returns:
-        Dict with status, case_file path, component counts, and fidelity warnings
+        Dict with status, case_file path, component counts, structured
+        diagnostics
     """
     try:
         file_path = checked_path(file_path, purpose="file_path")
@@ -584,16 +588,16 @@ def load_network_from_any(
         prepared = resolve_solver_case(
             file_path=file_path,
             source_format=source_format,
-            operating_point=operating_point,
-            study_commit=study_commit,
         )
         case = prepared.network
-        conv = case.to_format("matpower")
+        conversion = prepared.module.emit("matpower")
         abs_out = os.path.abspath(out_path)
         with open(abs_out, "w") as fh:
-            fh.write(conv.text)
+            fh.write(conversion.text)
     except FileNotFoundError:
         return {"status": "error", "message": f"File not found: {file_path}"}
+    except powerio.PowerIOError as exc:
+        return powerio_error_response(exc)
     except Exception as e:
         return {"status": "error", "message": str(e)}
     return {
@@ -603,10 +607,11 @@ def load_network_from_any(
         "info": {
             "buses": case.n_buses,
             "branches": case.n_branches,
-            "generators": case.n_gens,
+            "generators": case.n_generators,
         },
-        "warnings": list(prepared.warnings) + list(conv.warnings),
-        **({"package": prepared.package} if prepared.package is not None else {}),
+        "diagnostics": list(
+            diagnostic_records(prepared.diagnostics, conversion.diagnostics)
+        ),
     }
 
 

--- a/ANDES/requirements.txt
+++ b/ANDES/requirements.txt
@@ -1,3 +1,3 @@
 andes
 mcp>=2,<3
-powerio[mcp,matrix]>=0.9.0,<1
+powerio[mcp,matrix]>=1.0.0,<2

--- a/Egret/README.md
+++ b/Egret/README.md
@@ -37,8 +37,8 @@ Configure in your MCP client (e.g., Cursor, Claude Desktop):
 - **solve_unit_commitment_problem(case_file, solver, mipgap, timelimit)**: Solve a unit commitment problem with custom solver, MIP gap, and time limits.
 - **solve_ac_opf(case_file, solver, return_results)**: Run AC Optimal Power Flow on Matpower or Egret JSON case files.
 - **solve_dc_opf(case_file, solver, return_results)**: Run DC Optimal Power Flow on Matpower or Egret JSON case files.
-- **load_model_from_any(...)**: Convert any PowerIO-readable case or one selected `.pio.json` package state into an Egret model.
-- **load_model_from_json(...)**: Convert PowerIO model JSON or one selected `.pio.json` package state without staging the source input.
+- **load_model_from_any(...)**: Convert a balanced case PowerIO can read, or a static `.pio.json` module, into an Egret model. The result includes structured `diagnostics` and, for stored input, `module` context.
+- **load_model_from_json(...)**: Convert PowerIO balanced model JSON or a static `.pio.json` module without staging the source input. Inspect collections with PowerIO `list_states` and pass an `export_state` result to this tool.
 
 ## Prompt Example
 

--- a/Egret/egret_mcp.py
+++ b/Egret/egret_mcp.py
@@ -10,13 +10,18 @@ import io
 import logging
 from contextlib import redirect_stdout, redirect_stderr
 import numpy as np
+import powerio
 
 _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _repo_root_added = _repo_root not in sys.path
 if _repo_root_added:
     sys.path.insert(0, _repo_root)
 try:
-    from powermcp.solver_case import resolve_solver_case
+    from powermcp.solver_case import (
+        diagnostic_records,
+        powerio_error_response,
+        resolve_solver_case,
+    )
     from powermcp.sandbox import PathNotAllowed, checked_path, ensure_checked_directory
 finally:
     if _repo_root_added:
@@ -206,8 +211,8 @@ def solve_dc_opf(
         }
 
 # ---------------------------------------------------------------------------
-# PowerIO interchange: resolve one balanced state, convert it to Egret JSON, and
-# stage the file consumed by the solver tools above.
+# PowerIO interchange: resolve one balanced module, emit Egret JSON, and stage
+# the file consumed by the solver tools above.
 # ---------------------------------------------------------------------------
 
 
@@ -248,29 +253,24 @@ def _stage_egret_model(egret_json_text: str):
 def load_model_from_any(
     file_path: str,
     source_format: Optional[str] = None,
-    operating_point: Optional[int] = None,
-    study_commit: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Convert any powerio readable case file into an egret model.
+    """Convert any case PowerIO can read into an Egret model.
 
-    Reads any balanced PowerIO format or a ``.pio.json`` package, converts one
-    selected state to Egret JSON, validates it as ModelData, and stages it. For
-    a package containing stored state data, select operating_point or
-    study_commit. Pass the returned `case_file` path to solve_ac_opf, solve_dc_opf, or
-    solve_unit_commitment_problem. powerio is a core dependency, so this is
-    always available.
+    Reads any balanced PowerIO format or a static ``.pio.json`` module, emits
+    Egret JSON, validates it as ModelData, and stages it. Inspect collection
+    modules with PowerIO ``list_states`` and reduce them with ``export_state``
+    first. Pass the returned `case_file` path to solve_ac_opf, solve_dc_opf, or
+    solve_unit_commitment_problem. PowerIO is a core dependency.
 
     Args:
         file_path: Path to the case file
         source_format: Input format name (matpower, powermodels-json,
             egret-json, psse, powerworld); inferred from the file extension
             when omitted
-        operating_point: Optional package operating-point index to materialize
-        study_commit: Optional package study-commit index to materialize
 
     Returns:
         Dict with status, the staged `case_file` path, model element counts,
-        and powerio's fidelity warnings
+        and structured diagnostics
     """
     try:
         file_path = checked_path(file_path, purpose="file_path")
@@ -280,64 +280,63 @@ def load_model_from_any(
         prepared = resolve_solver_case(
             file_path=file_path,
             source_format=source_format,
-            operating_point=operating_point,
-            study_commit=study_commit,
         )
-        conv = prepared.network.to_format("egret-json")
-        path, info = _stage_egret_model(conv.text)
+        conversion = prepared.module.emit("egret-json")
+        path, info = _stage_egret_model(conversion.text)
     except FileNotFoundError:
         return {"status": "error", "message": f"File not found: {file_path}"}
+    except powerio.PowerIOError as exc:
+        return powerio_error_response(exc)
     except Exception as e:
         return {"status": "error", "message": str(e)}
     return {
         "status": "success",
         "case_file": path,
         "model_info": info,
-        "warnings": list(prepared.warnings) + list(conv.warnings),
-        **({"package": prepared.package} if prepared.package is not None else {}),
+        "diagnostics": list(
+            diagnostic_records(prepared.diagnostics, conversion.diagnostics)
+        ),
     }
 
 
 @mcp.tool()
 def load_model_from_json(
     network_json: str,
-    operating_point: Optional[int] = None,
-    study_commit: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Convert PowerIO model JSON or one package state into an Egret model.
+    """Convert PowerIO model JSON or one static module into an Egret model.
 
-    Accepts the `json` string returned by the powerio server's parse tool,
-    so a case parsed once there feeds egret without re-reading the file.
-    Converts it to egret JSON, validates it as an egret
-    ModelData, and stages it to a temp file. Pass the returned `case_file`
-    path to the solver tools. powerio is a core dependency, so this is always
-    available.
+    Accepts balanced model JSON or a static ``.pio.json`` module exported by
+    PowerIO, so a case parsed once there feeds egret without re-reading the
+    source file. Inspect collection modules with PowerIO ``list_states`` and
+    reduce them with ``export_state`` first. Converts it to Egret JSON,
+    validates it as an Egret ModelData, and stages it to a temp file. Pass the
+    returned `case_file` path to the solver tools. PowerIO is a core
+    dependency, so this is always available.
 
     Args:
-        network_json: The JSON transport string from powerio
-        operating_point: Optional package operating-point index to materialize
-        study_commit: Optional package study-commit index to materialize
+        network_json: PowerIO balanced model JSON or stored module JSON
 
     Returns:
         Dict with status, the staged `case_file` path, model element counts,
-        and powerio's fidelity warnings
+        and structured diagnostics
     """
     try:
         prepared = resolve_solver_case(
             network_json=network_json,
-            operating_point=operating_point,
-            study_commit=study_commit,
         )
-        conv = prepared.network.to_format("egret-json")
-        path, info = _stage_egret_model(conv.text)
+        conversion = prepared.module.emit("egret-json")
+        path, info = _stage_egret_model(conversion.text)
+    except powerio.PowerIOError as exc:
+        return powerio_error_response(exc)
     except Exception as e:
         return {"status": "error", "message": str(e)}
     return {
         "status": "success",
         "case_file": path,
         "model_info": info,
-        "warnings": list(prepared.warnings) + list(conv.warnings),
-        **({"package": prepared.package} if prepared.package is not None else {}),
+        "diagnostics": list(
+            diagnostic_records(prepared.diagnostics, conversion.diagnostics)
+        ),
     }
 
 

--- a/Egret/requirements.txt
+++ b/Egret/requirements.txt
@@ -1,4 +1,4 @@
 gridx-egret
 pyomo
 mcp>=2,<3
-powerio[mcp,matrix]>=0.9.0,<1
+powerio[mcp,matrix]>=1.0.0,<2

--- a/LTSpice/requirements.txt
+++ b/LTSpice/requirements.txt
@@ -1,6 +1,6 @@
 # Core MCP dependencies
 mcp>=2,<3
-powerio[mcp,matrix]>=0.9.0,<1
+powerio[mcp,matrix]>=1.0.0,<2
 
 # Circuit simulation dependencies
 matplotlib

--- a/OpenDSS/requirements.txt
+++ b/OpenDSS/requirements.txt
@@ -1,3 +1,3 @@
 py_dss_toolkit
 mcp>=2,<3
-powerio[mcp,matrix]>=0.9.0,<1
+powerio[mcp,matrix]>=1.0.0,<2

--- a/PLEXOSDB/README.md
+++ b/PLEXOSDB/README.md
@@ -56,9 +56,8 @@ python -c "from plexosdb_mcp.server import build_mcp_server; print(build_mcp_ser
 ### Why `powermcp run plexosdb` launches this as a script, not a module
 
 `PLEXOSDB/plexosdb_mcp/main.py` deliberately lives in a package also named
-`plexosdb_mcp` — the same import name as the upstream distribution it re-exports
-(mirroring `powerio/powerio_mcp.py`'s re-export of the `powerio` package). Because of
-that shared name, the registry launches it as a **script** (`entry_rel=
+`plexosdb_mcp` — the same import name as the upstream distribution it re-exports.
+Because of that shared name, the registry launches it as a **script** (`entry_rel=
 "plexosdb_mcp/main.py"`), not as a module. Module-style launch would add `PLEXOSDB/`
 itself to `sys.path`, and `import plexosdb_mcp` inside `main.py` would then resolve to
 *this* package before ever reaching the real, installed one — confirmed by direct

--- a/PLEXOSDB/plexosdb_mcp/main.py
+++ b/PLEXOSDB/plexosdb_mcp/main.py
@@ -10,10 +10,9 @@ PLEXOS XML database format directly via the open-source ``plexosdb`` library. Se
 PLEXOSDB/README.md for the (currently git-only) install step.
 
 This module keeps no copy of plexosdb-mcp's tool implementations -- it builds the
-upstream FastMCP server object as-is (``build_mcp_server``) and re-exports it, the
-same shape as ``powerio/powerio_mcp.py``'s ``mcp = _server.mcp``. plexosdb-mcp builds
-its server via a factory rather than a module-level singleton, so calling that
-factory once at import time is the direct analogue here.
+upstream FastMCP server object as-is (``build_mcp_server``) and re-exports it.
+plexosdb-mcp builds its server via a factory rather than a module-level singleton,
+so this connector calls that factory once at import time.
 
 The two tools added below call r2x's real, public API directly: ``r2x_plexos.
 PLEXOSParser`` builds an r2x System from a PLEXOS XML study, ``r2x_plexos_to_sienna.

--- a/PLEXOSDB/pyproject.toml
+++ b/PLEXOSDB/pyproject.toml
@@ -34,7 +34,7 @@ include = ["plexosdb_mcp*"]
 
 # NOTE ON THE NAME COLLISION: this package's importable name is deliberately
 # `plexosdb_mcp` -- the same as the upstream `plexosdb-mcp` distribution it
-# re-exports (mirrors powerio_mcp.py's re-export of the `powerio` package).
+# re-exports.
 # Do not `pip install -e PLEXOSDB` into the same environment as the upstream
 # git-installed `plexosdb-mcp` package and expect both to cleanly coexist as
 # independent site-packages entries; see PLEXOSDB/README.md for the supported

--- a/PLEXOSDB/tests/test_tools.py
+++ b/PLEXOSDB/tests/test_tools.py
@@ -215,7 +215,7 @@ class TestCompareSolutions(unittest.TestCase):
 class TestUpstreamReExport(unittest.TestCase):
     """The re-exported plexosdb-mcp tools themselves are not PowerMCP's to unit
     test (they belong to the upstream project); this only checks the shape of
-    the re-export, matching powerio_mcp.py's own precedent."""
+    the connector's thin re-export."""
 
     def test_mcp_and_upstream_names_are_re_exported(self):
         mod = _load_main_module()

--- a/PSCAD/pyproject.toml
+++ b/PSCAD/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 dependencies = [
     "mcp>=2,<3",
-    "powerio[mcp,matrix]>=0.9.0,<1",
+    "powerio[mcp,matrix]>=1.0.0,<2",
     "psutil"
 ]
 

--- a/PSLF/requirements.txt
+++ b/PSLF/requirements.txt
@@ -1,3 +1,3 @@
 pandas
 mcp>=2,<3
-powerio[mcp,matrix]>=0.9.0,<1
+powerio[mcp,matrix]>=1.0.0,<2

--- a/PSSE/requirements.txt
+++ b/PSSE/requirements.txt
@@ -1,2 +1,2 @@
 mcp>=2,<3
-powerio[mcp,matrix]>=0.9.0,<1
+powerio[mcp,matrix]>=1.0.0,<2

--- a/PowerFactory/requirements.txt
+++ b/PowerFactory/requirements.txt
@@ -1,6 +1,6 @@
 # MCP Python SDK 2 server framework
 mcp>=2,<3
-powerio[mcp,matrix]>=0.9.0,<1
+powerio[mcp,matrix]>=1.0.0,<2
 
 # Scientific stack
 numpy>=1.26

--- a/PowerWorld/requirements.txt
+++ b/PowerWorld/requirements.txt
@@ -1,4 +1,4 @@
 esa
 numba
 mcp>=2,<3
-powerio[mcp,matrix]>=0.9.0,<1
+powerio[mcp,matrix]>=1.0.0,<2

--- a/PyPSA/README.md
+++ b/PyPSA/README.md
@@ -54,9 +54,11 @@ Configure in your MCP client (e.g., Cursor, Claude Desktop):
 - [x] `optimize_investment` - Run capacity expansion optimization
 - [x] `import_from_csv_folder` - Import network from CSV files
 - [x] `export_to_csv_folder` - Export network to CSV format
-- [x] `import_case_from_any` - Import any PowerIO-readable case or one selected `.pio.json` package state to NetCDF
-- [x] `import_case_from_json` - Import PowerIO model JSON or one selected `.pio.json` package state to NetCDF
+- [x] `import_case_from_any` - Import any balanced PowerIO case or stored static `.pio.json` module to NetCDF
+- [x] `import_case_from_json` - Import PowerIO model JSON or a stored static `.pio.json` module to NetCDF
 - [x] `run_contingency_analysis` - N-1 contingency analysis
+
+Collection modules must be exported to a static module through PowerIO before importing. Interchange tools return structured `diagnostics`; stored module context is returned under `module`.
 
 # Future functionalities
 - [ ] `calculate_statistics` - Calculate capacity factors, line loading, and curtailment

--- a/PyPSA/pypsa_mcp.py
+++ b/PyPSA/pypsa_mcp.py
@@ -6,6 +6,7 @@ from mcp.server.mcpserver import MCPServer as FastMCP
 from pypsa import Network
 import numpy as np
 import pandas as pd
+import powerio
 from typing import Dict, List, Optional, Union, Any
 
 _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -13,7 +14,12 @@ _repo_root_added = _repo_root not in sys.path
 if _repo_root_added:
     sys.path.insert(0, _repo_root)
 try:
-    from powermcp.solver_case import resolve_solver_case
+    from powermcp.solver_case import (
+        bridge_diagnostic,
+        diagnostic_records,
+        powerio_error_response,
+        resolve_solver_case,
+    )
     from powermcp.sandbox import (
         PathNotAllowed,
         checked_path,
@@ -699,20 +705,28 @@ def export_to_csv_folder(network_name: str, folder_path: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# PowerIO interchange: resolve one balanced state, use PowerIO's native PyPSA CSV
-# writer, then save the PyPSA network to the NetCDF path used by other tools.
+# PowerIO interchange: resolve one balanced state, emit PowerIO's native PyPSA
+# CSV artifact, then save it to the NetCDF path used by other tools.
 # ---------------------------------------------------------------------------
 
-def _import_case_to_netcdf(case, output_path: str, overwrite_zero_s_nom: Optional[float]):
-    """Use PowerIO's native PyPSA CSV writer, then persist the network."""
-    with tempfile.TemporaryDirectory(prefix="powermcp-pypsa-") as staging:
-        written = case.write_pypsa_csv_folder(staging)
+def _import_case_to_netcdf(
+    prepared,
+    output_path: str,
+    overwrite_zero_s_nom: Optional[float],
+):
+    """Emit PowerIO's native PyPSA CSV artifact, then persist the network."""
+    with tempfile.TemporaryDirectory(prefix="powermcp-pypsa-") as staging_root:
+        staging = os.path.join(staging_root, "case")
+        emission = prepared.module.emit("pypsa-csv", staging)
         network = Network()
         network.import_from_csv_folder(staging)
-    warnings = list(written.get("warnings", []))
+    diagnostics = list(
+        diagnostic_records(prepared.diagnostics, emission.diagnostics)
+    )
+    case = prepared.network
 
-    # PowerIO 0.9 preserves source generator voltage targets in its native
-    # generators.csv extension column.  PyPSA imports that column but regulates
+    # PowerIO preserves source generator voltage targets in its native
+    # generators.csv extension column. PyPSA imports that column but regulates
     # voltage through Bus.v_mag_pu_set, so apply it explicitly before solving.
     if "v_mag_pu_set" in network.generators:
         generators = network.generators
@@ -727,13 +741,16 @@ def _import_case_to_netcdf(case, output_path: str, overwrite_zero_s_nom: Optiona
             target = float(values.iloc[0])
             network.buses.loc[bus, "v_mag_pu_set"] = target
             if not np.allclose(values.to_numpy(), target):
-                warnings.append(
-                    f"multiple voltage targets regulate bus {bus}; "
-                    f"using {target} from the first generator"
+                diagnostics.append(
+                    bridge_diagnostic(
+                        "POWERMCP.PYPSA.VOLTAGE_TARGET_CONFLICT",
+                        f"multiple voltage targets regulate bus {bus}; "
+                        f"using {target} from the first generator",
+                    )
                 )
 
-    # The 0.9 CSV writer emits generators in canonical source order.  Restore
-    # transition costs that PyPSA supports but the writer does not yet emit.
+    # The CSV emitter writes generators in canonical source order. Restore
+    # transition costs that PyPSA supports but the emitter does not yet carry.
     source_generators = list(case.generators)
     if len(source_generators) == len(network.generators):
         network.generators["start_up_cost"] = [
@@ -745,9 +762,12 @@ def _import_case_to_netcdf(case, output_path: str, overwrite_zero_s_nom: Optiona
             for generator in source_generators
         ]
     else:
-        warnings.append(
-            "generator transition costs could not be restored because the "
-            "PowerIO and PyPSA generator counts differ"
+        diagnostics.append(
+            bridge_diagnostic(
+                "POWERMCP.PYPSA.GENERATOR_COUNT_MISMATCH",
+                "generator transition costs could not be restored because the "
+                "PowerIO and PyPSA generator counts differ",
+            )
         )
     constant_costs = sum(
         1
@@ -757,9 +777,13 @@ def _import_case_to_netcdf(case, output_path: str, overwrite_zero_s_nom: Optiona
         and float((generator.get("cost") or {})["coeffs"][-1]) != 0.0
     )
     if constant_costs:
-        warnings.append(
-            f"{constant_costs} generator constant polynomial cost term(s) "
-            "have no equivalent in the PyPSA generator objective and were dropped"
+        diagnostics.append(
+            bridge_diagnostic(
+                "POWERMCP.PYPSA.CONSTANT_COST_DROPPED",
+                f"{constant_costs} generator constant polynomial cost term(s) "
+                "have no equivalent in the PyPSA generator objective and were "
+                "dropped",
+            )
         )
 
     zero_ratings = 0
@@ -770,11 +794,23 @@ def _import_case_to_netcdf(case, output_path: str, overwrite_zero_s_nom: Optiona
         zero_ratings += int(zero.sum())
         if overwrite_zero_s_nom is not None:
             table.loc[zero, "s_nom"] = overwrite_zero_s_nom
-    if zero_ratings and overwrite_zero_s_nom is None:
-        warnings.append(
-            f"{zero_ratings} branch(es) with rating 0 imported with s_nom 0; "
-            "pass overwrite_zero_s_nom to set a value"
-        )
+    if zero_ratings:
+        if overwrite_zero_s_nom is None:
+            diagnostics.append(
+                bridge_diagnostic(
+                    "POWERMCP.PYPSA.ZERO_BRANCH_RATING",
+                    f"{zero_ratings} branch(es) with rating 0 imported with "
+                    "s_nom 0; pass overwrite_zero_s_nom to set a value",
+                )
+            )
+        else:
+            diagnostics.append(
+                bridge_diagnostic(
+                    "POWERMCP.PYPSA.ZERO_BRANCH_RATING_REPLACED",
+                    f"replaced s_nom 0 on {zero_ratings} branch(es) with "
+                    f"{overwrite_zero_s_nom}",
+                )
+            )
     try:
         network.export_to_netcdf(output_path)
     except OSError as exc:
@@ -787,7 +823,7 @@ def _import_case_to_netcdf(case, output_path: str, overwrite_zero_s_nom: Optiona
         "transformers": len(network.transformers),
         "shunt_impedances": len(network.shunt_impedances),
     }
-    return info, warnings
+    return info, list(diagnostic_records(diagnostics))
 
 
 @mcp.tool()
@@ -796,31 +832,25 @@ def import_case_from_any(
     output_path: str,
     source_format: Optional[str] = None,
     overwrite_zero_s_nom: Optional[float] = None,
-    operating_point: Optional[int] = None,
-    study_commit: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Import any powerio readable case file as a PyPSA network saved to a
     NetCDF file.
 
-    Reads any balanced PowerIO format or a ``.pio.json`` package and writes a
-    PyPSA network to output_path. If the package contains stored state data,
-    select exactly one operating_point or study_commit; PowerIO materializes it
-    first.
-    PowerIO's native PyPSA writer preserves supported costs and element status.
+    Reads any balanced PowerIO format or stored ``.pio.json`` module and writes
+    a PyPSA network to output_path. Collection modules must be exported to a
+    static module through PowerIO before being passed to this tool. PowerIO's
+    native PyPSA emitter preserves supported costs and element status.
 
     Args:
         file_path: Path to the case file
         output_path: Where to save the imported network (.nc)
-        source_format: Input format name (matpower, powermodels-json,
-            egret-json, psse, powerworld); inferred from the file extension
-            when omitted
+        source_format: Optional PowerIO input format name; inferred from the
+            file extension when omitted
         overwrite_zero_s_nom: Replacement s_nom for branches with rating 0
-        operating_point: Optional package operating-point index to materialize
-        study_commit: Optional package study-commit index to materialize
 
     Returns:
         Dict with status, the saved network_file path, component counts, and
-        warnings about dropped or adjusted data
+        structured diagnostics for dropped or adjusted data
     """
     try:
         file_path = checked_path(file_path, purpose="file_path")
@@ -834,15 +864,14 @@ def import_case_from_any(
         prepared = resolve_solver_case(
             file_path=file_path,
             source_format=source_format,
-            operating_point=operating_point,
-            study_commit=study_commit,
         )
-        info, warnings = _import_case_to_netcdf(
-            prepared.network, output_path, overwrite_zero_s_nom
+        info, diagnostics = _import_case_to_netcdf(
+            prepared, output_path, overwrite_zero_s_nom
         )
-        warnings = list(prepared.warnings) + warnings
     except FileNotFoundError:
         return {"status": "error", "message": f"File not found: {file_path}"}
+    except powerio.PowerIOError as exc:
+        return powerio_error_response(exc, prefix="Failed to import case")
     except Exception as e:
         return {"status": "error", "message": f"Failed to import case: {str(e)}"}
     return {
@@ -850,8 +879,7 @@ def import_case_from_any(
         "message": f"Network imported and saved to {output_path}",
         "network_file": output_path,
         "info": info,
-        "warnings": warnings,
-        **({"package": prepared.package} if prepared.package is not None else {}),
+        "diagnostics": diagnostics,
     }
 
 
@@ -860,47 +888,40 @@ def import_case_from_json(
     network_json: str,
     output_path: str,
     overwrite_zero_s_nom: Optional[float] = None,
-    operating_point: Optional[int] = None,
-    study_commit: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Import PowerIO model JSON or one selected ``.pio.json`` package state
+    """Import PowerIO model JSON or a stored static ``.pio.json`` module
     as a PyPSA network saved to a NetCDF file.
 
     Accepts the `json` string returned by the powerio server's parse tool,
-    or a durable package emitted by its package tools. A package containing
-    stored state data requires exactly one operating-point or study-commit selector. A
-    case parsed once there loads here without passing a file around or
-    re-parsing it. Model JSON expects source-valued tables (MW, degrees)
-    as parse emits them, not the per-unit normalize form. Writes the
-    network to output_path (use a .nc extension); pass that path as
-    network_name to the other tools. powerio is a core dependency, so this is
-    always available.
+    or a stored module emitted by PowerIO. Collection modules must be exported
+    to a static module through PowerIO first. A case parsed once there loads
+    here without passing a file around or re-parsing it. Model JSON expects
+    source-valued tables (MW, degrees) as parse emits them, not the per-unit
+    form returned by `to_normalized`. Writes the network to output_path (use a
+    .nc extension);
+    pass that path as network_name to the other tools. powerio is a core
+    dependency, so this is always available.
 
     Args:
         network_json: The JSON transport string from powerio
         output_path: Where to save the imported network (.nc)
         overwrite_zero_s_nom: Replacement s_nom for branches with rating 0
-        operating_point: Optional package operating-point index to materialize
-        study_commit: Optional package study-commit index to materialize
 
     Returns:
         Dict with status, the saved network_file path, component counts, and
-        warnings about dropped or adjusted data
+        structured diagnostics for dropped or adjusted data
     """
     try:
         output_path = checked_path(output_path, purpose="output_path", for_write=True)
     except PathNotAllowed as exc:
         return {"status": "error", "message": str(exc)}
     try:
-        prepared = resolve_solver_case(
-            network_json=network_json,
-            operating_point=operating_point,
-            study_commit=study_commit,
+        prepared = resolve_solver_case(network_json=network_json)
+        info, diagnostics = _import_case_to_netcdf(
+            prepared, output_path, overwrite_zero_s_nom
         )
-        info, warnings = _import_case_to_netcdf(
-            prepared.network, output_path, overwrite_zero_s_nom
-        )
-        warnings = list(prepared.warnings) + warnings
+    except powerio.PowerIOError as exc:
+        return powerio_error_response(exc, prefix="Failed to import case")
     except Exception as e:
         return {"status": "error", "message": f"Failed to import case: {str(e)}"}
     return {
@@ -908,8 +929,7 @@ def import_case_from_json(
         "message": f"Network imported and saved to {output_path}",
         "network_file": output_path,
         "info": info,
-        "warnings": warnings,
-        **({"package": prepared.package} if prepared.package is not None else {}),
+        "diagnostics": diagnostics,
     }
 
 

--- a/PyPSA/requirements.txt
+++ b/PyPSA/requirements.txt
@@ -3,4 +3,4 @@ pypsa>=0.35.2,<2
 numpy>=1.24.0
 pandas>=2.0.0
 mcp>=2,<3
-powerio[mcp,matrix]>=0.9.0,<1
+powerio[mcp,matrix]>=1.0.0,<2

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The base install includes the open-source engines that need no extra setup — *
 ```bash
 pip install powermcp[psse]              # add PSS/E support
 pip install powermcp[andes,opendss]     # add several tools at once
-pip install powermcp[opensource]        # all open-source tools (ANDES, Egret, OpenDSS, surge, HOPE, LTSpice, GenX)
+pip install powermcp[opensource]        # open source tools, including the Tellegen adapter
 pip install powermcp[all]               # everything (closed-source tools still need the local software)
 ```
 
@@ -108,9 +108,11 @@ Re-running `powermcp install` pre-checks the tools you've already installed or c
 | `powermcp doctor` | Check each tool's dependencies and configured paths |
 | `powermcp config show` / `config set <tool>.<key> <path>` | Inspect / set local software paths |
 
-### Closed-source / EXE-based tools
+### Tools configured with local software paths
 
-These tools wrap commercial or locally-installed software, so PowerMCP stores the local path in `~/.powermcp/config.toml` (captured by `powermcp install`, or set manually with `powermcp config set`):
+PowerMCP stores local executable and software paths in
+`~/.powermcp/config.toml`. The installer can capture them, or you can use
+`powermcp config set`.
 
 | Tool | Config keys | Example |
 |---|---|---|
@@ -120,6 +122,7 @@ These tools wrap commercial or locally-installed software, so PowerMCP stores th
 | LTSpice | `ltspice.exe` *(auto-detected)* | Found automatically in standard locations — usually no setup needed. Override: `powermcp config set ltspice.exe "C:\Program Files\ADI\LTspice\LTspice.exe"` |
 | HOPE | `hope.repo_root`, `hope.julia_bin` | `powermcp config set hope.repo_root "C:\src\HOPE"` |
 | GenX | `genx.repo_root` | `powermcp config set genx.repo_root "/home/me/GenX.jl"` — the GenX.jl checkout; `GENX_DIR` overrides it |
+| Tellegen | `tellegen.binary` | Build `tellegen-cli`, then run `powermcp config set tellegen.binary "/path/to/tellegen/target/release/tellegen"` |
 | PowerWorld | *(none)* | `esa` auto-discovers a running, licensed Simulator via COM; the `powerworld` extra also installs `numba` (required by esa) |
 | PSCAD | *(none)* | `pip install powermcp[pscad-windows]` provides `mhi-pscad`; PSCAD must be installed |
 
@@ -127,66 +130,88 @@ These tools wrap commercial or locally-installed software, so PowerMCP stores th
 
 ### Case compilation between servers (PowerIO)
 
-PowerMCP runs the MCP server that [powerio](https://github.com/eigenergy/powerio) ships in its own wheel, as a **core dependency** (no extra needed) — `powermcp run powerio` is `python -m powerio.mcp`, so a powerio release that adds tools or changes their implementation needs no local server copy. It parses transmission and distribution formats into canonical JSON transports, converts between target artifacts with fidelity warnings, and builds the sparse matrices solvers need (B', B'', Y_bus, PTDF, LODF, Laplacian, LACPF).
+PowerMCP registers and launches the MCP server shipped by
+[PowerIO](https://github.com/eigenergy/powerio). `powermcp run powerio` runs
+`python -m powerio.mcp`; this repository does not keep a second server or
+reimplement its case semantics. PowerIO owns interchange, conversion,
+inspection, validation, structured diagnostics, normalization, matrices,
+display artifacts, version metadata, collection operations, lowerings, and
+sparse solver inputs. PowerMCP owns solver adapters that consume one concrete
+static case.
 
-Its JSON transport is the exchange format between PowerMCP servers: parse a case once, pass the returned `json` string between tool calls, and save runtime artifacts only when a backend needs a file. Existing `json` transport workflows remain supported.
+The Python boundary retains the module until the target artifact is emitted:
 
-```
-parse(path="case9.raw")                            # powerio server -> {"json": ..., "summary": ...}
-load_network_from_json(network_json=...)           # pandapower server ingests the transport
-load_model_from_json(network_json=...)             # egret server stages it as a solvable case file
-import_case_from_json(network_json=..., output_path="case9.nc")  # PyPSA server writes a .nc for its tools
-matrix(kind="ptdf", json=...)                      # powerio server builds matrices from it
-save(to_format="psse", out_path="case9.raw", json=...)  # stage a file for path only servers
-```
-
-PowerIO also supports the `.pio.json` package transport, which carries the model plus package metadata and structured diagnostics:
-
-```
-parsed = parse(path="case9.raw", transport="package")
-pkg = parsed["package_json"]
-summary(package_json=pkg)
-matrix(kind="ptdf", package_json=pkg)
-save(to_format="psse", out_path="case9.raw", package_json=pkg)
-diagnostics(package_json=pkg)  # package diagnostics summary and structured findings
+```python
+module = powerio.parse_file("case9.raw")
+network = module.value
+diagnostics = module.diagnostics
+ptdf = network.calc_ptdf()
+module.emit("matpower", "case9.m")
 ```
 
-A package can also retain provenance and source maps, stable row identities,
-validation state, operating-point series, cumulative study commits, and
-lowering history. The canonical PowerIO MCP tools continue to own that package
-lifecycle. PowerMCP uses the package only at the solver boundary:
+The MCP boundary uses the stored `.pio.json` module transport. The canonical
+tools are `parse`, `inspect`, `diagnostics`, `summarize`, `to_normalized`,
+`calc_matrix`, `display`, `about`, `list_states`, `inspect_state`,
+`export_state`, `to_balanced_report`, `to_balanced`, and `emit`.
 
+```python
+parsed = parse(path="case9.raw", transport="module")
+module_json = parsed["module_json"]
+inspect(module_json=module_json)
+diagnostics(module_json=module_json)
+calc_matrix(kind="ptdf", module_json=module_json)
+emit(format="psse", destination="case9.raw", module_json=module_json)
 ```
-# A static package loads directly.
-import_case_from_json(network_json=pkg, output_path="case9.nc")
 
-# A package with one or more stored states requires an explicit selection.
-# PowerIO v0.9 materializes and validates the selected state before PowerMCP
-# creates the solver model.
+A collection must be inspected and exported through PowerIO before a solver
+adapter accepts it. PowerMCP does not duplicate collection selectors:
+
+```python
+states = list_states(module_json=module_json)
+inspect_state(module_json=module_json, scenario="base")
+selected = export_state(module_json=module_json, scenario="base")
 import_case_from_json(
-    network_json=pkg,
-    output_path="dispatch.nc",
-    operating_point=3,
+    network_json=selected["module_json"], output_path="dispatch.nc"
 )
-load_network_from_json(network_json=pkg, study_commit=1)  # pandapower
 ```
 
-The same `operating_point` and `study_commit` selectors are available on the
-PowerIO import tools for pandapower, PyPSA, ANDES, and Egret. PowerMCP rejects
-unselected stored state data instead of silently solving the package's base model.
-Study materialization honors the package's `base_operating_point`. Balanced
-solvers also reject multiconductor packages until the caller explicitly lowers
-them with PowerIO, so a lossy distribution-to-transmission reduction is never
-implicit. PyPSA and pandapower use PowerIO's native writers, preserving the
-supported cost and in-service metadata without PowerMCP rebuilding PYPOWER
-tables.
+The same rule applies to time series, using a `time_position` returned by
+`list_states`. Balanced solvers reject multiconductor modules until the caller
+checks `to_balanced_report` and explicitly calls `to_balanced`. PyPSA and
+pandapower emit through PowerIO's native writers so source maps, diagnostics,
+history, supported costs, and in service metadata remain attached to the
+interchange boundary.
 
-`summary` returns the canonical nested shape used by PowerIO and PowerMCP: counts live under `elements` (`elements.buses`, `elements.branches`, `elements.generators`) and topology metadata lives under `topology` (`topology.connected_components`, `topology.reference_buses`).
+Model JSON remains available for direct static network exchange. Use module
+transport when provenance, source ownership, diagnostics, validation, or
+history must survive between calls.
 
-`save` covers the servers without a bridge: write the converted case to disk and point their load tools at the file. For OpenDSS, save a distribution transport as DSS, then compile that DSS file:
+### DC OPF and capacity planning (Tellegen)
 
-```
-save(to_format="dss", out_path="feeder.dss", json=..., json_format="bmopf-json")
+Install the adapter with `pip install "powermcp[tellegen]"`, build
+`tellegen-cli`, and configure `tellegen.binary`. The server exposes three
+tools:
+
+- `capabilities` returns Tellegen's formulation and differentiation records.
+- `solve_dc_opf` accepts a stored PowerIO module and returns the
+  `dc_opf_solution` module in `results`.
+- `plan_capacity` accepts the planning request defined by Tellegen's contract
+  and returns its `CapacityPlanOutcome` and exact solution module in `results`.
+
+Capacity planning uses implicit gradients to choose capacity increase trials
+and exact DC OPF solves to accept a bounded proposal. The search is heuristic
+and does not change the input module. PowerMCP checks the configured CLI against
+the bundled `tellegen.cli/1` contract before each operation.
+
+For OpenDSS, emit a distribution transport as DSS, then compile that file:
+
+```python
+emit(
+    format="dss",
+    destination="feeder.dss",
+    json=distribution_json,
+    json_format="bmopf-json",
+)
 compile_opendss_file(dss_file="feeder.dss")
 ```
 
@@ -202,6 +227,7 @@ Every bundled server is still a standalone script. Clone the repo and run any se
 python pandapower/panda_mcp.py
 python PSSE/psse_mcp.py          # uses ~/.powermcp/config.toml if present, else legacy default paths
 python -m powerio.mcp            # powerio ships its own server; the clone holds no copy
+python tellegen/tellegen_mcp.py  # needs POWERMCP_TELLEGEN_BINARY when run directly
 ```
 
 ### Testing with your LLMs

--- a/pandapower/README.md
+++ b/pandapower/README.md
@@ -35,12 +35,14 @@ Configure in your MCP client (e.g., Cursor, Claude Desktop):
 
 - **create_empty_network()**: Create an empty pandapower network.
 - **load_network(file_path: str)**: Load a network from a `.json` file.
-- **load_network_from_any(...)**: Load any PowerIO-readable case or one selected `.pio.json` package state.
-- **load_network_from_json(...)**: Load PowerIO model JSON or one selected `.pio.json` package state without staging a file.
-- **export_network_to_format(to_format: str)**: Export the active network through PowerIO's native writer.
+- **load_network_from_any(...)**: Load any balanced PowerIO case or stored static `.pio.json` module.
+- **load_network_from_json(...)**: Load PowerIO model JSON or a stored static `.pio.json` module without staging a file.
+- **export_network_to_format(to_format: str)**: Export the active network through `PioModule.emit`.
 - **run_power_flow(algorithm, calculate_voltage_angles, max_iteration, tolerance_mva)**: Run power flow analysis (Newton-Raphson or Backward/Forward Sweep).
 - **run_contingency_analysis(contingency_type, elements)**: Run N-1 or N-2 contingency analysis on lines and transformers.
 - **get_network_info()**: Get statistics and data for buses, lines, transformers, generators, loads, and switches.
+
+Collection modules must be exported to a static module through PowerIO before loading. Interchange tools return structured `diagnostics`; stored module context is returned under `module`.
 
 ## Prompt Example
 

--- a/pandapower/panda_mcp.py
+++ b/pandapower/panda_mcp.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 import pandapower as pp
+import powerio
 from mcp.server.mcpserver import MCPServer as FastMCP
 import logging
 
@@ -11,7 +12,11 @@ _repo_root_added = _repo_root not in sys.path
 if _repo_root_added:
     sys.path.insert(0, _repo_root)
 try:
-    from powermcp.solver_case import resolve_solver_case
+    from powermcp.solver_case import (
+        diagnostic_records,
+        powerio_error_response,
+        resolve_solver_case,
+    )
     from powermcp.sandbox import PathNotAllowed, checked_path
 finally:
     if _repo_root_added:
@@ -274,45 +279,26 @@ def get_network_info() -> Dict[str, Any]:
 
 # ---------------------------------------------------------------------------
 # PowerIO interchange: resolve one balanced state and use PowerIO's native
-# pandapower writer. Export still round-trips pandapower's PYPOWER tables
-# through PowerIO because pandapower has no corresponding native writer.
+# pandapower emitter. Export transforms pandapower's PYPOWER tables into a
+# PowerIO module because pandapower has no corresponding native emitter.
 # ---------------------------------------------------------------------------
 
 _POWERIO_HINT = "powerio not installed: pip install 'powerio[mcp,matrix]'"
 
-def _powerio_to_net(case):
-    """Use PowerIO's native writer to create the pandapower network."""
-    conversion = case.to_format("pandapower-json")
-    return pp.from_json_string(conversion.text), list(conversion.warnings)
-
-
-def _ppc_to_matpower_text(ppc) -> str:
-    """Serialize PYPOWER input tables as MATPOWER .m text for powerio to parse.
-    Columns beyond the MATPOWER input widths (result columns) are dropped."""
-    width = {"bus": 13, "gen": 21, "branch": 13}
-    out = [
-        "function mpc = ppc_export",
-        "mpc.version = '2';",
-        f"mpc.baseMVA = {float(ppc['baseMVA'])!r};",
-    ]
-    for name in ("bus", "gen", "branch", "gencost"):
-        table = ppc.get(name)
-        if table is None or len(table) == 0:
-            continue
-        w = width.get(name)
-        rows = "\n".join(
-            "\t" + "\t".join(repr(float(v)) for v in (row[:w] if w else row)) + ";"
-            for row in table
-        )
-        out.append(f"mpc.{name} = [\n{rows}\n];")
-    return "\n".join(out) + "\n"
+def _powerio_to_net(prepared):
+    """Use PowerIO's native emitter to create the pandapower network."""
+    conversion = prepared.module.emit("pandapower-json")
+    diagnostics = diagnostic_records(
+        prepared.diagnostics,
+        conversion.diagnostics,
+    )
+    return pp.from_json_string(conversion.text), list(diagnostics)
 
 
 def _network_info_response(
     message: str,
     *,
-    warnings: Optional[List[str]] = None,
-    package: Optional[Dict[str, Any]] = None,
+    diagnostics: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     response = {
         "status": "success",
@@ -322,11 +308,8 @@ def _network_info_response(
             "lines": len(_current_net.line),
             "trafos": len(_current_net.trafo),
         },
+        "diagnostics": list(diagnostics or []),
     }
-    if warnings:
-        response["warnings"] = warnings
-    if package is not None:
-        response["package"] = package
     return response
 
 
@@ -334,23 +317,17 @@ def _network_info_response(
 def load_network_from_any(
     file_path: str,
     source_format: Optional[str] = None,
-    operating_point: Optional[int] = None,
-    study_commit: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Load a network from any powerio readable case file.
 
-    Reads any balanced PowerIO format or a ``.pio.json`` package and replaces
-    the current network. If the package contains stored state data, select
-    exactly one operating_point or study_commit; PowerIO materializes it before
-    conversion.
+    Reads any balanced PowerIO format or stored ``.pio.json`` module and
+    replaces the current network. Collection modules must be exported to a
+    static module through PowerIO before being passed to this tool.
 
     Args:
         file_path: Path to the case file
-        source_format: Input format name (matpower, powermodels-json,
-            egret-json, psse, powerworld); inferred from the file extension
-            when omitted
-        operating_point: Optional package operating-point index to materialize
-        study_commit: Optional package study-commit index to materialize
+        source_format: Optional PowerIO input format name; inferred from the
+            file extension when omitted
 
     Returns:
         Dict containing status and network information
@@ -365,40 +342,36 @@ def load_network_from_any(
         prepared = resolve_solver_case(
             file_path=file_path,
             source_format=source_format,
-            operating_point=operating_point,
-            study_commit=study_commit,
         )
-        _current_net, conversion_warnings = _powerio_to_net(prepared.network)
+        _current_net, diagnostics = _powerio_to_net(prepared)
     except FileNotFoundError:
         return {"status": "error", "message": f"File not found: {file_path}"}
+    except powerio.PowerIOError as exc:
+        return powerio_error_response(exc, prefix="Failed to load network")
     except Exception as e:
         return {"status": "error", "message": f"Failed to load network: {str(e)}"}
     return _network_info_response(
         f"Network loaded successfully from {file_path}",
-        warnings=list(prepared.warnings) + conversion_warnings,
-        package=prepared.package,
+        diagnostics=diagnostics,
     )
 
 
 @mcp.tool()
 def load_network_from_json(
     network_json: str,
-    operating_point: Optional[int] = None,
-    study_commit: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Load PowerIO model JSON or one selected ``.pio.json`` package state.
+    """Load PowerIO model JSON or a stored static ``.pio.json`` module.
 
     Accepts the `json` string returned by the powerio server's parse tool,
     so a case parsed once there loads here without passing a file around or
     re-parsing it. Expects source-valued tables (MW, degrees)
-    as parse emits them, not the per-unit normalize form. Replaces
-    the currently loaded network. powerio is a core dependency, so this is
-    always available.
+    as parse emits them, not the per-unit form returned by `to_normalized`. Replaces
+    the currently loaded network. Collection modules must be exported to a
+    static module through PowerIO first. powerio is a core dependency, so
+    this is always available.
 
     Args:
         network_json: The JSON transport string from powerio
-        operating_point: Optional package operating-point index to materialize
-        study_commit: Optional package study-commit index to materialize
 
     Returns:
         Dict containing status and network information
@@ -406,18 +379,15 @@ def load_network_from_json(
     logger.info("Loading network from powerio JSON transport")
     global _current_net
     try:
-        prepared = resolve_solver_case(
-            network_json=network_json,
-            operating_point=operating_point,
-            study_commit=study_commit,
-        )
-        _current_net, conversion_warnings = _powerio_to_net(prepared.network)
+        prepared = resolve_solver_case(network_json=network_json)
+        _current_net, diagnostics = _powerio_to_net(prepared)
+    except powerio.PowerIOError as exc:
+        return powerio_error_response(exc, prefix="Failed to load network")
     except Exception as e:
         return {"status": "error", "message": f"Failed to load network: {str(e)}"}
     return _network_info_response(
         "Network loaded successfully from JSON transport",
-        warnings=list(prepared.warnings) + conversion_warnings,
-        package=prepared.package,
+        diagnostics=diagnostics,
     )
 
 
@@ -425,17 +395,16 @@ def load_network_from_json(
 def export_network_to_format(to_format: str) -> Dict[str, Any]:
     """Export the current network to a power system case format via powerio.
 
-    Converts the loaded network to MATPOWER tables and serializes them with
-    powerio. to_format is a powerio format name: matpower (m),
-    powermodels-json (pm), egret-json (egret), psse (raw), powerworld (aux).
-    powerio is a core dependency, so this is always available.
+    Converts the loaded network to PYPOWER tables, wraps the balanced network
+    in a PowerIO module, and emits the requested format. powerio is a core
+    dependency, so this is always available.
 
     Args:
         to_format: Target format name
 
     Returns:
-        Dict with status, the exported case `text`, and fidelity `warnings`
-        listing anything the target format could not represent
+        Dict with status, the exported case `text`, and structured
+        `diagnostics`
     """
     logger.info(f"Exporting network via powerio to format: {to_format}")
     try:
@@ -447,13 +416,22 @@ def export_network_to_format(to_format: str) -> Dict[str, Any]:
         from pandapower.converter.pypower.to_ppc import to_ppc
 
         ppc = to_ppc(net, init="flat")
-        case = powerio.parse_str(_ppc_to_matpower_text(ppc), "matpower")
-        conv = case.to_format(to_format)
+        network = powerio.from_ppc(ppc)
+        module = powerio.PioModule.from_value(network)
+        conversion = module.emit(to_format)
+        diagnostics = diagnostic_records(
+            module.diagnostics,
+            conversion.diagnostics,
+        )
     except RuntimeError as re:
         return {"status": "error", "message": str(re)}
     except Exception as e:
         return {"status": "error", "message": f"Failed to export network: {str(e)}"}
-    return {"status": "success", "text": conv.text, "warnings": list(conv.warnings)}
+    return {
+        "status": "success",
+        "text": conversion.text,
+        "diagnostics": list(diagnostics),
+    }
 
 
 if __name__ == "__main__":

--- a/pandapower/requirements.txt
+++ b/pandapower/requirements.txt
@@ -1,3 +1,3 @@
 pandapower
 mcp>=2,<3
-powerio[mcp,matrix]>=0.9.0,<1
+powerio[mcp,matrix]>=1.0.0,<2

--- a/powermcp/README.md
+++ b/powermcp/README.md
@@ -19,9 +19,10 @@ pip install powermcp
 ```
 
 The base install includes **pandapower**, **PyPSA**, and the canonical **PowerIO**
-conversion server. PowerIO `.pio.json` packages can be passed directly to the
-solver import tools, with explicit operating-point or study-commit selection
-when a package contains stored state data. Everything else is opt-in via an extra:
+conversion server. Static PowerIO `.pio.json` modules can be passed directly to
+the solver import tools. Collections must first be discovered with PowerIO
+`list_states` and materialized with `export_state`. Everything else is opt-in
+via an extra:
 
 ```bash
 pip install "powermcp[psse]"            # one tool
@@ -44,6 +45,7 @@ pip install "powermcp[all]"             # everything
 | `surge` | surge | **Python 3.12–3.14 only** |
 | `hope` | HOPE | + needs Julia at runtime |
 | `genx` | GenX | + needs a GenX.jl checkout; case submission needs SLURM `sbatch` |
+| `tellegen` | Tellegen | build `tellegen-cli` and configure `tellegen.binary` |
 | `ltspice` | LTSpice | executable **auto-detected** (override with `ltspice.exe`) |
 | `powerworld` | PowerWorld | needs licensed Simulator (COM); extra also installs `numba` (required by esa 1.3.5) |
 | `psse`, `pslf`, `powerfactory` | PSS/E, PSLF, PowerFactory | engine loaded from a configured local path |
@@ -101,7 +103,7 @@ powermcp config set <tool>.<key> <path>  # set one path
 powermcp --version
 ```
 
-### Closed-source tool paths
+### Local tool paths
 
 These are stored in `~/.powermcp/config.toml` (captured by the wizard, or set manually):
 
@@ -112,6 +114,7 @@ powermcp config set ltspice.exe     "C:\Program Files\ADI\LTspice\LTspice.exe"
 powermcp config set pslf.python_lib "C:\Program Files\GE PSLF\PSLF_PYTHON"
 powermcp config set powerfactory.python_path "...\DIgSILENT\PowerFactory 2024\Python\3.11"
 powermcp config set hope.repo_root  "C:\src\HOPE"
+powermcp config set tellegen.binary "/path/to/tellegen/target/release/tellegen"
 ```
 
 Resolution order for each key is **environment variable** (`POWERMCP_PSSE_BIN`, …) →
@@ -229,6 +232,7 @@ for Claude Desktop without `pip install`:
 ```bash
 python pandapower/panda_mcp.py
 python PSSE/psse_mcp.py     # uses ~/.powermcp/config.toml if present, else legacy paths
+python tellegen/tellegen_mcp.py  # needs POWERMCP_TELLEGEN_BINARY
 ```
 
 ---

--- a/powermcp/registry.py
+++ b/powermcp/registry.py
@@ -8,8 +8,8 @@ whether it is Windows-only, and which local software paths it needs captured in
 
 from __future__ import annotations
 
-import importlib.resources as resources
 from dataclasses import dataclass, field
+from importlib import resources
 from pathlib import Path
 
 # In an editable install or a raw git checkout, the powermcp package lives at
@@ -87,7 +87,7 @@ class Tool:
 # Tools whose path is genuinely Windows-only commercial software.
 _W = True
 
-TOOLS: dict[str, "Tool"] = {
+TOOLS: dict[str, Tool] = {
     t.name: t
     for t in (
         # ---- CORE (always installed) ----
@@ -151,7 +151,19 @@ TOOLS: dict[str, "Tool"] = {
             "powerio", "PowerIO", "open-source", windows_only=False, extra=None,
             server_dir=None, run_kind="package", module="powerio.mcp",
             probe="powerio",
-            notes="Format-neutral conversion, matrices, and auditable .pio.json packages. Its canonical MCP server owns package operations; pandapower, PyPSA, Egret, and ANDES resolve package states only when importing into a solver.",
+            notes="Native interchange, diagnostics, matrices, lowerings, and auditable .pio.json modules. Its MCP server owns module and collection operations; solver adapters accept exported static cases.",
+        ),
+        Tool(
+            "tellegen", "Tellegen", "open-source", windows_only=False,
+            extra="tellegen", server_dir="tellegen", run_kind="script",
+            entry_rel="tellegen_mcp.py", probe=None,
+            config_keys=(
+                ConfigKey("binary", "Path to the Tellegen CLI executable", "file"),
+            ),
+            notes=(
+                "DC OPF and capacity planning over PowerIO modules. Build the "
+                "Tellegen CLI separately, then configure its executable path."
+            ),
         ),
         # ---- CLOSED-SOURCE / VENDOR ----
         Tool(
@@ -256,14 +268,14 @@ def install_hint(extra: str | None) -> str:
     return f"pip install powermcp[{extra}]" if extra else "pip install powermcp"
 
 
-def get_tool(name: str) -> "Tool":
+def get_tool(name: str) -> Tool:
     try:
         return TOOLS[name]
     except KeyError:
         raise KeyError(f"unknown tool '{name}'. Known tools: {', '.join(TOOLS)}") from None
 
 
-def all_tools() -> list["Tool"]:
+def all_tools() -> list[Tool]:
     return list(TOOLS.values())
 
 

--- a/powermcp/solver_case.py
+++ b/powermcp/solver_case.py
@@ -1,14 +1,16 @@
-"""Resolve PowerIO inputs into one balanced state for a solver.
+"""Resolve PowerIO inputs into one balanced module for a solver.
 
-PowerIO owns case parsing and the durable ``.pio.json`` package lifecycle.
-PowerMCP owns the point where a concrete network enters one of its solver
-servers.  Keeping that boundary here gives every solver the same validation,
-state-selection, diagnostic, and multiconductor rules without copying them.
+PowerIO owns parsing, stored ``.pio.json`` modules, diagnostics, collection
+discovery, and state export. PowerMCP owns the point where one static balanced
+value crosses into a solver server. Keeping the module at that boundary
+preserves its source, diagnostics, and history until the target format is
+emitted.
 """
 
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -17,198 +19,160 @@ import powerio
 
 from powermcp.sandbox import checked_path, checked_read_tree
 
-_PACKAGE_FORMATS = frozenset(
-    {"package", "pio", "pio-json", "pio_json", "pio-package", "pio_package"}
-)
-
 
 @dataclass(frozen=True)
 class SolverCase:
-    """One validated balanced state ready for a PowerMCP solver."""
+    """One static balanced PowerIO module ready for a solver bridge."""
 
+    module: powerio.PioModule
     network: powerio.BalancedNetwork
-    warnings: tuple[str, ...] = ()
-    package: dict[str, Any] | None = None
+    diagnostics: tuple[dict[str, Any], ...] = ()
 
 
-def _format_token(value: str | None) -> str | None:
-    return value.strip().lower().replace("_", "-") if value is not None else None
+def _source_span_record(span: Any) -> dict[str, Any]:
+    if isinstance(span, dict):
+        return dict(span)
+    return {
+        "source": str(span.source),
+        "byte_start": int(span.byte_start),
+        "byte_end": int(span.byte_end),
+    }
 
 
-def _package_document(text: str) -> dict[str, Any] | None:
-    """Return the parsed document only when ``text`` identifies a package."""
-    try:
-        value = json.loads(text)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(value, dict):
-        return None
-    if value.get("model_kind") not in ("balanced", "multiconductor"):
-        return None
-    return value if isinstance(value.get("model"), dict) else None
+def diagnostic_record(item: Any) -> dict[str, Any]:
+    """Convert a PowerIO diagnostic to its JSON safe structured form."""
+    if isinstance(item, dict):
+        return dict(item)
+    record: dict[str, Any] = {
+        "code": str(item.code),
+        "severity": str(item.severity),
+        "message": str(item.message),
+    }
+    for name in ("id", "target", "suggested_action"):
+        value = getattr(item, name, None)
+        if value is not None:
+            record[name] = str(value)
+    related = list(getattr(item, "related", ()) or ())
+    if related:
+        record["related"] = [str(value) for value in related]
+    spans = list(getattr(item, "spans", ()) or ())
+    if spans:
+        record["spans"] = [_source_span_record(span) for span in spans]
+    details = getattr(item, "details", None)
+    if details:
+        record["details"] = dict(details)
+    return record
 
 
-def _diagnostic_messages(items: Any) -> tuple[str, ...]:
-    messages = []
-    for item in items if isinstance(items, list) else []:
-        if not isinstance(item, dict) or item.get("severity") != "warning":
-            continue
-        code = item.get("code")
-        message = item.get("message")
-        if code and message:
-            messages.append(f"{code}: {message}")
-        elif message:
-            messages.append(str(message))
-    return tuple(messages)
+def diagnostic_records(*groups: Iterable[Any]) -> tuple[dict[str, Any], ...]:
+    """Combine diagnostic groups in order and remove exact duplicates."""
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for group in groups:
+        for item in group:
+            record = diagnostic_record(item)
+            key = json.dumps(record, sort_keys=True, separators=(",", ":"))
+            if key not in seen:
+                seen.add(key)
+                records.append(record)
+    return tuple(records)
 
 
-def _unique_messages(*groups: Any) -> tuple[str, ...]:
-    return tuple(
-        dict.fromkeys(
-            str(message)
-            for group in groups
-            for message in (group or ())
-            if message
+def bridge_diagnostic(code: str, message: str) -> dict[str, Any]:
+    """Create one structured PowerMCP bridge diagnostic."""
+    return {"code": code, "severity": "warning", "message": message}
+
+
+def powerio_error_response(
+    error: powerio.PowerIOError,
+    *,
+    prefix: str | None = None,
+) -> dict[str, str]:
+    """Keep a PowerIO error code in a PowerMCP error envelope."""
+    message = str(error)
+    if prefix:
+        message = f"{prefix}: {message}"
+    return {"status": "error", "code": str(error.code), "message": message}
+
+
+def _available_positions(positions: list[int]) -> str:
+    """Describe time positions without flooding an MCP error response."""
+    if len(positions) <= 20:
+        return str(positions)
+    if all(
+        position == positions[0] + offset for offset, position in enumerate(positions)
+    ):
+        return f"{positions[0]}..{positions[-1]} ({len(positions)} available)"
+    preview = ", ".join(str(position) for position in positions[:10])
+    return f"[{preview}, ...] ({len(positions)} available; last {positions[-1]})"
+
+
+def _available_scenarios(scenarios: list[str]) -> str:
+    if len(scenarios) <= 20:
+        return repr(scenarios)
+    preview = ", ".join(repr(scenario) for scenario in scenarios[:10])
+    return f"[{preview}, ...] ({len(scenarios)} available)"
+
+
+def _selection_required(inventory: dict[str, Any]) -> ValueError:
+    keyed_by = inventory.get("keyed_by")
+    if keyed_by == "time_position":
+        rows = inventory.get("time_points")
+        positions = []
+        if isinstance(rows, list):
+            positions = [
+                row["position"]
+                for row in rows
+                if isinstance(row, dict) and isinstance(row.get("position"), int)
+            ]
+        return ValueError(
+            "the PowerIO module contains a time series; call PowerIO list_states, "
+            "then export_state with time_position from "
+            f"{_available_positions(positions)} before passing it to a solver"
         )
+    if keyed_by == "scenario":
+        rows = inventory.get("scenarios")
+        scenarios = []
+        if isinstance(rows, list):
+            scenarios = [
+                str(row["id"])
+                for row in rows
+                if isinstance(row, dict) and row.get("id") is not None
+            ]
+        return ValueError(
+            "the PowerIO module contains a scenario set; call PowerIO list_states, "
+            "then export_state with scenario from "
+            f"{_available_scenarios(scenarios)} before passing it to a solver"
+        )
+    return ValueError(
+        "the PowerIO module contains a collection; call PowerIO list_states and "
+        "export_state before passing it to a solver"
     )
 
 
-def _operating_point_indexes(points: Any) -> list[int]:
-    if not isinstance(points, dict) or not isinstance(points.get("points"), list):
-        return []
-    return [
-        point["index"]
-        for point in points["points"]
-        if isinstance(point, dict) and isinstance(point.get("index"), int)
-    ]
+def _resolve_module(module: powerio.PioModule) -> SolverCase:
+    operations = set(module.inspect().get("operations", ()))
+    if "list_states" in operations:
+        raise _selection_required(module.list_states())
 
-
-def _study_commit_indexes(study: Any) -> list[int]:
-    if not isinstance(study, dict) or not isinstance(study.get("commits"), list):
-        return []
-    return list(range(len(study["commits"])))
-
-
-def _available_indexes(indexes: list[int]) -> str:
-    """Describe state choices without flooding an MCP error response."""
-    if len(indexes) <= 20:
-        return str(indexes)
-    if all(
-        index == indexes[0] + offset for offset, index in enumerate(indexes)
-    ):
-        return f"{indexes[0]}..{indexes[-1]} ({len(indexes)} available)"
-    preview = ", ".join(str(index) for index in indexes[:10])
-    return f"[{preview}, ...] ({len(indexes)} available; last {indexes[-1]})"
-
-
-def _index_inventory(indexes: list[int]) -> dict[str, Any]:
-    inventory: dict[str, Any] = {
-        "count": len(indexes),
-        "first": indexes[0],
-        "last": indexes[-1],
-    }
-    if len(indexes) <= 20:
-        inventory["indexes"] = indexes
-    return inventory
-
-
-def _validated(package: powerio.Package) -> dict[str, Any]:
-    # A serialized package carries the validation summary from the time it was
-    # written. Recompute it after deserialization so a modified model cannot
-    # keep a stale ``status: ok`` and cross the solver boundary unchecked.
-    package.validate()
-    validation = package.validation()
-    if validation.get("status") in ("error", "fatal"):
+    if module.kind == "multiconductor_network":
         raise ValueError(
-            "the PowerIO package fails validation; inspect it with "
-            "the canonical PowerIO diagnostics tool before solving it"
+            "this solver requires a balanced network; transform the module with "
+            "PowerIO PioModule.to_balanced() first"
         )
-    return validation
-
-
-def _resolve_package(
-    package: powerio.Package,
-    *,
-    original_document: dict[str, Any] | None,
-    input_warnings: tuple[str, ...],
-    operating_point: int | None,
-    study_commit: int | None,
-) -> SolverCase:
-    """Validate and reduce a package to the one state a solver can consume."""
-    if operating_point is not None and study_commit is not None:
-        raise ValueError("choose either operating_point or study_commit, not both")
-    if operating_point is not None and operating_point < 0:
-        raise ValueError("operating_point must be zero or greater")
-    if study_commit is not None and study_commit < 0:
-        raise ValueError("study_commit must be zero or greater")
-
-    _validated(package)
-    if package.model_kind != "balanced":
+    if module.kind != "balanced_network":
         raise ValueError(
-            "this solver requires a balanced package; explicitly lower the "
-            "package with PowerIO Package.lower_multiconductor_to_balanced() first"
+            "this solver requires a balanced network; the PowerIO module carries "
+            f"{module.kind!r}"
         )
-
-    points = package.operating_points()
-    study = package.study()
-    point_indexes = _operating_point_indexes(points)
-    commit_indexes = _study_commit_indexes(study)
-    selection: dict[str, Any] | None = None
-    if operating_point is not None:
-        if not point_indexes:
-            raise ValueError("the .pio.json package has no operating points")
-        package = package.materialize_operating_point(operating_point)
-        selection = {"kind": "operating_point", "index": operating_point}
-    elif study_commit is not None:
-        if not commit_indexes:
-            raise ValueError("the .pio.json package has no study commits")
-        package = package.materialize_study_commit(study_commit)
-        selection = {"kind": "study_commit", "index": study_commit}
-        if isinstance(study, dict) and study.get("base_operating_point") is not None:
-            selection["base_operating_point"] = study["base_operating_point"]
-    elif point_indexes or commit_indexes:
-        choices = []
-        if point_indexes:
-            choices.append(f"operating_point from {_available_indexes(point_indexes)}")
-        if commit_indexes:
-            choices.append(f"study_commit from {_available_indexes(commit_indexes)}")
-        raise ValueError(
-            "the .pio.json package contains stored solver state data; select "
-            + " or ".join(choices)
-        )
-
-    validation = _validated(package)
-    network = package.as_balanced()
-    package_context: dict[str, Any] | None = None
-    if original_document is not None:
-        source_maps = original_document.get("source_maps")
-        package_context = {
-            "powerio_version": original_document.get("powerio_version"),
-            "model_kind": package.model_kind,
-            "producer": original_document.get("producer"),
-            "origin": original_document.get("origin"),
-            "validation": validation,
-            "source_map_entries": (
-                len(source_maps) if isinstance(source_maps, list) else 0
-            ),
-        }
-        if original_document.get("package_id") is not None:
-            package_context["package_id"] = original_document["package_id"]
-        if point_indexes:
-            package_context["operating_points"] = _index_inventory(point_indexes)
-        if commit_indexes:
-            package_context["study_commits"] = _index_inventory(commit_indexes)
-        if selection is not None:
-            package_context["materialized"] = selection
+    network = module.value
+    if not isinstance(network, powerio.BalancedNetwork):
+        raise TypeError("PowerIO returned a non-balanced value for balanced_network")
 
     return SolverCase(
-        network,
-        _unique_messages(
-            input_warnings,
-            network.read_warnings,
-            _diagnostic_messages(package.diagnostics()),
-        ),
-        package_context,
+        module=module,
+        network=network,
+        diagnostics=diagnostic_records(module.diagnostics),
     )
 
 
@@ -217,59 +181,27 @@ def resolve_solver_case(
     file_path: str | None = None,
     network_json: str | None = None,
     source_format: str | None = None,
-    operating_point: int | None = None,
-    study_commit: int | None = None,
 ) -> SolverCase:
-    """Resolve exactly one file or JSON input into a validated solver case.
+    """Resolve exactly one file or JSON input into a static balanced module.
 
-    Ordinary case files are wrapped with :class:`powerio.Package`, so the same
-    PowerIO 0.9 validation and diagnostics run for file and package inputs.
-    Package metadata is returned only when the caller supplied a package.
+    ``network_json`` accepts any JSON input recognized by PowerIO, including
+    balanced model JSON and stored modules. Collection modules must be exported
+    to a static module through PowerIO before they cross the solver boundary.
+    PowerIO owns format detection, upgrades, validation, and typed errors.
     """
     if (file_path is None) == (network_json is None):
         raise ValueError("provide exactly one of file_path or network_json")
 
-    original_document: dict[str, Any] | None = None
-    input_warnings: tuple[str, ...] = ()
     if file_path is not None:
-        # A directory format (for example PyPSA CSV) can contain many files.
-        # Checking only the directory itself would still permit a descendant
-        # symlink to escape the operator's configured MCP roots.
         file_path = checked_path(file_path, purpose="file_path")
-        candidate = Path(file_path)
-        if candidate.is_dir():
+        if Path(file_path).is_dir():
             file_path = checked_read_tree(file_path, purpose="file_path")
-            candidate = Path(file_path)
-        explicit_package = _format_token(source_format) in _PACKAGE_FORMATS
-        if explicit_package or candidate.suffix.lower() == ".json":
-            try:
-                text = candidate.read_text(encoding="utf-8")
-            except OSError:
-                if explicit_package:
-                    raise
-            else:
-                original_document = _package_document(text)
-                if original_document is not None:
-                    package = powerio.Package.from_json(text)
-                elif explicit_package:
-                    raise ValueError("input is not a .pio.json package")
-        if original_document is None:
-            package = powerio.Package.from_file(file_path, source_format)
+        module = powerio.parse_file(file_path, format=source_format)
     else:
-        original_document = _package_document(network_json)
-        if original_document is not None:
-            package = powerio.Package.from_json(network_json)
-        else:
-            if operating_point is not None or study_commit is not None:
-                raise ValueError("state selectors are only valid for .pio.json packages")
-            network = powerio.from_json(network_json)
-            input_warnings = tuple(network.read_warnings)
-            package = powerio.Package.from_balanced(network)
+        module = powerio.parse_text(
+            network_json,
+            format=source_format,
+            name="solver-input.json",
+        )
 
-    return _resolve_package(
-        package,
-        original_document=original_document,
-        input_warnings=input_warnings,
-        operating_point=operating_point,
-        study_commit=study_commit,
-    )
+    return _resolve_module(module)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 [project]
 name = "powermcp"
 version = "0.3.0"
-description = "MCP servers for power-system software (PowerWorld, OpenDSS, PSS/E, pandapower, PyPSA, and more)"
+description = "MCP servers for PowerIO, Tellegen, pandapower, PyPSA, and other power system tools"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
@@ -44,12 +44,12 @@ dependencies = [
     # imports the latter, so the floor tracks that, not just powerio's own
     # [mcp] extra requirement (mcp>=2,<3).
     "mcp>=2,<3",
-    # powerio supplies the conversion server, package model, native solver
-    # writers, shared JSON transports, and path policy used by the bridges.
-    # PowerMCP uses APIs introduced in powerio 0.9.0.
+    # powerio supplies the conversion server, module model, native solver
+    # writers, structured diagnostics, and path policy used by the bridges.
+    # PowerMCP uses the final 1.0 module and MCP APIs.
     # powerio ships the server itself (`python -m powerio.mcp`), so this repo
     # bundles no copy of it and `powermcp run powerio` runs powerio's.
-    "powerio[mcp,matrix]>=0.9.0,<1",
+    "powerio[mcp,matrix]>=1.0.0,<2",
     # CLI / installer toolkit:
     # packaging: the doctor compares an installed version against the floor
     # declared right here, so it has to read a version specifier.
@@ -75,6 +75,8 @@ hope       = ["PyYAML>=6.0"]
 # already arrive with the core install via pandapower, so the extra exists to
 # make the dependency explicit rather than to add anything new.
 genx       = ["matplotlib>=3.7", "pandas>=2.0,<3"]
+# PowerMCP ships the adapter. Build and configure the Rust CLI separately.
+tellegen   = ["jsonschema>=4,<5"]
 # powerio moved to core `dependencies`; the extra is gone (a bare
 # `pip install powermcp` now always provides the conversion server).
 # --- closed-source / vendor tool engines ---
@@ -103,7 +105,7 @@ powerfactory = ["numpy>=1.26", "matplotlib>=3.8", "pandas>=1.5"]  # vendor `powe
 # powermcp[plexosdb]` until that's resolved upstream.
 plexosdb   = ["r2x-plexos>=0.3.0", "r2x-plexos-to-sienna>=0.1.0", "r2x-sienna>=0.4.0"]
 # --- convenience groups ---
-opensource = ["powermcp[andes]", "powermcp[egret]", "powermcp[opendss]", "powermcp[ltspice]", "powermcp[surge]", "powermcp[hope]", "powermcp[genx]"]
+opensource = ["powermcp[andes]", "powermcp[egret]", "powermcp[opendss]", "powermcp[ltspice]", "powermcp[surge]", "powermcp[hope]", "powermcp[genx]", "powermcp[tellegen]"]
 windows    = ["powermcp[pscad-windows]", "powermcp[powerworld]", "powermcp[powerfactory]", "powermcp[psse]", "powermcp[pslf]"]
 all        = ["powermcp[opensource]", "powermcp[powerworld]", "powermcp[powerfactory]", "powermcp[pscad-windows]", "powermcp[psse]", "powermcp[pslf]", "powermcp[plexosdb]"]
 
@@ -138,6 +140,7 @@ packages = ["powermcp"]
 "PowerFactory" = "powermcp/_servers/PowerFactory"
 "LTSpice"      = "powermcp/_servers/LTSpice"
 "PLEXOSDB"     = "powermcp/_servers/PLEXOSDB"
+"tellegen"     = "powermcp/_servers/tellegen"
 
 # The sdist must contain the server dirs at the repo root so that the
 # build-wheel-from-sdist step (used by `python -m build`) can force-include them.
@@ -146,10 +149,11 @@ include = [
     "powermcp",
     "pandapower", "PyPSA", "ANDES", "Egret", "surge", "OpenDSS", "HOPE",
     "PSCAD", "PSSE", "PSLF", "PowerWorld", "PowerFactory", "LTSpice", "PLEXOSDB",
-    "GenX",
+    "GenX", "tellegen",
     "README.md", "LICENSE", "pyproject.toml",
 ]
 exclude = [
     "**/__pycache__", "**/*.py[cod]", "**/.pytest_cache",
+    ".venv*", "**/.venv*", ".uv-build-cache", "**/.uv-build-cache",
     "PSCAD/tests", "HOPE/tests", "PLEXOSDB/tests",
 ]

--- a/surge/requirements.txt
+++ b/surge/requirements.txt
@@ -1,3 +1,3 @@
 surge-py>=0.1.5
 mcp>=2,<3
-powerio[mcp,matrix]>=0.9.0,<1
+powerio[mcp,matrix]>=1.0.0,<2

--- a/surge/surge_mcp.py
+++ b/surge/surge_mcp.py
@@ -933,6 +933,7 @@ def export_tables(output_dir: str) -> Dict[str, Any]:
         net = _require_network()
 
         def write_tables(staging: str) -> Dict[str, Any]:
+            os.makedirs(staging)
             written: List[str] = []
             rows: Dict[str, int] = {}
             for fname, accessor in (

--- a/tellegen/README.md
+++ b/tellegen/README.md
@@ -1,0 +1,36 @@
+# Tellegen MCP server
+
+The adapter passes stored PowerIO modules to a configured Tellegen CLI. The
+CLI contract supplies every public request and response schema.
+
+## Tools
+
+`capabilities` returns Tellegen's formulation and differentiation capability
+records.
+
+`solve_dc_opf` accepts a `powerio.module/1` object containing a balanced network
+or DC OPF instance. Its `results` field is the `dc_opf_solution` module returned
+by Tellegen.
+
+`plan_capacity` accepts the `plan_request` in Tellegen's contract: a PowerIO
+module and `CapacityPlanSpec`. It uses implicit gradients to choose capacity
+increase trials and exact DC OPF solves to accept a bounded proposal. The search
+is heuristic. Its `results` field contains the `CapacityPlanOutcome` and exact
+solution module for the amended instance. The input module is unchanged.
+
+PowerMCP checks requests, responses, and the configured CLI against the bundled
+`tellegen.cli/1` contract. A mismatched CLI is refused before an OPF command
+runs.
+
+## Build and configure Tellegen
+
+Build `tellegen-cli` from a Tellegen checkout:
+
+```bash
+cargo build --release --locked -p tellegen-cli
+powermcp config set tellegen.binary /path/to/tellegen/target/release/tellegen
+```
+
+`POWERMCP_TELLEGEN_BINARY` overrides the saved path. Run the server with
+`powermcp run tellegen`. From a PowerMCP checkout, you can also run
+`python tellegen/tellegen_mcp.py` when the environment variable is set.

--- a/tellegen/tellegen-contract.json
+++ b/tellegen/tellegen-contract.json
@@ -1,0 +1,30780 @@
+{
+  "contract": "tellegen.cli/1",
+  "powerio_version": "1.0.0",
+  "schemas": {
+    "capabilities_response": {
+      "$defs": {
+        "Bound": {
+          "description": "A min or max bound, e.g. the lower/upper voltage-magnitude limit.",
+          "enum": [
+            "Min",
+            "Max"
+          ],
+          "type": "string"
+        },
+        "CostTerm": {
+          "description": "Which generation-cost coefficient: the quadratic `cq` or the linear `cl`.",
+          "enum": [
+            "Quadratic",
+            "Linear"
+          ],
+          "type": "string"
+        },
+        "End": {
+          "description": "Which end of a branch a flow is measured at.",
+          "enum": [
+            "From",
+            "To"
+          ],
+          "type": "string"
+        },
+        "GB": {
+          "description": "Conductance `g` or susceptance `b`, the real/imaginary parts of an admittance.",
+          "enum": [
+            "Conductance",
+            "Susceptance"
+          ],
+          "type": "string"
+        },
+        "Operand": {
+          "description": "What a sensitivity is taken *of*, named for the physical power quantity rather\nthan a formulation's internal variable. The orthogonal sub-axes (active/reactive,\nfrom/to, voltage representation) are visible to the type system; each formulation\nmaps a request to its own KKT rows or returns [`SensError::Unsupported`].\n\nThe dialects fold into one vocabulary: DC `Angle` is `Voltage(Angle)`, the conic\nsquared magnitude `w` is `Voltage(Squared)`, the nodal price is `Price(Active)`.",
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "description": "Nodal-balance dual (the LMP for active power, the reactive price for\nreactive), per bus.",
+              "properties": {
+                "Price": {
+                  "$ref": "#/$defs/Power"
+                }
+              },
+              "required": [
+                "Price"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Generator dispatch `pg` / `qg`, per generator.",
+              "properties": {
+                "Dispatch": {
+                  "$ref": "#/$defs/Power"
+                }
+              },
+              "required": [
+                "Dispatch"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Branch active/reactive flow at the from/to end, per branch.",
+              "properties": {
+                "Flow": {
+                  "properties": {
+                    "end": {
+                      "$ref": "#/$defs/End"
+                    },
+                    "power": {
+                      "$ref": "#/$defs/Power"
+                    }
+                  },
+                  "required": [
+                    "power",
+                    "end"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "Flow"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Bus voltage in the formulation's representation (`vm` / `va` / `w` / `wr` /\n`wi`), per bus.",
+              "properties": {
+                "Voltage": {
+                  "$ref": "#/$defs/VoltageKind"
+                }
+              },
+              "required": [
+                "Voltage"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "Parameter": {
+          "description": "What a sensitivity is taken *with respect to* — the parameter whose hand-derived\n`dK/dp` column drives the solve.",
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "description": "Bus active/reactive demand `pd` / `qd`, per bus.",
+              "properties": {
+                "Demand": {
+                  "$ref": "#/$defs/Power"
+                }
+              },
+              "required": [
+                "Demand"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Generation cost coefficient, per generator.",
+              "properties": {
+                "Cost": {
+                  "$ref": "#/$defs/CostTerm"
+                }
+              },
+              "required": [
+                "Cost"
+              ],
+              "type": "object"
+            },
+            {
+              "const": "LineLimit",
+              "description": "DC thermal limit `fmax` / AC-conic apparent-power `|S|` limit, per branch.",
+              "type": "string"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Branch series admittance `g` / `b`, per branch.",
+              "properties": {
+                "SeriesAdmittance": {
+                  "$ref": "#/$defs/GB"
+                }
+              },
+              "required": [
+                "SeriesAdmittance"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Bus shunt admittance `gs` / `bs`, per bus.",
+              "properties": {
+                "ShuntAdmittance": {
+                  "$ref": "#/$defs/GB"
+                }
+              },
+              "required": [
+                "ShuntAdmittance"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Voltage-magnitude bound right-hand side (the `w = |V|²` bound), per bus.",
+              "properties": {
+                "VoltageBound": {
+                  "$ref": "#/$defs/Bound"
+                }
+              },
+              "required": [
+                "VoltageBound"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Generator output bound right-hand side (`pmax` / `pmin` / `qmax` / `qmin`),\nper generator.",
+              "properties": {
+                "GenBound": {
+                  "properties": {
+                    "bound": {
+                      "$ref": "#/$defs/Bound"
+                    },
+                    "power": {
+                      "$ref": "#/$defs/Power"
+                    }
+                  },
+                  "required": [
+                    "power",
+                    "bound"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "GenBound"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Transformer tap ratio / phase shift, per branch.",
+              "properties": {
+                "Transformer": {
+                  "$ref": "#/$defs/TapKind"
+                }
+              },
+              "required": [
+                "Transformer"
+              ],
+              "type": "object"
+            },
+            {
+              "const": "Switching",
+              "description": "Branch switching state `sw` in `[0, 1]`, per branch.",
+              "type": "string"
+            }
+          ]
+        },
+        "Power": {
+          "description": "Active or reactive power. The orthogonal P/Q sub-axis shared by prices,\ndispatch, flows, and demand.",
+          "enum": [
+            "Active",
+            "Reactive"
+          ],
+          "type": "string"
+        },
+        "Problem": {
+          "description": "Which problem to solve. The convex/power flow solve paths, as the lowercase JSON\ntags `\"dcpf\"`/`\"dcopf\"`/`\"acpf\"`/`\"socwr\"`. A plain (not internally tagged) enum\nso a request that omits it defaults to [`DcOpf`](Problem::DcOpf), and `{}` is a\nvalid base-case DC OPF request.\n\nThe `\"acopf\"` tag (full nonlinear AC OPF) is retained for wire-format stability\nbut is not solved by this build: [`capabilities_json`] reports it unavailable and\nrequesting it returns a clean `Err`.",
+          "oneOf": [
+            {
+              "const": "dcpf",
+              "description": "DC power flow: angles and flows at the fixed generator setpoints. No prices,\nno dispatch, no sensitivity.",
+              "type": "string"
+            },
+            {
+              "const": "dcopf",
+              "description": "DC OPF: the LMP / dispatch / flow workhorse. Differentiable via the DC KKT.",
+              "type": "string"
+            },
+            {
+              "const": "acpf",
+              "description": "AC polar Newton power flow. Voltages and nodal injections. Differentiable\nvia the AC Newton system.",
+              "type": "string"
+            },
+            {
+              "const": "socwr",
+              "description": "SOCWR (Jabr) conic relaxation of AC OPF. Differentiable via the conic KKT.",
+              "type": "string"
+            },
+            {
+              "const": "acopf",
+              "description": "Full nonlinear AC OPF. Not available in this build (the dispatch errors\ncleanly); the tag is kept so the JSON contract stays stable.",
+              "type": "string"
+            }
+          ]
+        },
+        "ProblemCaps": {
+          "description": "What one formulation can do in this binary: whether it is built, the named\noutput blocks it populates, and (when the `sensitivity` feature is on) the\noperands and parameters it supports. Any (operand, parameter) pair drawn from\nthe two lists is a valid sensitivity cell, so the UI takes the cross product.",
+          "properties": {
+            "available": {
+              "description": "Built in this binary (acopf is always `false`; it is not in this build).",
+              "type": "boolean"
+            },
+            "blocks": {
+              "description": "Output blocks this formulation fills, e.g. `[\"lmp\",\"va\",\"flows\",\"dispatch\"]`.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "formulation": {
+              "$ref": "#/$defs/Problem"
+            },
+            "operands": {
+              "items": {
+                "$ref": "#/$defs/Operand"
+              },
+              "type": "array"
+            },
+            "parameters": {
+              "items": {
+                "$ref": "#/$defs/Parameter"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "formulation",
+            "available",
+            "blocks",
+            "operands",
+            "parameters"
+          ],
+          "type": "object"
+        },
+        "TapKind": {
+          "description": "A transformer control: the tap ratio or the phase-shift angle.",
+          "enum": [
+            "Ratio",
+            "PhaseShift"
+          ],
+          "type": "string"
+        },
+        "VoltageKind": {
+          "description": "How a voltage operand is represented: polar (`Magnitude`, `Angle`) for the AC\npower flow, or the W-space lift (`Squared` = `|V|²`, `ProductReal` = `Re(Vi Vj*)`,\n`ProductImag` = `Im(Vi Vj*)`) for the conic relaxation.",
+          "enum": [
+            "Magnitude",
+            "Angle",
+            "Squared",
+            "ProductReal",
+            "ProductImag"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "items": {
+        "$ref": "#/$defs/ProblemCaps"
+      },
+      "title": "Array_of_ProblemCaps",
+      "type": "array"
+    },
+    "capacity_plan_spec": {
+      "$defs": {
+        "BusId": {
+          "description": "A source bus ID, preserved from the input format.\n\nMATPOWER IDs are 1-based and can contain gaps. They are distinct from the\nzero based dense indices produced by\n[`IndexedNetwork::bus_index`](crate::IndexedNetwork::bus_index). JSON stores\nthis type as an integer.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "BusWeight": {
+          "description": "One bus term of a weighted objective, addressed by PowerIO bus ID.",
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "weight": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "weight"
+          ],
+          "type": "object"
+        },
+        "ImplicitObjective": {
+          "description": "A safe, serializable outer objective over the optimal solve. Every\nvariant is a scalar with a well defined gradient through the KKT system;\nnew observables (generation, line loading, operating cost) add variants\nrather than accepting code.",
+          "oneOf": [
+            {
+              "description": "`Phi = Σ_b w_b · lmp_b` over the selected buses. Positive weights\nmake the search look for capacity increases that lower the weighted\nmarginal value of demand.",
+              "properties": {
+                "kind": {
+                  "const": "weighted_lmp",
+                  "type": "string"
+                },
+                "weights": {
+                  "items": {
+                    "$ref": "#/$defs/BusWeight"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "kind",
+                "weights"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "The bounded decision space and search limits of one planning run. All\npower quantities are MW.",
+      "properties": {
+        "budget_mw": {
+          "description": "Total intervention budget: `Σ_e increase_e` never exceeds it.",
+          "format": "double",
+          "type": "number"
+        },
+        "candidates": {
+          "description": "Candidate branches whose thermal ratings the search may increase.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "exact_solve_budget": {
+          "description": "Maximum number of exact OPF solves, including the baseline and every\naccepted or rejected trial.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "increment_mw": {
+          "description": "Discrete capacity increase considered in one trial.",
+          "format": "double",
+          "type": "number"
+        },
+        "max_changed_lines": {
+          "description": "Positive cardinality bound over the final proposal, not one iteration.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "max_increase_per_branch_mw": {
+          "description": "Maximum cumulative increase for one branch.",
+          "format": "double",
+          "type": "number"
+        },
+        "objective": {
+          "$ref": "#/$defs/ImplicitObjective"
+        }
+      },
+      "required": [
+        "objective",
+        "candidates",
+        "max_increase_per_branch_mw",
+        "budget_mw",
+        "increment_mw",
+        "max_changed_lines",
+        "exact_solve_budget"
+      ],
+      "title": "CapacityPlanSpec",
+      "type": "object"
+    },
+    "plan_request": {
+      "$defs": {
+        "AcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "constraints": {
+              "$ref": "#/$defs/ActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1"
+            }
+          },
+          "required": [
+            "network",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "AcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_limit_multiplier": {
+              "description": "Nonnegative multiplier on the from-terminal apparent power bound.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_from_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_limit_multiplier": {
+              "description": "Nonnegative multiplier on the to-terminal apparent power bound.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_to_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_power_marginal": {
+              "description": "Optimal objective derivative per added MW of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_active_price": {
+              "description": "Read only 0.10 name for the active demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_reactive_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_reactive_power_marginal": {
+              "description": "Optimal objective derivative per added MVAr of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_reactive_price": {
+              "description": "Read only 0.10 name for the reactive demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_reactive_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/AcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_magnitude",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "bus_reactive_injection",
+            "branch_from_active_flow",
+            "branch_from_reactive_flow",
+            "branch_to_active_flow",
+            "branch_to_reactive_flow",
+            "generator_active_power",
+            "generator_reactive_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "AcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network"
+          ],
+          "type": "object"
+        },
+        "AcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_reactive_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_dispatch": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeneratorDispatchV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "instance": {
+              "$ref": "#/$defs/AcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_magnitude",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "bus_reactive_injection",
+            "branch_from_active_flow",
+            "branch_from_reactive_flow",
+            "branch_to_active_flow",
+            "branch_to_reactive_flow"
+          ],
+          "type": "object"
+        },
+        "AcScucInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "inputs": {
+              "$ref": "#/$defs/ScucInputs",
+              "description": "The complete SCUC inputs, in the calculation crate's own\nserialization, typed through this document's schema."
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network",
+            "inputs"
+          ],
+          "type": "object"
+        },
+        "AcScucSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "device_outputs": {
+              "$ref": "#/$defs/ScucDeviceOutputsV1"
+            },
+            "instance": {
+              "$ref": "#/$defs/AcScucInstanceV1"
+            },
+            "network_outputs": {
+              "$ref": "#/$defs/ScucNetworkOutputsV1"
+            },
+            "objective": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "network_outputs",
+            "device_outputs"
+          ],
+          "type": "object"
+        },
+        "ActiveConstraints": {
+          "description": "The active constraint families of a balanced OPF instance.",
+          "properties": {
+            "angle_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Branch angle difference bounds."
+            },
+            "generator_capability": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Generator capability bounds (active and reactive limits)."
+            },
+            "thermal_limits": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Branch thermal limits."
+            },
+            "voltage_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Bus voltage magnitude bounds."
+            }
+          },
+          "required": [
+            "generator_capability",
+            "voltage_bounds",
+            "thermal_limits",
+            "angle_bounds"
+          ],
+          "type": "object"
+        },
+        "ActivePowerReference": {
+          "enum": [
+            "P_AVAILABLE",
+            "P_MAX",
+            "S_MAX"
+          ],
+          "type": "string"
+        },
+        "ActivePowerUnit": {
+          "enum": [
+            "VA_FRACTION",
+            "W"
+          ],
+          "type": "string"
+        },
+        "Area": {
+          "description": "An area record: the area's scheduled net interchange and its swing bus.\n\nThe [`number`](Area::number) matches the `area` field carried on each\n[`Bus`]; this table holds the per-area metadata (the interchange target and\nthe area slack) that the bus number alone can't. Maps to the PSS/E area record\n(`I, ISW, PDES, PTOL, ARNAME`).",
+          "properties": {
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "net_interchange": {
+              "description": "Scheduled net interchange (MW); positive is export out of the area.",
+              "format": "double",
+              "type": "number"
+            },
+            "number": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "slack_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The area swing (slack) bus, or `None` when unset."
+            },
+            "tolerance": {
+              "description": "Interchange tolerance bandwidth (MW).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "number",
+            "net_interchange",
+            "tolerance"
+          ],
+          "type": "object"
+        },
+        "BalancedNetwork": {
+          "description": "A balanced network with stable source bus IDs and separate element tables.\n\n`remote = \"Self\"` turns the derived serde impls into inherent functions;\nthe trait impls beneath the struct route them through [`crate::nonfinite`],\nso a nonfinite float spells as a string on every JSON route.",
+          "properties": {
+            "areas": {
+              "default": [],
+              "description": "Area records: scheduled interchange and per-area swing bus. Distinct from\nthe bare `area` number on each [`Bus`]; this is the area's metadata, which\nevery conversion dropped before. `#[serde(default)]` so older JSON still\ndeserializes.",
+              "items": {
+                "$ref": "#/$defs/Area"
+              },
+              "type": "array"
+            },
+            "base_frequency": {
+              "default": 60.0,
+              "description": "System base frequency in hertz (50 or 60). Threaded through the formats\nthat record it (PSS/E `BASFRQ`, pandapower `f_hz`) and defaulted to\n[`DEFAULT_BASE_FREQUENCY`] for the rest. Load-bearing for any\nreactance↔henry conversion (pandapower line charging) and reported as a\nfidelity loss when a non-default value writes to a format with no\nfrequency field.",
+              "format": "double",
+              "type": "number"
+            },
+            "base_mva": {
+              "format": "double",
+              "type": "number"
+            },
+            "branches": {
+              "items": {
+                "$ref": "#/$defs/Branch"
+              },
+              "type": "array"
+            },
+            "buses": {
+              "items": {
+                "$ref": "#/$defs/Bus"
+              },
+              "type": "array"
+            },
+            "generators": {
+              "items": {
+                "$ref": "#/$defs/Generator"
+              },
+              "type": "array"
+            },
+            "geo": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeoMeta"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "hvdc": {
+              "items": {
+                "$ref": "#/$defs/Hvdc"
+              },
+              "type": "array"
+            },
+            "loads": {
+              "items": {
+                "$ref": "#/$defs/Load"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "shunts": {
+              "items": {
+                "$ref": "#/$defs/Shunt"
+              },
+              "type": "array"
+            },
+            "solver": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SolverParams"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Solver / solution-control metadata when the source carries it, else `None`.\n`#[serde(default)]` so older JSON still deserializes."
+            },
+            "source_format": {
+              "$ref": "#/$defs/SourceFormat"
+            },
+            "storage": {
+              "items": {
+                "$ref": "#/$defs/Storage"
+              },
+              "type": "array"
+            },
+            "switches": {
+              "default": [],
+              "items": {
+                "$ref": "#/$defs/Switch"
+              },
+              "type": "array"
+            },
+            "transformers_3w": {
+              "default": [],
+              "description": "Three-winding transformers, kept as typed records rather than folded into\n`branches`, so a star point and the per-winding data survive a round trip.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes. [`IndexedNetwork`](crate::IndexedNetwork) lowers each\nin-service record into a star bus plus three branches (via\n[`Transformer3W::to_star_expansion`]) before building any matrix, so a\n3-winding transformer does appear in `Y_bus`/connectivity; the canonical\nmodel keeps the typed record for round-trip fidelity.",
+              "items": {
+                "$ref": "#/$defs/Transformer3W"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "base_mva",
+            "buses",
+            "loads",
+            "shunts",
+            "branches",
+            "generators",
+            "storage",
+            "hvdc",
+            "source_format"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkScenarioSetV1": {
+          "additionalProperties": false,
+          "properties": {
+            "scenarios": {
+              "items": {
+                "$ref": "#/$defs/BalancedNetworkScenarioV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "scenarios"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkScenarioV1": {
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "probability": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "value": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "id",
+            "value"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            },
+            "values": {
+              "items": {
+                "$ref": "#/$defs/BalancedNetwork"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "time_points",
+            "values"
+          ],
+          "type": "object"
+        },
+        "BalancedOperatingPointTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "description": "Quantity name → dense columns, the balanced instantaneous vocabulary.",
+              "type": "object"
+            },
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "network",
+            "time_points",
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "Branch": {
+          "properties": {
+            "angmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "angmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "b": {
+              "description": "MATPOWER compatible total line charging susceptance (p.u.). This is the\nlegacy total projection; when [`charging`](Branch::charging) is present,\nper terminal admittance is canonical and this field is compatibility data.",
+              "format": "double",
+              "type": "number"
+            },
+            "charging": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchCharging"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Per terminal shunt admittance (p.u.). If absent, derive symmetric\nsusceptance from [`b`](Branch::b)."
+            },
+            "control": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TransformerControl"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Regulating-transformer control data, when this branch is a transformer\nunder automatic tap or phase control. `None` for lines and for fixed-ratio\ntransformers. `#[serde(default)]` so JSON written before the field existed\nstill deserializes."
+            },
+            "current_ratings": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchCurrentRatings"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Current ratings, when the source distinguishes them from MVA ratings."
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "r": {
+              "description": "Series resistance (p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "rate_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_c": {
+              "format": "double",
+              "type": "number"
+            },
+            "rating_sets": {
+              "default": [],
+              "description": "Additional MVA rating sets beyond A/B/C. Matrix builders continue to use\n`rate_a` unless they opt into one of these named sets.",
+              "items": {
+                "$ref": "#/$defs/BranchRatingSet"
+              },
+              "type": "array"
+            },
+            "route": {
+              "description": "Polyline route in the network's coordinate space (`BalancedNetwork.geo`),\npresent only when a source provides intermediate geometry; endpoint\nonly rendering derives from the bus locations. `#[serde(default)]` so\nJSON written before the field existed still deserializes.",
+              "items": {
+                "$ref": "#/$defs/Location"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "shift": {
+              "description": "Phase shift (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "solution": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchSolution"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Solved branch flow values, when present in a case snapshot."
+            },
+            "tap": {
+              "description": "Tap ratio, MATPOWER convention: 0 means \"no tap\" (a line), treated as 1.",
+              "format": "double",
+              "type": "number"
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x": {
+              "description": "Series reactance (p.u.).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "r",
+            "x",
+            "b",
+            "rate_a",
+            "rate_b",
+            "rate_c",
+            "tap",
+            "shift",
+            "in_service",
+            "angmin",
+            "angmax",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "BranchCharging": {
+          "description": "Per terminal branch shunt admittance in p.u. This is the canonical\nphysical branch shunt model when present.",
+          "properties": {
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "g_fr",
+            "b_fr",
+            "g_to",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "BranchCurrentRatings": {
+          "description": "Current limits for a branch, in source units.",
+          "properties": {
+            "c_rating_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rating_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rating_c": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "c_rating_a",
+            "c_rating_b",
+            "c_rating_c"
+          ],
+          "type": "object"
+        },
+        "BranchRatingSet": {
+          "description": "Extra branch MVA rating set beyond the canonical A/B/C columns.",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "rate_mva": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "name",
+            "rate_mva"
+          ],
+          "type": "object"
+        },
+        "BranchSolution": {
+          "description": "Solved branch terminal flows in MW/MVAr.",
+          "properties": {
+            "pf": {
+              "format": "double",
+              "type": "number"
+            },
+            "pt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qt": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "pf",
+            "qf",
+            "pt",
+            "qt"
+          ],
+          "type": "object"
+        },
+        "Bus": {
+          "properties": {
+            "area": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "base_kv": {
+              "format": "double",
+              "type": "number"
+            },
+            "evhi": {
+              "default": null,
+              "description": "Emergency (short-term) voltage band, set only when the source states one\ndistinct from the normal [`vmax`](Bus::vmax)/[`vmin`](Bus::vmin) band (PSS/E\n`EVHI`/`EVLO`). `None` means the emergency band equals the normal band, so\nread `evhi.unwrap_or(vmax)` / `evlo.unwrap_or(vmin)`. `#[serde(default)]` so\nJSON written before the fields existed still deserializes.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "evlo": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "id": {
+              "$ref": "#/$defs/BusId",
+              "description": "Stable bus id (1-based in MATPOWER; preserved verbatim)."
+            },
+            "kind": {
+              "$ref": "#/$defs/BusType"
+            },
+            "location": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Location"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional bus coordinates in the network coordinate space."
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uid": {
+              "description": "Stable row identity for `.pio.json` payloads and operating point updates:\nthe source record uid where the format defines one (GOC3), synthesized at\npackage build otherwise. `#[serde(default)]` so JSON written before the\nfield existed still deserializes.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "va": {
+              "description": "Voltage angle (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "vm": {
+              "description": "Voltage magnitude (p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "vmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "vmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "zone": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "id",
+            "kind",
+            "vm",
+            "va",
+            "base_kv",
+            "vmax",
+            "vmin",
+            "area",
+            "zone",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "BusId": {
+          "description": "A source bus ID, preserved from the input format.\n\nMATPOWER IDs are 1-based and can contain gaps. They are distinct from the\nzero based dense indices produced by\n[`IndexedNetwork::bus_index`](crate::IndexedNetwork::bus_index). JSON stores\nthis type as an integer.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "BusType": {
+          "description": "Bus type per MATPOWER convention: 1=PQ, 2=PV, 3=ref/slack, 4=isolated.",
+          "enum": [
+            "PQ",
+            "PV",
+            "REF",
+            "ISOLATED"
+          ],
+          "type": "string"
+        },
+        "BusWeight": {
+          "description": "One bus term of a weighted objective, addressed by PowerIO bus ID.",
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "weight": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "weight"
+          ],
+          "type": "object"
+        },
+        "Canvas": {
+          "description": "Diagram canvas metadata.",
+          "properties": {
+            "height": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "units": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "CapacityPlanSpec": {
+          "description": "The bounded decision space and search limits of one planning run. All\npower quantities are MW.",
+          "properties": {
+            "budget_mw": {
+              "description": "Total intervention budget: `Σ_e increase_e` never exceeds it.",
+              "format": "double",
+              "type": "number"
+            },
+            "candidates": {
+              "description": "Candidate branches whose thermal ratings the search may increase.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "exact_solve_budget": {
+              "description": "Maximum number of exact OPF solves, including the baseline and every\naccepted or rejected trial.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "increment_mw": {
+              "description": "Discrete capacity increase considered in one trial.",
+              "format": "double",
+              "type": "number"
+            },
+            "max_changed_lines": {
+              "description": "Positive cardinality bound over the final proposal, not one iteration.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "max_increase_per_branch_mw": {
+              "description": "Maximum cumulative increase for one branch.",
+              "format": "double",
+              "type": "number"
+            },
+            "objective": {
+              "$ref": "#/$defs/ImplicitObjective"
+            }
+          },
+          "required": [
+            "objective",
+            "candidates",
+            "max_increase_per_branch_mw",
+            "budget_mw",
+            "increment_mw",
+            "max_changed_lines",
+            "exact_solve_budget"
+          ],
+          "type": "object"
+        },
+        "Configuration": {
+          "enum": [
+            "wye",
+            "delta",
+            "single_phase"
+          ],
+          "type": "string"
+        },
+        "ConstraintSelection": {
+          "description": "Which elements of one constraint family are active, by stable element\nidentity (the payload `uid`, else `{table}:{row}`; buses by their id).",
+          "oneOf": [
+            {
+              "description": "Every element with a stated limit.",
+              "properties": {
+                "select": {
+                  "const": "all",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "No element; the family is relaxed.",
+              "properties": {
+                "select": {
+                  "const": "none",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exactly the named elements.",
+              "properties": {
+                "identities": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "select": {
+                  "const": "only",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select",
+                "identities"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ControlVoltageReference": {
+          "enum": [
+            "PN_PER_PHASE",
+            "PP_PER_PHASE",
+            "PP_AVERAGED",
+            "PG_AVERAGED",
+            "PN_AVERAGED",
+            "PG_PER_PHASE"
+          ],
+          "type": "string"
+        },
+        "CoordsKind": {
+          "description": "Coordinate origin.",
+          "enum": [
+            "source",
+            "synthetic",
+            "manual",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "DcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "approximation": {
+              "description": "Frozen `powerio.module/1` key from 0.10. The value is the selected\n[`BranchSusceptanceFormula`](powerio_tx::BranchSusceptanceFormula) stable name.",
+              "type": "string"
+            },
+            "constraints": {
+              "$ref": "#/$defs/ActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1",
+              "description": "The typed objective the instance states, in the calculation crate's\nown serialization."
+            }
+          },
+          "required": [
+            "network",
+            "approximation",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "DcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_flow_dual": {
+              "description": "Read only 0.10 signed thermal dual (`from - to`). The 1.x reader splits\nit into the two directional multiplier columns.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_limit_multiplier": {
+              "description": "Nonnegative multiplier on the from-side thermal bound, by branch.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_limit_multiplier": {
+              "description": "Nonnegative multiplier on the to-side thermal bound, by branch.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_power_marginal": {
+              "description": "Optimal objective derivative per added MW of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_price": {
+              "description": "Read only 0.10 name for the active demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/DcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "branch_from_active_flow",
+            "branch_to_active_flow",
+            "generator_active_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "DcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "approximation": {
+              "description": "Frozen `powerio.module/1` key from 0.10. The value is the selected\n[`BranchSusceptanceFormula`](powerio_tx::BranchSusceptanceFormula) stable name.",
+              "type": "string"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network",
+            "approximation"
+          ],
+          "type": "object"
+        },
+        "DcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_dispatch": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeneratorDispatchV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "instance": {
+              "$ref": "#/$defs/DcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "branch_from_active_flow",
+            "branch_to_active_flow"
+          ],
+          "type": "object"
+        },
+        "DiagnosticV1": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "related": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "severity": {
+              "$ref": "#/$defs/SeverityV1"
+            },
+            "spans": {
+              "items": {
+                "$ref": "#/$defs/SourceSpanV1"
+              },
+              "type": "array"
+            },
+            "suggested_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "target": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "severity",
+            "code",
+            "message"
+          ],
+          "type": "object"
+        },
+        "DigestAlgorithmV1": {
+          "enum": [
+            "sha256"
+          ],
+          "type": "string"
+        },
+        "DigestV1": {
+          "additionalProperties": false,
+          "properties": {
+            "algorithm": {
+              "$ref": "#/$defs/DigestAlgorithmV1"
+            },
+            "value": {
+              "description": "Lowercase hexadecimal, without a prefix.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "algorithm",
+            "value"
+          ],
+          "type": "object"
+        },
+        "DistBus": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "grounded": {
+              "description": "Terminals tied to ground with zero impedance.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "location": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistLocation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional bus coordinates in the network coordinate space."
+            },
+            "terminals": {
+              "description": "Ordered terminal names; OpenDSS node numbers as strings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "v_min": {
+              "description": "Voltage magnitude bounds, volts: the scalar pair plus the phase to\nneutral and phase to phase families, and the per-sequence scalars\n(BMOPF schema 0.1.0: positive sequence has both bounds, negative and\nzero sequence and neutral to ground are magnitude caps whose lower\nbound is always 0).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vn_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vneg_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpn_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpn_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpos_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpos_min": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpp_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpp_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vzero_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "terminals",
+            "grounded",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistCanvas": {
+          "description": "Diagram canvas metadata.",
+          "properties": {
+            "height": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "units": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "DistCapacitor": {
+          "description": "A rated capacitor bank (BMOPF schema 0.1.0 `capacitor`): `q_rated` vars\ndelivered at `v_nom` volts across the element terminals, distinct from the\nraw admittance [`DistShunt`]. The DSS converter still lowers OpenDSS\ncapacitors to shunt B matrices; this element carries capacitors that arrive\nas BMOPF input.",
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "q_rated": {
+              "description": "Nameplate rated reactive power of the whole bank, vars.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_nom": {
+              "description": "Nameplate nominal voltage, volts: line to line for the three phase\nconfigurations, across the terminals for SINGLE_PHASE.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "q_rated",
+            "v_nom",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistControlProfile": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "power_factor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/PowerFactorControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volt_var": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/VoltVarControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volt_watt": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/VoltWattControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistCoordsKind": {
+          "description": "Coordinate origin.",
+          "enum": [
+            "source",
+            "synthetic",
+            "manual",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "DistGenerator": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "cost": {
+              "description": "Generation cost, $/kWh per phase conductor, exactly as the source\nstates it: one entry per phase, or a single entry for a scalar\nstatement. No OpenDSS equivalent, so it is None until a format\nsupplies it.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_min": {
+              "default": null,
+              "description": "Bounds per phase. A `null` element reads as -Inf in a lower bound\nand +Inf in an upper bound: the PMD unbounded spelling (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_nom": {
+              "description": "Setpoint, watts per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "s_max": {
+              "description": "Per-conductor apparent power and current limits, VA and amps (BMOPF\ngenerator fields, alongside the p/q bounds).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "p_nom",
+            "q_nom",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistGeoMeta": {
+          "description": "Network level coordinate metadata.",
+          "oneOf": [
+            {
+              "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "geographic",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Planar coordinates, with the CRS named when known.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "projected",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Drawing coordinates with no earth referent.",
+              "properties": {
+                "canvas": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/DistCanvas"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "space": {
+                  "const": "diagram",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source did not declare a coordinate space.",
+              "properties": {
+                "space": {
+                  "const": "unknown",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            }
+          ],
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistCoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Default origin for points without their own `kind`."
+            }
+          },
+          "type": "object"
+        },
+        "DistIbr": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "control_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Per conductor current limits, amperes.",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_avail": {
+              "description": "Available active power, watts.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "prime_mover": {
+              "$ref": "#/$defs/IbrPrimeMover"
+            },
+            "q_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "s_max": {
+              "description": "Per phase apparent power nameplate ratings, volt amperes.",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": "array"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "topology": {
+              "$ref": "#/$defs/IbrTopology"
+            },
+            "voltage_aggregation": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/IbrVoltageAggregation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "topology",
+            "prime_mover",
+            "s_max",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLine": {
+          "properties": {
+            "bus_from": {
+              "type": "string"
+            },
+            "bus_to": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "description": "Per-conductor ampacity and apparent power limits, amps and VA\n(BMOPF schema 0.1.0 line fields, alongside the linecode's own).\nA `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "length": {
+              "description": "Meters. A `null` reads as NaN: a BMOPF line without a length (#268).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "linecode": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "route": {
+              "description": "Polyline route in the network's coordinate space (`MulticonductorNetwork.geo`),\npresent only when a source provides intermediate geometry.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes.",
+              "items": {
+                "$ref": "#/$defs/DistLocation"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "s_max": {
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_map_from": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "terminal_map_to": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus_from",
+            "bus_to",
+            "terminal_map_from",
+            "terminal_map_to",
+            "linecode",
+            "length",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLineCode": {
+          "properties": {
+            "b_from": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "b_to": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g_from": {
+              "description": "Shunt admittance halves at each end, S per meter.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "g_to": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "n_conductors": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "r_series": {
+              "description": "Series impedance, ohm per meter.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "s_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "source": {
+              "description": "Origin of the impedance matrices (BMOPF `source`, e.g. \"fem\",\n\"datasheet\", \"import\").",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x_series": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "n_conductors",
+            "r_series",
+            "x_series",
+            "g_from",
+            "b_from",
+            "g_to",
+            "b_to",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLoad": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_nom": {
+              "description": "Watts per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_nom": {
+              "description": "Vars per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "voltage_model": {
+              "$ref": "#/$defs/DistLoadVoltageModel"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "p_nom",
+            "q_nom",
+            "voltage_model",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLoadVoltageModel": {
+          "oneOf": [
+            {
+              "description": "Constant power load. `v_nom` is volts per active phase when the source\nstates it.",
+              "properties": {
+                "model": {
+                  "const": "constant_power",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Constant current load. `v_nom` is volts per active phase.",
+              "properties": {
+                "model": {
+                  "const": "constant_current",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Constant impedance load. `v_nom` is volts per active phase.",
+              "properties": {
+                "model": {
+                  "const": "constant_impedance",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "ZIP load coefficients by active phase. `v_nom` is volts per active\nphase; alpha terms apply to active power and beta terms to reactive\npower.",
+              "properties": {
+                "alpha_i": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "alpha_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "alpha_z": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_i": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_z": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "model": {
+                  "const": "zip",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom",
+                "alpha_z",
+                "alpha_i",
+                "alpha_p",
+                "beta_z",
+                "beta_i",
+                "beta_p"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exponential voltage model by active phase. `v_nom` is volts per active\nphase.",
+              "properties": {
+                "gamma_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "gamma_q": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "model": {
+                  "const": "exponential",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom",
+                "gamma_p",
+                "gamma_q"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "DistLocation": {
+          "description": "A point attached to one model element.",
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistCoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Point origin when it differs from the network default."
+            },
+            "x": {
+              "description": "X coordinate. In geographic space this is longitude.",
+              "format": "double",
+              "type": "number"
+            },
+            "y": {
+              "description": "Y coordinate. In geographic space this is latitude.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ],
+          "type": "object"
+        },
+        "DistShunt": {
+          "properties": {
+            "b": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g": {
+              "description": "Total siemens in conductor order.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "g",
+            "b",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistSourceFormat": {
+          "description": "Where the network came from; fixes the echo tier target.",
+          "enum": [
+            "dss",
+            "bmopf-json",
+            "pmd-json"
+          ],
+          "type": "string"
+        },
+        "DistSwitch": {
+          "properties": {
+            "bus_from": {
+              "type": "string"
+            },
+            "bus_to": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "open": {
+              "type": "boolean"
+            },
+            "terminal_map_from": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "terminal_map_to": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus_from",
+            "bus_to",
+            "terminal_map_from",
+            "terminal_map_to",
+            "open",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistTransformer": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "phases": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "windings": {
+              "items": {
+                "$ref": "#/$defs/DistWinding"
+              },
+              "type": "array"
+            },
+            "xsc_pct": {
+              "description": "Short circuit reactances between winding pairs, percent:\n`[xhl]` for two windings, `[xhl, xht, xlt]` for three.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "windings",
+            "xsc_pct",
+            "phases",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistWinding": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "conn": {
+              "$ref": "#/$defs/DistWindingConn"
+            },
+            "r_neutral": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "r_pct": {
+              "description": "Winding resistance, percent of the winding base.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "s_rating": {
+              "description": "Volt amperes.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "tap": {
+              "format": "double",
+              "type": "number"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_ref": {
+              "description": "Rated winding voltage, volts (line to line for 2 and 3 phase).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "x_neutral": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "bus",
+            "terminal_map",
+            "conn",
+            "v_ref",
+            "s_rating",
+            "r_pct",
+            "tap"
+          ],
+          "type": "object"
+        },
+        "DistWindingConn": {
+          "enum": [
+            "wye",
+            "delta"
+          ],
+          "type": "string"
+        },
+        "DurationV1": {
+          "additionalProperties": false,
+          "description": "A stored duration: unsigned seconds plus a nanosecond remainder below one\nbillion, exactly.",
+          "properties": {
+            "nanos": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "secs": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "secs",
+            "nanos"
+          ],
+          "type": "object"
+        },
+        "GenCost": {
+          "description": "A generator cost curve (`mpc.gencost` row).",
+          "properties": {
+            "coeffs": {
+              "description": "Raw coefficients, highest order first for the polynomial model:\n`[c_{k-1}, …, c1, c0]`.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "model": {
+              "description": "1 = piecewise linear, 2 = polynomial.",
+              "format": "uint8",
+              "maximum": 255,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "ncost": {
+              "description": "Number of cost coefficients (polynomial) or breakpoints (piecewise).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "shutdown": {
+              "format": "double",
+              "type": "number"
+            },
+            "startup": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "model",
+            "startup",
+            "shutdown",
+            "ncost",
+            "coeffs"
+          ],
+          "type": "object"
+        },
+        "Generator": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "caps": {
+              "additionalProperties": {
+                "format": "double",
+                "type": "number"
+              },
+              "default": {},
+              "description": "The MATPOWER gen capability / ramp columns past `PMIN`, aligned to\n`GEN_EXTRA_KEYS` by index (`None` for a column the source omitted).\nA fixed array, not an [`Extras`] map: a string-keyed map per generator\ncosts 11 heap allocations each, which dominates the parse of a large\ngenerator-heavy case. Surfaced into formats that name them (PowerModels).\nOn the JSON snapshot it is a name-keyed object (see `caps_serde`) so the\nschema stays additive when `GEN_EXTRA_KEYS` grows; `#[serde(default)]` so a\nsnapshot that omits it deserializes to the empty set.",
+              "type": "object"
+            },
+            "cost": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GenCost"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "mbase": {
+              "format": "double",
+              "type": "number"
+            },
+            "pg": {
+              "description": "Real power set point (MW).",
+              "format": "double",
+              "type": "number"
+            },
+            "pmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "qg": {
+              "description": "Reactive power set point (MVAr).",
+              "format": "double",
+              "type": "number"
+            },
+            "qmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "regulated_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "The remote bus whose voltage this generator regulates, when that is not its\nown terminal bus (PSS/E `IREG`). `None` means it regulates its own bus.\nPart of the cross-element voltage-control graph: a format that names a\nremote regulated bus (PSS/E) keeps it across a round trip instead of\ncollapsing every generator onto its own terminal. `#[serde(default)]` so\nJSON written before the field existed still deserializes."
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "vg": {
+              "description": "Voltage set point (p.u.).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "pg",
+            "qg",
+            "pmax",
+            "pmin",
+            "qmax",
+            "qmin",
+            "vg",
+            "mbase",
+            "in_service"
+          ],
+          "type": "object"
+        },
+        "GeneratorDispatchV1": {
+          "additionalProperties": false,
+          "description": "A solution's producer stated generator dispatch.",
+          "properties": {
+            "p_mw": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "q_mvar": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "p_mw",
+            "q_mvar"
+          ],
+          "type": "object"
+        },
+        "GeoMeta": {
+          "description": "Network level coordinate metadata.",
+          "oneOf": [
+            {
+              "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "geographic",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Planar coordinates, with the CRS named when known.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "projected",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Drawing coordinates with no earth referent.",
+              "properties": {
+                "canvas": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/Canvas"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "space": {
+                  "const": "diagram",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source did not declare a coordinate space.",
+              "properties": {
+                "space": {
+                  "const": "unknown",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            }
+          ],
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/CoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Default origin for points without their own `kind`."
+            }
+          },
+          "type": "object"
+        },
+        "HistoryEntryV1": {
+          "additionalProperties": false,
+          "description": "Describes an operation that produced the current value. Not a replay\nprogram; replayable revisions require their own typed value.",
+          "properties": {
+            "assumptions": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "input_kind": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "$ref": "#/$defs/HistoryKindV1"
+            },
+            "losses": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Stable registered operation name.",
+              "type": "string"
+            },
+            "output_kind": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "parameters": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "required": [
+            "id",
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        "HistoryKindV1": {
+          "enum": [
+            "parse",
+            "upgrade",
+            "transform",
+            "edit",
+            "repair"
+          ],
+          "type": "string"
+        },
+        "Hvdc": {
+          "description": "A two-terminal HVDC line (MATPOWER `dcline`).\n\n`pf`/`pt`/`qf`/`qt` are stored in MATPOWER's sign convention regardless of\nsource: the PowerModels reader un-flips `pt`/`qf`/`qt` on the way in, and the\nPowerModels writer re-flips them on the way out (PowerModels.jl uses the\nopposite sign). The flip is a format-boundary translation, so a derived view\nlike `to_normalized` keeps the MATPOWER convention and only scales to per unit.",
+          "properties": {
+            "cost": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GenCost"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "loss0": {
+              "format": "double",
+              "type": "number"
+            },
+            "loss1": {
+              "format": "double",
+              "type": "number"
+            },
+            "pf": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "pt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmaxf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmaxt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qminf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmint": {
+              "format": "double",
+              "type": "number"
+            },
+            "qt": {
+              "format": "double",
+              "type": "number"
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "vf": {
+              "format": "double",
+              "type": "number"
+            },
+            "vt": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "in_service",
+            "pf",
+            "pt",
+            "qf",
+            "qt",
+            "vf",
+            "vt",
+            "pmin",
+            "pmax",
+            "qminf",
+            "qmaxf",
+            "qmint",
+            "qmaxt",
+            "loss0",
+            "loss1",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "IbrPrimeMover": {
+          "enum": [
+            "PV",
+            "BATTERY",
+            "GENERIC",
+            "STATCOM",
+            "DSTATCOM"
+          ],
+          "type": "string"
+        },
+        "IbrTopology": {
+          "enum": [
+            "SINGLE_PHASE",
+            "THREE_LEG",
+            "FOUR_LEG"
+          ],
+          "type": "string"
+        },
+        "IbrVoltageAggregation": {
+          "enum": [
+            "PER_PHASE",
+            "AVERAGE"
+          ],
+          "type": "string"
+        },
+        "Impedance": {
+          "description": "A series impedance with the MVA base it is expressed on. Used pairwise by\n[`Transformer3W`]; a self-contained unit so the base travels with the value\ninstead of being implied by position.\n\n`r`/`x` are per unit on the *system* base (the same `CZ = 1` convention as\n[`Branch::r`]/[`Branch::x`], so the matrix math needs no rebasing); `base_mva`\nrecords the winding-pair MVA base the source file declared (PSS/E `SBASE1-2`\nand friends), kept so a write-back reproduces it and so a future `CZ = 2`\nreader has somewhere to put the winding base it must rebase from. Room to grow\n(winding voltage base, turns-ratio units) as the transformer control work\nlands without reshaping the [`Transformer3W::z`] array.",
+          "properties": {
+            "base_mva": {
+              "format": "double",
+              "type": "number"
+            },
+            "r": {
+              "format": "double",
+              "type": "number"
+            },
+            "x": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "r",
+            "x",
+            "base_mva"
+          ],
+          "type": "object"
+        },
+        "ImplicitObjective": {
+          "description": "A safe, serializable outer objective over the optimal solve. Every\nvariant is a scalar with a well defined gradient through the KKT system;\nnew observables (generation, line loading, operating cost) add variants\nrather than accepting code.",
+          "oneOf": [
+            {
+              "description": "`Phi = Σ_b w_b · lmp_b` over the selected buses. Positive weights\nmake the search look for capacity increases that lower the weighted\nmarginal value of demand.",
+              "properties": {
+                "kind": {
+                  "const": "weighted_lmp",
+                  "type": "string"
+                },
+                "weights": {
+                  "items": {
+                    "$ref": "#/$defs/BusWeight"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "kind",
+                "weights"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "Load": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "p": {
+              "description": "Active demand (MW).",
+              "format": "double",
+              "type": "number"
+            },
+            "q": {
+              "description": "Reactive demand (MVAr).",
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "voltage_model": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LoadVoltageModel"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Voltage dependence, when the source states one. `None` is constant power."
+            }
+          },
+          "required": [
+            "bus",
+            "p",
+            "q",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "LoadVoltageModel": {
+          "description": "Voltage dependence for a transmission load.",
+          "oneOf": [
+            {
+              "description": "Explicit constant power marker.",
+              "properties": {
+                "kind": {
+                  "const": "constant_power",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "ZIP load split in source units. The three active parts sum to\n[`Load::p`], and the three reactive parts sum to [`Load::q`].",
+              "properties": {
+                "kind": {
+                  "const": "zip",
+                  "type": "string"
+                },
+                "load_type": {
+                  "default": null,
+                  "description": "Source load type code, when a format has one (PSS/E `ID`/`LOADTYPE`\nstyle metadata).",
+                  "format": "int32",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "p_constant_current": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "p_constant_impedance": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "p_constant_power": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_current": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_impedance": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_power": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "scaling": {
+                  "default": null,
+                  "description": "Source scaling factor, when a format has one.",
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "v_nom": {
+                  "default": null,
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "p_constant_power",
+                "q_constant_power",
+                "p_constant_current",
+                "q_constant_current",
+                "p_constant_impedance",
+                "q_constant_impedance"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exponential voltage model: `P = p * (V / v_nom)^gamma_p`,\n`Q = q * (V / v_nom)^gamma_q`.",
+              "properties": {
+                "gamma_p": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "gamma_q": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "kind": {
+                  "const": "exponential",
+                  "type": "string"
+                },
+                "p": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "v_nom": {
+                  "default": null,
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "p",
+                "q",
+                "gamma_p",
+                "gamma_q"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "Location": {
+          "description": "A point attached to one model element.",
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/CoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Point origin when it differs from the network default."
+            },
+            "x": {
+              "description": "X coordinate. In geographic space this is longitude.",
+              "format": "double",
+              "type": "number"
+            },
+            "y": {
+              "description": "Y coordinate. In geographic space this is latitude.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ],
+          "type": "object"
+        },
+        "McAcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "constraints": {
+              "$ref": "#/$defs/MulticonductorActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1"
+            }
+          },
+          "required": [
+            "network",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "McAcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/McAcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "source_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_current_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "terminal_voltage_magnitude",
+            "terminal_voltage_angle",
+            "source_active_injection",
+            "generator_active_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "McAcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            }
+          },
+          "required": [
+            "network"
+          ],
+          "type": "object"
+        },
+        "McAcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "instance": {
+              "$ref": "#/$defs/McAcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "source_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_current_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "terminal_voltage_magnitude",
+            "terminal_voltage_angle",
+            "source_active_injection"
+          ],
+          "type": "object"
+        },
+        "MulticonductorActiveConstraints": {
+          "description": "The active constraint families of a multiconductor OPF instance.",
+          "properties": {
+            "conductor_limits": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Conductor current or apparent power limits."
+            },
+            "generator_capability": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Per phase generator capability bounds."
+            },
+            "terminal_voltage_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Terminal voltage magnitude bounds."
+            }
+          },
+          "required": [
+            "terminal_voltage_bounds",
+            "conductor_limits",
+            "generator_capability"
+          ],
+          "type": "object"
+        },
+        "MulticonductorNetwork": {
+          "description": "A multiconductor distribution network.\n\n`source` retains the original text for the byte exact echo tier;\n`defaulted` records, per element (`\"class.name\"` key), the fields the\nreader materialized from format defaults rather than the source text.",
+          "properties": {
+            "base_frequency": {
+              "description": "Hz.",
+              "format": "double",
+              "type": "number"
+            },
+            "buses": {
+              "items": {
+                "$ref": "#/$defs/DistBus"
+              },
+              "type": "array"
+            },
+            "capacitors": {
+              "items": {
+                "$ref": "#/$defs/DistCapacitor"
+              },
+              "type": "array"
+            },
+            "commands": {
+              "description": "Source commands and options the typed model does not interpret\n(`solve`, `set mode=...`), in order, as (verb, args).",
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "control_profiles": {
+              "items": {
+                "$ref": "#/$defs/DistControlProfile"
+              },
+              "type": "array"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "generators": {
+              "items": {
+                "$ref": "#/$defs/DistGenerator"
+              },
+              "type": "array"
+            },
+            "geo": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistGeoMeta"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "ibrs": {
+              "items": {
+                "$ref": "#/$defs/DistIbr"
+              },
+              "type": "array"
+            },
+            "linecodes": {
+              "items": {
+                "$ref": "#/$defs/DistLineCode"
+              },
+              "type": "array"
+            },
+            "lines": {
+              "items": {
+                "$ref": "#/$defs/DistLine"
+              },
+              "type": "array"
+            },
+            "loads": {
+              "items": {
+                "$ref": "#/$defs/DistLoad"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "options": {
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "shunts": {
+              "items": {
+                "$ref": "#/$defs/DistShunt"
+              },
+              "type": "array"
+            },
+            "source_format": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistSourceFormat"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "sources": {
+              "description": "BMOPF allows exactly one; the model allows any number and the BMOPF\nwriter warns beyond the first.",
+              "items": {
+                "$ref": "#/$defs/VoltageSource"
+              },
+              "type": "array"
+            },
+            "switches": {
+              "items": {
+                "$ref": "#/$defs/DistSwitch"
+              },
+              "type": "array"
+            },
+            "transformers": {
+              "items": {
+                "$ref": "#/$defs/DistTransformer"
+              },
+              "type": "array"
+            },
+            "untyped": {
+              "items": {
+                "$ref": "#/$defs/UntypedObject"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "base_frequency",
+            "buses",
+            "linecodes",
+            "lines",
+            "switches",
+            "transformers",
+            "loads",
+            "generators",
+            "shunts",
+            "sources",
+            "untyped",
+            "commands",
+            "options",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "MulticonductorOperatingPointTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            },
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "description": "Quantity name → dense columns, the multiconductor instantaneous\nvocabulary.",
+              "type": "object"
+            },
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "network",
+            "time_points",
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "ObjectiveTermV1": {
+          "description": "One typed objective term, mirroring `powerio_prob::ObjectiveTerm` with its\nweight wrapped for the nonfinite spelling: an internally tagged enum's\nderived `Deserialize` re-decodes its variant from a buffered generic\nvalue rather than the deserializer callers pass in, so wrapping the whole\ndocument's deserializer (as [`StoredModuleV1`] does for every plain\nstruct field) never reaches this `f64`.",
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "term": {
+                  "const": "network_generator_cost",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "term"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "term": {
+                  "const": "network_per_phase_cost",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "term"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Read only compatibility for 0.10 documents. The runtime removes this\nterm and records `READ.MODULE.OBJECTIVE_TERM_RETIRED` because the token\ndid not define a portable quantity or unit.",
+              "properties": {
+                "term": {
+                  "const": "differentiability_regularization",
+                  "type": "string"
+                },
+                "weight": {
+                  "$ref": "#/$defs/StoredF64"
+                }
+              },
+              "required": [
+                "term",
+                "weight"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ObjectiveV1": {
+          "additionalProperties": false,
+          "description": "The complete typed objective, mirroring `powerio_prob::Objective`.",
+          "properties": {
+            "terms": {
+              "items": {
+                "$ref": "#/$defs/ObjectiveTermV1"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "PowerFactorControl": {
+          "properties": {
+            "pf": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "pf"
+          ],
+          "type": "object"
+        },
+        "ProducerV1": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "ReactivePowerReference": {
+          "enum": [
+            "VAR_MAX",
+            "VAR_AVAILABLE"
+          ],
+          "type": "string"
+        },
+        "ReactivePowerUnit": {
+          "enum": [
+            "VA_FRACTION",
+            "VAR"
+          ],
+          "type": "string"
+        },
+        "Residuals": {
+          "description": "Numerical residuals of the solved equations, in the problem's power unit.\nA field is `None` when the producer did not report it.",
+          "properties": {
+            "max_active_power_mismatch": {
+              "description": "Largest absolute active power balance mismatch, MW.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "max_reactive_power_mismatch": {
+              "description": "Largest absolute reactive power balance mismatch, MVAr.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "ScopfAcContingencySurvivors": {
+          "description": "Per-contingency surviving AC lines and transformers, one group per\ncontingency in `reliability.contingency` document order.",
+          "properties": {
+            "ln": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/ScopfAcLineSurvivorRow"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "xf": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/ScopfTransformerSurvivorRow"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "ln",
+            "xf"
+          ],
+          "type": "object"
+        },
+        "ScopfAcLineRow": {
+          "description": "One AC line row.",
+          "properties": {
+            "b_ch": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_ln",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "c_su",
+            "c_sd",
+            "u_0",
+            "s_max",
+            "g_sr",
+            "b_sr",
+            "b_ch",
+            "g_fr",
+            "g_to",
+            "b_fr",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "ScopfAcLineSurvivorRow": {
+          "description": "One AC line surviving a contingency.",
+          "properties": {
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max_ctg": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ctg",
+            "j_ln",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "b_sr",
+            "s_max_ctg"
+          ],
+          "type": "object"
+        },
+        "ScopfActiveReserveRow": {
+          "description": "One active power zonal reserve row.",
+          "properties": {
+            "c_nsc": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rgd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rgu": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rrd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rru": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_scr": {
+              "format": "double",
+              "type": "number"
+            },
+            "n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_rrd_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_rru_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "sigma_nsc": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_rgd": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_rgu": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_scr": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "n_p",
+            "uid",
+            "c_rgu",
+            "c_rgd",
+            "c_scr",
+            "c_nsc",
+            "c_rru",
+            "c_rrd",
+            "sigma_rgu",
+            "sigma_rgd",
+            "sigma_scr",
+            "sigma_nsc",
+            "p_rru_min",
+            "p_rrd_min"
+          ],
+          "type": "object"
+        },
+        "ScopfActiveReserveSetRow": {
+          "description": "One (bus, active reserve zone, device) membership row.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dev": {
+              "description": "The member device's ordinals ([`ScopfDeviceRow::j_dev`],\n[`ScopfDeviceRow::j_sdd`]).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "i",
+            "n_p",
+            "uid",
+            "j_dev",
+            "j_sdd"
+          ],
+          "type": "object"
+        },
+        "ScopfBusRow": {
+          "description": "One bus row: `(i, uid, v_min, v_max)`.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "v_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "v_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "i",
+            "uid",
+            "v_min",
+            "v_max"
+          ],
+          "type": "object"
+        },
+        "ScopfDcContingencyFlowRow": {
+          "description": "One surviving DC line in one contingency and period.",
+          "properties": {
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "flat_jtk_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            }
+          },
+          "required": [
+            "flat_jtk_dc",
+            "ctg",
+            "j_dc",
+            "to_bus",
+            "fr_bus",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfDcLineRow": {
+          "description": "One DC line row.",
+          "properties": {
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pdc_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_fr_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_fr_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_to_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_to_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_dc",
+            "uid",
+            "pdc_max",
+            "qdc_fr_min",
+            "qdc_to_min",
+            "qdc_fr_max",
+            "qdc_to_max",
+            "to_bus",
+            "fr_bus"
+          ],
+          "type": "object"
+        },
+        "ScopfDeviceClassLayout": {
+          "description": "How the two device classes sit in the `simple_dispatchable_device` section.\n\nA model that stacks producers and consumers into one variable vector\naddresses a device by a per class offset, which is a bijection only when\neach class owns one unbroken run. Reading the order without that\nprecondition is the one mistake this type makes unavailable.",
+          "oneOf": [
+            {
+              "description": "Each class is one unbroken run. `producers_first` says which run\nstarts first.",
+              "properties": {
+                "kind": {
+                  "const": "contiguous",
+                  "type": "string"
+                },
+                "producers_first": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "kind",
+                "producers_first"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The two classes interleave, so no per class offset addresses a device.",
+              "properties": {
+                "kind": {
+                  "const": "interleaved",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ScopfDeviceRow": {
+          "description": "One simple dispatchable device row.\n\nProducers and consumers share this layout. Vector fields use the internal\nzero based period order.\n\nThe reactive capability block is the `q_bound_cap`/`q_linear_cap` pair and\nthe parameters of the mode each one selects. The two modes are mutually\nexclusive and a device can select neither. A parameter of a mode the device\ndid not select is `None`. Read the two flags before the parameters.",
+          "properties": {
+            "beta": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "beta_lb": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "beta_ub": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "c_nsc": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_on": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_qrd": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_qru": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rgd": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rgu": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rrd_off": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rrd_on": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rru_off": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rru_on": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_scr": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_dev": {
+              "description": "0-based position within the row's own class list (`prod` or `cons`),\nin document order. Serialization can retain base 0 or select base 1.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "description": "0-based position in the canonical device stacking: the producer block,\nthen the consumer block, document order within each. Sound for every\nuid spelling, including interleaved classes.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_0": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_nsc_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rd": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rd_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rgd_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rgu_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rrd_off_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rrd_on_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rru_off_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rru_on_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_ru": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_ru_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_scr_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_0": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_0_lb": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_0_ub": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_bound_cap": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "q_linear_cap": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "q_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_p0": {
+              "description": "The intercept of the linear capability line. The GOC3 document calls\nthis `q_0`, which this row already uses for `initial_status.q`.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "sus": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "bus",
+            "uid",
+            "j_dev",
+            "j_sdd",
+            "c_on",
+            "c_su",
+            "c_sd",
+            "p_ru",
+            "p_rd",
+            "p_ru_su",
+            "p_rd_sd",
+            "c_rgu",
+            "c_rgd",
+            "c_scr",
+            "c_nsc",
+            "c_rru_on",
+            "c_rru_off",
+            "c_rrd_on",
+            "c_rrd_off",
+            "c_qru",
+            "c_qrd",
+            "p_rgu_max",
+            "p_rgd_max",
+            "p_scr_max",
+            "p_nsc_max",
+            "p_rru_on_max",
+            "p_rru_off_max",
+            "p_rrd_on_max",
+            "p_rrd_off_max",
+            "p_0",
+            "q_0",
+            "u_0",
+            "p_max",
+            "p_min",
+            "q_max",
+            "q_min",
+            "sus",
+            "q_bound_cap",
+            "q_linear_cap"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMaxCsRow": {
+          "properties": {
+            "a_en_max_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_max_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_cs_ind",
+            "uid",
+            "a_en_max_start",
+            "a_en_max_end",
+            "e_max"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMaxPrRow": {
+          "properties": {
+            "a_en_max_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_max_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_pr_ind",
+            "uid",
+            "a_en_max_start",
+            "a_en_max_end",
+            "e_max"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMinCsRow": {
+          "properties": {
+            "a_en_min_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_min_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_cs_ind",
+            "uid",
+            "a_en_min_start",
+            "a_en_min_end",
+            "e_min"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMinPrRow": {
+          "properties": {
+            "a_en_min_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_min_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_pr_ind",
+            "uid",
+            "a_en_min_start",
+            "a_en_min_end",
+            "e_min"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMaxCsRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_cs_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMaxPrRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_pr_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMinCsRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_cs_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMinPrRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_pr_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindows": {
+          "description": "Energy requirement windows and their period memberships.",
+          "properties": {
+            "t_w_en_max_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMaxCsRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_max_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMaxPrRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_min_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMinCsRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_min_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMinPrRow"
+              },
+              "type": "array"
+            },
+            "w_en_max_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMaxCsRow"
+              },
+              "type": "array"
+            },
+            "w_en_max_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMaxPrRow"
+              },
+              "type": "array"
+            },
+            "w_en_min_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMinCsRow"
+              },
+              "type": "array"
+            },
+            "w_en_min_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMinPrRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "w_en_max_pr",
+            "w_en_max_cs",
+            "w_en_min_pr",
+            "w_en_min_cs",
+            "t_w_en_max_pr",
+            "t_w_en_max_cs",
+            "t_w_en_min_pr",
+            "t_w_en_min_cs"
+          ],
+          "type": "object"
+        },
+        "ScopfFixedPhaseRow": {
+          "description": "A transformer with a fixed phase shift (`fpd`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "phi_o": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "phi_o"
+          ],
+          "type": "object"
+        },
+        "ScopfFixedRatioRow": {
+          "description": "A transformer with a fixed winding ratio (`fwr`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tau_o": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "tau_o"
+          ],
+          "type": "object"
+        },
+        "ScopfLengths": {
+          "description": "Set sizes for each indexed device class.",
+          "properties": {
+            "i": {
+              "description": "Bus count.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "k": {
+              "description": "Contingency count.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_ac": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_br": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_cs": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_cspr": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_pr": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_sh": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "l_j_xf",
+            "l_j_ln",
+            "l_j_ac",
+            "l_j_dc",
+            "l_j_br",
+            "l_j_cs",
+            "l_j_pr",
+            "l_j_cspr",
+            "l_j_sh",
+            "i",
+            "l_t",
+            "l_n_p",
+            "l_n_q",
+            "k"
+          ],
+          "type": "object"
+        },
+        "ScopfPriceBlockRow": {
+          "description": "One flattened device, period, and price block row.",
+          "properties": {
+            "c_en": {
+              "format": "double",
+              "type": "number"
+            },
+            "flat_k": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "m": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "flat_k",
+            "uid",
+            "t",
+            "m",
+            "c_en",
+            "p_max"
+          ],
+          "type": "object"
+        },
+        "ScopfPriceBlocks": {
+          "description": "Flattened producer and consumer price blocks.",
+          "properties": {
+            "consumer": {
+              "items": {
+                "$ref": "#/$defs/ScopfPriceBlockRow"
+              },
+              "type": "array"
+            },
+            "producer": {
+              "items": {
+                "$ref": "#/$defs/ScopfPriceBlockRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "producer",
+            "consumer"
+          ],
+          "type": "object"
+        },
+        "ScopfReactiveReserveRow": {
+          "description": "One reactive (reactive-power) zonal reserve row.",
+          "properties": {
+            "c_qrd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_qru": {
+              "format": "double",
+              "type": "number"
+            },
+            "n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "q_qrd_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_qru_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "n_q",
+            "uid",
+            "c_qru",
+            "c_qrd",
+            "q_qru_min",
+            "q_qrd_min"
+          ],
+          "type": "object"
+        },
+        "ScopfReactiveReserveSetRow": {
+          "description": "One (bus, reactive reserve zone, device) membership row.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dev": {
+              "description": "The member device's ordinals ([`ScopfDeviceRow::j_dev`],\n[`ScopfDeviceRow::j_sdd`]).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "i",
+            "n_q",
+            "uid",
+            "j_dev",
+            "j_sdd"
+          ],
+          "type": "object"
+        },
+        "ScopfShuntRow": {
+          "description": "One shunt row.",
+          "properties": {
+            "b_sh": {
+              "format": "double",
+              "type": "number"
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_sh": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_sh": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_sh",
+            "uid",
+            "bus",
+            "g_sh",
+            "b_sh"
+          ],
+          "type": "object"
+        },
+        "ScopfStaticData": {
+          "description": "Static buses, branches, devices, controls, reserves, and memberships.",
+          "properties": {
+            "acl_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfAcLineRow"
+              },
+              "type": "array"
+            },
+            "active_reserve": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveRow"
+              },
+              "type": "array"
+            },
+            "active_reserve_set_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "active_reserve_set_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "acx_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfTransformerRow"
+              },
+              "type": "array"
+            },
+            "bus": {
+              "items": {
+                "$ref": "#/$defs/ScopfBusRow"
+              },
+              "type": "array"
+            },
+            "cons": {
+              "items": {
+                "$ref": "#/$defs/ScopfDeviceRow"
+              },
+              "type": "array"
+            },
+            "dc_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfDcLineRow"
+              },
+              "type": "array"
+            },
+            "fpd": {
+              "items": {
+                "$ref": "#/$defs/ScopfFixedPhaseRow"
+              },
+              "type": "array"
+            },
+            "fwr": {
+              "items": {
+                "$ref": "#/$defs/ScopfFixedRatioRow"
+              },
+              "type": "array"
+            },
+            "prod": {
+              "items": {
+                "$ref": "#/$defs/ScopfDeviceRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve_set_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve_set_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "shunt": {
+              "items": {
+                "$ref": "#/$defs/ScopfShuntRow"
+              },
+              "type": "array"
+            },
+            "vpd": {
+              "items": {
+                "$ref": "#/$defs/ScopfVariablePhaseRow"
+              },
+              "type": "array"
+            },
+            "vwr": {
+              "items": {
+                "$ref": "#/$defs/ScopfVariableRatioRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "bus",
+            "shunt",
+            "acl_branch",
+            "acx_branch",
+            "vpd",
+            "fpd",
+            "vwr",
+            "fwr",
+            "dc_branch",
+            "prod",
+            "cons",
+            "active_reserve",
+            "reactive_reserve",
+            "active_reserve_set_pr",
+            "active_reserve_set_cs",
+            "reactive_reserve_set_pr",
+            "reactive_reserve_set_cs"
+          ],
+          "type": "object"
+        },
+        "ScopfTransformerRow": {
+          "description": "One two winding transformer row.",
+          "properties": {
+            "b_ch": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_xf",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "c_su",
+            "c_sd",
+            "u_0",
+            "s_max",
+            "g_sr",
+            "b_sr",
+            "b_ch",
+            "g_fr",
+            "g_to",
+            "b_fr",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "ScopfTransformerSurvivorRow": {
+          "description": "One transformer surviving a contingency.",
+          "properties": {
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max_ctg": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ctg",
+            "j_xf",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "b_sr",
+            "s_max_ctg"
+          ],
+          "type": "object"
+        },
+        "ScopfVariablePhaseRow": {
+          "description": "A transformer with a variable phase-shift control range (`vpd`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "phi_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "phi_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "phi_min",
+            "phi_max"
+          ],
+          "type": "object"
+        },
+        "ScopfVariableRatioRow": {
+          "description": "A transformer with a variable winding ratio control range (`vwr`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tau_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "tau_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "tau_min",
+            "tau_max"
+          ],
+          "type": "object"
+        },
+        "ScopfViolationCost": {
+          "description": "The case's four violation prices. The GOC3 document spells them\n`p_bus_vio_cost`, `q_bus_vio_cost`, `s_vio_cost`, and `e_vio_cost` under\n`network.violation_cost`. Any one of them can be absent and is then `None`:\nGOCompetition's 14 bus validation case has no `e_vio_cost`.",
+          "properties": {
+            "e": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_bus": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_bus": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "s": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "ScucDeviceOutputsV1": {
+          "additionalProperties": false,
+          "properties": {
+            "on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_nsyn_res": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_on": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_ramp_res_down_online": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_ramp_res_up_online": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_reg_res_down": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_reg_res_up": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_syn_res": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q_res_down": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q_res_up": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "on_status",
+            "p_on",
+            "q",
+            "p_reg_res_up",
+            "p_reg_res_down",
+            "p_syn_res",
+            "p_nsyn_res",
+            "p_ramp_res_up_online",
+            "p_ramp_res_down_online",
+            "q_res_up",
+            "q_res_down"
+          ],
+          "type": "object"
+        },
+        "ScucInputs": {
+          "description": "Matrix free SCOPF input data.\n\nInternal class, period, contingency, window, and flattened row indices are\nzero based and follow the source document order of the section that owns\nthem. Source UIDs and external bus IDs remain separate fields.",
+          "properties": {
+            "ac_contingency_survivors": {
+              "$ref": "#/$defs/ScopfAcContingencySurvivors"
+            },
+            "dc_contingency_flows": {
+              "items": {
+                "$ref": "#/$defs/ScopfDcContingencyFlowRow"
+              },
+              "type": "array"
+            },
+            "device_class_layout": {
+              "$ref": "#/$defs/ScopfDeviceClassLayout"
+            },
+            "dt": {
+              "description": "The interval durations, so a model needs no raw-document read for its\ntime axis. `lengths.l_t` is this vector's length.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "energy_windows": {
+              "$ref": "#/$defs/ScopfEnergyWindows"
+            },
+            "lengths": {
+              "$ref": "#/$defs/ScopfLengths"
+            },
+            "price_blocks": {
+              "$ref": "#/$defs/ScopfPriceBlocks"
+            },
+            "static_data": {
+              "$ref": "#/$defs/ScopfStaticData",
+              "description": "Buses, branches, devices, controls, reserves, and memberships."
+            },
+            "violation_cost": {
+              "$ref": "#/$defs/ScopfViolationCost"
+            }
+          },
+          "required": [
+            "static_data",
+            "lengths",
+            "energy_windows",
+            "price_blocks",
+            "ac_contingency_survivors",
+            "dc_contingency_flows",
+            "violation_cost",
+            "device_class_layout",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScucNetworkOutputsV1": {
+          "additionalProperties": false,
+          "properties": {
+            "ac_line_on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus_va": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus_vm": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_pdc_fr": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_qdc_fr": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_qdc_to": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "shunt_step": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_ta": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_tm": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "bus_vm",
+            "bus_va",
+            "shunt_step",
+            "ac_line_on_status",
+            "transformer_tm",
+            "transformer_ta",
+            "transformer_on_status"
+          ],
+          "type": "object"
+        },
+        "SeverityV1": {
+          "enum": [
+            "error",
+            "warning",
+            "remark",
+            "note"
+          ],
+          "type": "string"
+        },
+        "Shunt": {
+          "properties": {
+            "b": {
+              "description": "Shunt susceptance (MVAr at V = 1 p.u.). For a switched shunt this is the\ninitial (steady-state) value within the [`control`](Shunt::control) blocks.",
+              "format": "double",
+              "type": "number"
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "control": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SwitchedShuntControl"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Switching-control data when this is a switched (adjustable) shunt; `None`\nfor a fixed shunt. `#[serde(default)]` so JSON written before the field\nexisted still deserializes."
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g": {
+              "description": "Shunt conductance (MW at V = 1 p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "bus",
+            "g",
+            "b",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "ShuntBlock": {
+          "description": "One block of a switched shunt: `steps` equal increments of susceptance `b`.",
+          "properties": {
+            "b": {
+              "description": "Susceptance increment per step (MVAr at V = 1 p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "steps": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "steps",
+            "b"
+          ],
+          "type": "object"
+        },
+        "SolverParams": {
+          "description": "Solver / solution-control metadata: the Newton tolerance and iteration cap,\nthe zero-impedance threshold, and the per-quantity adjustment-enable flags.\n\nEach field is optional because a source states only the ones it carries. No\npower flow physics, but it determines whether a downstream solver reproduces\nthe source tool's converged answer. Maps to the PSS/E v34+ system-wide block\n(`GENERAL THRSHZ`, `NEWTON TOLN`/`ITMXN`, `SOLVER ACTAPS`/`AREAIN`/`PHSHFT`/\n`DCTAPS`/`SWSHNT`).",
+          "properties": {
+            "adjust_area_interchange": {
+              "description": "Whether the solver adjusts area interchange (`SOLVER AREAIN`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_dc_taps": {
+              "description": "Whether the solver adjusts DC line taps (`SOLVER DCTAPS`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_phase_shift": {
+              "description": "Whether the solver adjusts phase-shift angles (`SOLVER PHSHFT`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_switched_shunt": {
+              "description": "Whether the solver adjusts switched shunts (`SOLVER SWSHNT`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_taps": {
+              "description": "Whether the solver adjusts transformer taps (`SOLVER ACTAPS`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "max_iterations": {
+              "description": "Newton iteration cap (`NEWTON ITMXN`).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "newton_tolerance": {
+              "description": "Newton power flow mismatch tolerance (`NEWTON TOLN`).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "zero_impedance_threshold": {
+              "description": "Branches with `|x|` below this are treated as zero impedance (`GENERAL THRSHZ`).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "SourceDescriptorV1": {
+          "additionalProperties": false,
+          "properties": {
+            "byte_length": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "digest": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DigestV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "format": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "byte_length"
+          ],
+          "type": "object"
+        },
+        "SourceFormat": {
+          "description": "Which format a [`BalancedNetwork`] was read from. Drives the same format byte exact\necho on write.\n\nSerializes as the same lowercase token [`name`](SourceFormat::name) reports\nand every string entry point accepts, so the value a document carries is\nvalid input to `from`. Documents written before 0.9.0 spelled the bare\nvariant name (\"Matpower\"); the read side still accepts those spellings.",
+          "oneOf": [
+            {
+              "enum": [
+                "matpower",
+                "powermodels-json",
+                "egret-json",
+                "psse",
+                "powerworld",
+                "pandapower-json"
+              ],
+              "type": "string"
+            },
+            {
+              "const": "pslf",
+              "description": "Read from a GE PSLF `.epc` case. Same source text is retained, so a\nsame-format write echoes it byte-for-byte; a cross-format or\nsource-dropped write goes through the `.epc` serializer\n([`write_pslf`](crate::write_pslf)).",
+              "type": "string"
+            },
+            {
+              "const": "powerworld-pwb",
+              "description": "Read from a PowerWorld `.pwb` binary case. Read only: there is no\n`.pwb` writer and no retained source text, so writing goes through\nanother format's writer.",
+              "type": "string"
+            },
+            {
+              "const": "in-memory",
+              "description": "Built in memory, for example from synth or an edited case; no source text.",
+              "type": "string"
+            },
+            {
+              "const": "normalized",
+              "description": "A normalized derived form ([`BalancedNetwork::to_normalized`]): per unit, radians,\nfiltered, source bus ids preserved. Distinct from\n[`InMemory`](SourceFormat::InMemory) so consumers can tell a per unit\nproduct from a raw in memory network; it has no source text and a different\nunit basis than a parsed network.",
+              "type": "string"
+            },
+            {
+              "const": "gridfm",
+              "description": "Read back from a gridfm-datakit Parquet dataset (the ML→classical bridge,\n`powerio-matrix`'s `read_gridfm_dataset`). A lossy, power flow complete\nreconstruction with no retained source text: original bus ids are\nsynthesized `1..n`, per element load/shunt granularity is folded to one\nsynthetic element per bus, and HVDC/storage/piecewise costs are absent.",
+              "type": "string"
+            },
+            {
+              "const": "pypsa-csv",
+              "description": "Read from a PyPSA CSV folder. This is a folder format rather than a\nsingle retained text document, so same-format writes are canonicalized.",
+              "type": "string"
+            },
+            {
+              "const": "goc3-json",
+              "description": "Read from a DOE GO Challenge 3 JSON input document. The source is a\nunit commitment data set; the neutral transmission model keeps a static\nfirst interval network and retains the source text for the full data.",
+              "type": "string"
+            },
+            {
+              "const": "surge-json",
+              "description": "Read from a Surge native JSON document.",
+              "type": "string"
+            },
+            {
+              "const": "opfdata-json",
+              "description": "Read from one raw JSON document in a DeepMind OPFData release. The\nsource carries both solver initial values and a solution. The balanced\nmodel represents the solved snapshot and retains the source for an\nexact write back to the same format.",
+              "type": "string"
+            }
+          ]
+        },
+        "SourceMapEntryV1": {
+          "additionalProperties": false,
+          "properties": {
+            "relation": {
+              "$ref": "#/$defs/SourceRelationV1"
+            },
+            "spans": {
+              "description": "Empty only for `defaulted`, `synthetic`, or `transformed`.",
+              "items": {
+                "$ref": "#/$defs/SourceSpanV1"
+              },
+              "type": "array"
+            },
+            "target": {
+              "description": "RFC 6901 pointer into `value.data`.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "target",
+            "relation"
+          ],
+          "type": "object"
+        },
+        "SourceRelationV1": {
+          "enum": [
+            "exact",
+            "defaulted",
+            "inferred",
+            "converted_units",
+            "aggregated",
+            "split",
+            "synthetic",
+            "transformed",
+            "retained_extra"
+          ],
+          "type": "string"
+        },
+        "SourceSpanV1": {
+          "additionalProperties": false,
+          "properties": {
+            "byte_end": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "byte_start": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "byte_start",
+            "byte_end"
+          ],
+          "type": "object"
+        },
+        "Storage": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "charge_efficiency": {
+              "format": "double",
+              "type": "number"
+            },
+            "charge_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "current_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "discharge_efficiency": {
+              "format": "double",
+              "type": "number"
+            },
+            "discharge_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "energy": {
+              "format": "double",
+              "type": "number"
+            },
+            "energy_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "p_loss": {
+              "format": "double",
+              "type": "number"
+            },
+            "ps": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_loss": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "qs": {
+              "format": "double",
+              "type": "number"
+            },
+            "r": {
+              "format": "double",
+              "type": "number"
+            },
+            "thermal_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "ps",
+            "qs",
+            "energy",
+            "energy_rating",
+            "charge_rating",
+            "discharge_rating",
+            "charge_efficiency",
+            "discharge_efficiency",
+            "thermal_rating",
+            "qmin",
+            "qmax",
+            "r",
+            "x",
+            "p_loss",
+            "q_loss",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "StoredF64": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ]
+            }
+          ]
+        },
+        "StoredModuleV1": {
+          "additionalProperties": false,
+          "properties": {
+            "diagnostics": {
+              "items": {
+                "$ref": "#/$defs/DiagnosticV1"
+              },
+              "type": "array"
+            },
+            "extensions": {
+              "additionalProperties": true,
+              "description": "Nonsemantic third party annotations. Keys must be namespaced.",
+              "type": "object"
+            },
+            "history": {
+              "items": {
+                "$ref": "#/$defs/HistoryEntryV1"
+              },
+              "type": "array"
+            },
+            "producer": {
+              "$ref": "#/$defs/ProducerV1"
+            },
+            "schema": {
+              "type": "string"
+            },
+            "source_map": {
+              "items": {
+                "$ref": "#/$defs/SourceMapEntryV1"
+              },
+              "type": "array"
+            },
+            "sources": {
+              "items": {
+                "$ref": "#/$defs/SourceDescriptorV1"
+              },
+              "type": "array"
+            },
+            "value": {
+              "$ref": "#/$defs/StoredValueV1"
+            },
+            "version": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "schema",
+            "version",
+            "producer",
+            "value"
+          ],
+          "type": "object"
+        },
+        "StoredOperatingPointV1": {
+          "additionalProperties": false,
+          "description": "One stored operating point: the state quantities of a single point,\nkeyed by the instantaneous vocabulary, each with its resolved identity\norder and one row of values.",
+          "properties": {
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "StoredQuantityV1": {
+          "additionalProperties": false,
+          "description": "One state quantity's dense columns: the resolved identity order, then the\npoint major values (`time_points.len() × identities.len()`).",
+          "properties": {
+            "identities": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "values": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "identities",
+            "values"
+          ],
+          "type": "object"
+        },
+        "StoredValueV1": {
+          "description": "The tagged value DTO. `data` is a typed record, never an untyped JSON\ncatchall; the network payloads are the typed serializations the network\ncrates own (which carry the nonfinite spellings themselves).",
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetwork"
+                },
+                "kind": {
+                  "const": "balanced_network",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/MulticonductorNetwork"
+                },
+                "kind": {
+                  "const": "multiconductor_network",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetworkTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "balanced_network_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedOperatingPointTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "balanced_operating_point_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/MulticonductorOperatingPointTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "multiconductor_operating_point_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetworkScenarioSetV1"
+                },
+                "kind": {
+                  "const": "balanced_network_scenario_set",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "dc_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "dc_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "mc_ac_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "mc_ac_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcScucInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_scuc_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "dc_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "dc_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "mc_ac_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "mc_ac_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcScucSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_scuc_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "Switch": {
+          "description": "A transmission switch. Closed switches are preserved as data; matrix builders\ndo not lower them into zero impedance branches.",
+          "properties": {
+            "closed": {
+              "type": "boolean"
+            },
+            "current_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "pf": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "pt": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "qf": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "qt": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "thermal_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "closed",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "SwitchedShuntControl": {
+          "description": "Switching-control data for a switched shunt ([`Shunt::control`]): the mode,\nthe regulated voltage band and bus, the reactive-range percentage, and the\nadjustable susceptance blocks. The shunt's [`b`](Shunt::b) is the initial\nvalue within the blocks' total range.",
+          "properties": {
+            "blocks": {
+              "items": {
+                "$ref": "#/$defs/ShuntBlock"
+              },
+              "type": "array"
+            },
+            "control_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The regulated bus; `None` means the shunt regulates its own bus."
+            },
+            "mode": {
+              "$ref": "#/$defs/SwitchedShuntMode"
+            },
+            "rmpct": {
+              "description": "Percent of the controlled device's reactive range to apply (PSS/E `RMPCT`).",
+              "format": "double",
+              "type": "number"
+            },
+            "vhigh": {
+              "description": "Regulated voltage band (per unit).",
+              "format": "double",
+              "type": "number"
+            },
+            "vlow": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "mode",
+            "vhigh",
+            "vlow",
+            "rmpct",
+            "blocks"
+          ],
+          "type": "object"
+        },
+        "SwitchedShuntMode": {
+          "description": "How a switched shunt adjusts its susceptance. Maps to the PSS/E `MODSW` code.",
+          "oneOf": [
+            {
+              "const": "locked",
+              "description": "Fixed at its initial susceptance, no automatic switching (`MODSW` 0).",
+              "type": "string"
+            },
+            {
+              "const": "continuous",
+              "description": "Continuous adjustment within the block range (`MODSW` 1).",
+              "type": "string"
+            },
+            {
+              "const": "discrete",
+              "description": "Discrete adjustment in fixed steps (`MODSW` 2 and up).",
+              "type": "string"
+            }
+          ]
+        },
+        "Termination": {
+          "description": "How the producing calculation ended.",
+          "oneOf": [
+            {
+              "description": "The calculation converged to its stated tolerance.",
+              "properties": {
+                "kind": {
+                  "const": "converged",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The iteration limit ended the calculation before convergence.",
+              "properties": {
+                "kind": {
+                  "const": "iteration_limit",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The solver proved the constraints admit no solution. The optimization\noutcome an OPF consumer acts on differently from a numerical failure:\nthe case is overconstrained, and no retry or setting change fixes it.",
+              "properties": {
+                "kind": {
+                  "const": "infeasible",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The solver proved the objective unbounded over the feasible set.",
+              "properties": {
+                "kind": {
+                  "const": "unbounded",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The calculation failed.",
+              "properties": {
+                "kind": {
+                  "const": "failed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source records a solved calculation without termination\ninformation (DeepMind OPFData does).",
+              "properties": {
+                "kind": {
+                  "const": "not_reported",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "TimePointV1": {
+          "additionalProperties": false,
+          "properties": {
+            "duration": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DurationV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "label": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "label"
+          ],
+          "type": "object"
+        },
+        "Transformer3W": {
+          "description": "A three winding transformer with three terminal buses joined at a star point.\n\nSeries impedance is stored for winding pairs 1-2, 2-3, and 3-1. The record\nalso retains star point voltage and per winding control data. PSS/E three\nwinding records and PSLF tertiary winding records map to this type.\n[`to_star_expansion`](Transformer3W::to_star_expansion) turns it into the synthetic\nstar bus plus three branches for a consumer that works in the bus-branch model;\n[`IndexedNetwork`](crate::IndexedNetwork) applies it before building any matrix,\nso a 3-winding transformer contributes to `Y_bus` and connectivity.",
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "mag_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "mag_g": {
+              "description": "Magnetizing shunt referred to the star point (p.u. on the system base).",
+              "format": "double",
+              "type": "number"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "star_va": {
+              "format": "double",
+              "type": "number"
+            },
+            "star_vm": {
+              "description": "Star-point voltage magnitude (p.u.) and angle (degrees), as solved.",
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "windings": {
+              "description": "The three windings, in order (primary, secondary, tertiary).",
+              "items": {
+                "$ref": "#/$defs/Winding"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            "z": {
+              "description": "Pairwise series impedance `[z12, z23, z31]` (primary-secondary,\nsecondary-tertiary, tertiary-primary), each per unit on the system base\nwith its declared MVA base.",
+              "items": {
+                "$ref": "#/$defs/Impedance"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            }
+          },
+          "required": [
+            "windings",
+            "z",
+            "star_vm",
+            "star_va",
+            "mag_g",
+            "mag_b",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "TransformerControl": {
+          "description": "Automatic-control data for a regulating transformer ([`Branch::control`]).\n\nThe limits carry whatever the [`mode`](TransformerControl::mode) regulates:\n`tap_min`/`tap_max` bound the tap ratio (or the phase angle, for\n[`ActiveFlow`](TransformerControlMode::ActiveFlow)), and `band_min`/`band_max`\nbound the controlled quantity (the regulated voltage band, or the\nscheduled MW/MVAr). `ntp` is the number of discrete tap positions and\n`controlled_bus` is the regulated bus (`None` = the transformer's own\nterminal). `mva_base` is the winding MVA base the impedance is referred to.",
+          "properties": {
+            "band_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "band_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "controlled_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "mode": {
+              "$ref": "#/$defs/TransformerControlMode"
+            },
+            "mva_base": {
+              "format": "double",
+              "type": "number"
+            },
+            "ntp": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tap_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "tap_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "mode",
+            "tap_min",
+            "tap_max",
+            "band_min",
+            "band_max",
+            "ntp",
+            "mva_base"
+          ],
+          "type": "object"
+        },
+        "TransformerControlMode": {
+          "description": "What a regulating transformer's tap (or phase shift) automatically controls.\nMaps to the PSS/E control code `COD` and the PSLF transformer `type`.",
+          "oneOf": [
+            {
+              "const": "fixed",
+              "description": "Fixed ratio, no automatic adjustment (PSS/E `COD` 0/±4, PSLF type 1).",
+              "type": "string"
+            },
+            {
+              "const": "voltage",
+              "description": "Bus voltage control via tap (LTC; PSS/E `COD` ±1, PSLF type 2).",
+              "type": "string"
+            },
+            {
+              "const": "reactive_flow",
+              "description": "Reactive power flow control via tap (PSS/E `COD` ±2).",
+              "type": "string"
+            },
+            {
+              "const": "active_flow",
+              "description": "Active power flow control via phase shift (PSS/E `COD` ±3, PSLF type 4).",
+              "type": "string"
+            }
+          ]
+        },
+        "UntypedObject": {
+          "description": "An object the reader recognized but does not type: preserved by class,\nname, and raw property text so conversions can warn precisely.",
+          "properties": {
+            "class": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "props": {
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "class",
+            "name",
+            "props"
+          ],
+          "type": "object"
+        },
+        "VoltVarControl": {
+          "properties": {
+            "breakpoints": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_min_for_q": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_min_for_q_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_limits": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_ref": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ReactivePowerReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "q_unit": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ReactivePowerUnit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "voltage_reference": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ControlVoltageReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "breakpoints",
+            "q_limits"
+          ],
+          "type": "object"
+        },
+        "VoltWattControl": {
+          "properties": {
+            "breakpoints": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_limits": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_ref": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActivePowerReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "p_unit": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActivePowerUnit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "voltage_reference": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ControlVoltageReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "breakpoints",
+            "p_limits"
+          ],
+          "type": "object"
+        },
+        "VoltageSource": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_angle": {
+              "description": "Radians per terminal.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "v_magnitude": {
+              "description": "Volts per terminal (0.0 on grounded terminals).",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "v_magnitude",
+            "v_angle",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "Winding": {
+          "description": "One winding of a [`Transformer3W`]: its terminal bus, off-nominal ratio, phase\nshift, nominal voltage, and thermal ratings.",
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "nominal_kv": {
+              "description": "Winding nominal voltage (kV); 0 defers to the terminal bus base kV.",
+              "format": "double",
+              "type": "number"
+            },
+            "rate_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_c": {
+              "format": "double",
+              "type": "number"
+            },
+            "shift": {
+              "description": "Phase shift (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "tap": {
+              "description": "Off-nominal turns ratio (1.0 = nominal); the PSS/E `WINDV`, `CW = 1`.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "tap",
+            "shift",
+            "nominal_kv",
+            "rate_a",
+            "rate_b",
+            "rate_c"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "module": {
+          "$ref": "#/$defs/StoredModuleV1"
+        },
+        "spec": {
+          "$ref": "#/$defs/CapacityPlanSpec"
+        }
+      },
+      "required": [
+        "module",
+        "spec"
+      ],
+      "title": "PlanRequest",
+      "type": "object"
+    },
+    "plan_response": {
+      "$defs": {
+        "AcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "constraints": {
+              "$ref": "#/$defs/ActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1"
+            }
+          },
+          "required": [
+            "network",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "AcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_limit_multiplier": {
+              "description": "Nonnegative multiplier on the from-terminal apparent power bound.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_from_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_limit_multiplier": {
+              "description": "Nonnegative multiplier on the to-terminal apparent power bound.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_to_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_power_marginal": {
+              "description": "Optimal objective derivative per added MW of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_active_price": {
+              "description": "Read only 0.10 name for the active demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_reactive_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_reactive_power_marginal": {
+              "description": "Optimal objective derivative per added MVAr of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_reactive_price": {
+              "description": "Read only 0.10 name for the reactive demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_reactive_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/AcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_magnitude",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "bus_reactive_injection",
+            "branch_from_active_flow",
+            "branch_from_reactive_flow",
+            "branch_to_active_flow",
+            "branch_to_reactive_flow",
+            "generator_active_power",
+            "generator_reactive_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "AcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network"
+          ],
+          "type": "object"
+        },
+        "AcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_reactive_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_dispatch": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeneratorDispatchV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "instance": {
+              "$ref": "#/$defs/AcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_magnitude",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "bus_reactive_injection",
+            "branch_from_active_flow",
+            "branch_from_reactive_flow",
+            "branch_to_active_flow",
+            "branch_to_reactive_flow"
+          ],
+          "type": "object"
+        },
+        "AcScucInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "inputs": {
+              "$ref": "#/$defs/ScucInputs",
+              "description": "The complete SCUC inputs, in the calculation crate's own\nserialization, typed through this document's schema."
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network",
+            "inputs"
+          ],
+          "type": "object"
+        },
+        "AcScucSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "device_outputs": {
+              "$ref": "#/$defs/ScucDeviceOutputsV1"
+            },
+            "instance": {
+              "$ref": "#/$defs/AcScucInstanceV1"
+            },
+            "network_outputs": {
+              "$ref": "#/$defs/ScucNetworkOutputsV1"
+            },
+            "objective": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "network_outputs",
+            "device_outputs"
+          ],
+          "type": "object"
+        },
+        "ActiveConstraints": {
+          "description": "The active constraint families of a balanced OPF instance.",
+          "properties": {
+            "angle_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Branch angle difference bounds."
+            },
+            "generator_capability": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Generator capability bounds (active and reactive limits)."
+            },
+            "thermal_limits": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Branch thermal limits."
+            },
+            "voltage_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Bus voltage magnitude bounds."
+            }
+          },
+          "required": [
+            "generator_capability",
+            "voltage_bounds",
+            "thermal_limits",
+            "angle_bounds"
+          ],
+          "type": "object"
+        },
+        "ActivePowerReference": {
+          "enum": [
+            "P_AVAILABLE",
+            "P_MAX",
+            "S_MAX"
+          ],
+          "type": "string"
+        },
+        "ActivePowerUnit": {
+          "enum": [
+            "VA_FRACTION",
+            "W"
+          ],
+          "type": "string"
+        },
+        "Area": {
+          "description": "An area record: the area's scheduled net interchange and its swing bus.\n\nThe [`number`](Area::number) matches the `area` field carried on each\n[`Bus`]; this table holds the per-area metadata (the interchange target and\nthe area slack) that the bus number alone can't. Maps to the PSS/E area record\n(`I, ISW, PDES, PTOL, ARNAME`).",
+          "properties": {
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "net_interchange": {
+              "description": "Scheduled net interchange (MW); positive is export out of the area.",
+              "format": "double",
+              "type": "number"
+            },
+            "number": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "slack_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The area swing (slack) bus, or `None` when unset."
+            },
+            "tolerance": {
+              "description": "Interchange tolerance bandwidth (MW).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "number",
+            "net_interchange",
+            "tolerance"
+          ],
+          "type": "object"
+        },
+        "BalancedNetwork": {
+          "description": "A balanced network with stable source bus IDs and separate element tables.\n\n`remote = \"Self\"` turns the derived serde impls into inherent functions;\nthe trait impls beneath the struct route them through [`crate::nonfinite`],\nso a nonfinite float spells as a string on every JSON route.",
+          "properties": {
+            "areas": {
+              "default": [],
+              "description": "Area records: scheduled interchange and per-area swing bus. Distinct from\nthe bare `area` number on each [`Bus`]; this is the area's metadata, which\nevery conversion dropped before. `#[serde(default)]` so older JSON still\ndeserializes.",
+              "items": {
+                "$ref": "#/$defs/Area"
+              },
+              "type": "array"
+            },
+            "base_frequency": {
+              "default": 60.0,
+              "description": "System base frequency in hertz (50 or 60). Threaded through the formats\nthat record it (PSS/E `BASFRQ`, pandapower `f_hz`) and defaulted to\n[`DEFAULT_BASE_FREQUENCY`] for the rest. Load-bearing for any\nreactance↔henry conversion (pandapower line charging) and reported as a\nfidelity loss when a non-default value writes to a format with no\nfrequency field.",
+              "format": "double",
+              "type": "number"
+            },
+            "base_mva": {
+              "format": "double",
+              "type": "number"
+            },
+            "branches": {
+              "items": {
+                "$ref": "#/$defs/Branch"
+              },
+              "type": "array"
+            },
+            "buses": {
+              "items": {
+                "$ref": "#/$defs/Bus"
+              },
+              "type": "array"
+            },
+            "generators": {
+              "items": {
+                "$ref": "#/$defs/Generator"
+              },
+              "type": "array"
+            },
+            "geo": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeoMeta"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "hvdc": {
+              "items": {
+                "$ref": "#/$defs/Hvdc"
+              },
+              "type": "array"
+            },
+            "loads": {
+              "items": {
+                "$ref": "#/$defs/Load"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "shunts": {
+              "items": {
+                "$ref": "#/$defs/Shunt"
+              },
+              "type": "array"
+            },
+            "solver": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SolverParams"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Solver / solution-control metadata when the source carries it, else `None`.\n`#[serde(default)]` so older JSON still deserializes."
+            },
+            "source_format": {
+              "$ref": "#/$defs/SourceFormat"
+            },
+            "storage": {
+              "items": {
+                "$ref": "#/$defs/Storage"
+              },
+              "type": "array"
+            },
+            "switches": {
+              "default": [],
+              "items": {
+                "$ref": "#/$defs/Switch"
+              },
+              "type": "array"
+            },
+            "transformers_3w": {
+              "default": [],
+              "description": "Three-winding transformers, kept as typed records rather than folded into\n`branches`, so a star point and the per-winding data survive a round trip.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes. [`IndexedNetwork`](crate::IndexedNetwork) lowers each\nin-service record into a star bus plus three branches (via\n[`Transformer3W::to_star_expansion`]) before building any matrix, so a\n3-winding transformer does appear in `Y_bus`/connectivity; the canonical\nmodel keeps the typed record for round-trip fidelity.",
+              "items": {
+                "$ref": "#/$defs/Transformer3W"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "base_mva",
+            "buses",
+            "loads",
+            "shunts",
+            "branches",
+            "generators",
+            "storage",
+            "hvdc",
+            "source_format"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkScenarioSetV1": {
+          "additionalProperties": false,
+          "properties": {
+            "scenarios": {
+              "items": {
+                "$ref": "#/$defs/BalancedNetworkScenarioV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "scenarios"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkScenarioV1": {
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "probability": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "value": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "id",
+            "value"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            },
+            "values": {
+              "items": {
+                "$ref": "#/$defs/BalancedNetwork"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "time_points",
+            "values"
+          ],
+          "type": "object"
+        },
+        "BalancedOperatingPointTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "description": "Quantity name → dense columns, the balanced instantaneous vocabulary.",
+              "type": "object"
+            },
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "network",
+            "time_points",
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "Branch": {
+          "properties": {
+            "angmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "angmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "b": {
+              "description": "MATPOWER compatible total line charging susceptance (p.u.). This is the\nlegacy total projection; when [`charging`](Branch::charging) is present,\nper terminal admittance is canonical and this field is compatibility data.",
+              "format": "double",
+              "type": "number"
+            },
+            "charging": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchCharging"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Per terminal shunt admittance (p.u.). If absent, derive symmetric\nsusceptance from [`b`](Branch::b)."
+            },
+            "control": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TransformerControl"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Regulating-transformer control data, when this branch is a transformer\nunder automatic tap or phase control. `None` for lines and for fixed-ratio\ntransformers. `#[serde(default)]` so JSON written before the field existed\nstill deserializes."
+            },
+            "current_ratings": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchCurrentRatings"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Current ratings, when the source distinguishes them from MVA ratings."
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "r": {
+              "description": "Series resistance (p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "rate_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_c": {
+              "format": "double",
+              "type": "number"
+            },
+            "rating_sets": {
+              "default": [],
+              "description": "Additional MVA rating sets beyond A/B/C. Matrix builders continue to use\n`rate_a` unless they opt into one of these named sets.",
+              "items": {
+                "$ref": "#/$defs/BranchRatingSet"
+              },
+              "type": "array"
+            },
+            "route": {
+              "description": "Polyline route in the network's coordinate space (`BalancedNetwork.geo`),\npresent only when a source provides intermediate geometry; endpoint\nonly rendering derives from the bus locations. `#[serde(default)]` so\nJSON written before the field existed still deserializes.",
+              "items": {
+                "$ref": "#/$defs/Location"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "shift": {
+              "description": "Phase shift (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "solution": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchSolution"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Solved branch flow values, when present in a case snapshot."
+            },
+            "tap": {
+              "description": "Tap ratio, MATPOWER convention: 0 means \"no tap\" (a line), treated as 1.",
+              "format": "double",
+              "type": "number"
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x": {
+              "description": "Series reactance (p.u.).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "r",
+            "x",
+            "b",
+            "rate_a",
+            "rate_b",
+            "rate_c",
+            "tap",
+            "shift",
+            "in_service",
+            "angmin",
+            "angmax",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "BranchCharging": {
+          "description": "Per terminal branch shunt admittance in p.u. This is the canonical\nphysical branch shunt model when present.",
+          "properties": {
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "g_fr",
+            "b_fr",
+            "g_to",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "BranchCurrentRatings": {
+          "description": "Current limits for a branch, in source units.",
+          "properties": {
+            "c_rating_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rating_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rating_c": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "c_rating_a",
+            "c_rating_b",
+            "c_rating_c"
+          ],
+          "type": "object"
+        },
+        "BranchRatingSet": {
+          "description": "Extra branch MVA rating set beyond the canonical A/B/C columns.",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "rate_mva": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "name",
+            "rate_mva"
+          ],
+          "type": "object"
+        },
+        "BranchSolution": {
+          "description": "Solved branch terminal flows in MW/MVAr.",
+          "properties": {
+            "pf": {
+              "format": "double",
+              "type": "number"
+            },
+            "pt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qt": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "pf",
+            "qf",
+            "pt",
+            "qt"
+          ],
+          "type": "object"
+        },
+        "Bus": {
+          "properties": {
+            "area": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "base_kv": {
+              "format": "double",
+              "type": "number"
+            },
+            "evhi": {
+              "default": null,
+              "description": "Emergency (short-term) voltage band, set only when the source states one\ndistinct from the normal [`vmax`](Bus::vmax)/[`vmin`](Bus::vmin) band (PSS/E\n`EVHI`/`EVLO`). `None` means the emergency band equals the normal band, so\nread `evhi.unwrap_or(vmax)` / `evlo.unwrap_or(vmin)`. `#[serde(default)]` so\nJSON written before the fields existed still deserializes.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "evlo": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "id": {
+              "$ref": "#/$defs/BusId",
+              "description": "Stable bus id (1-based in MATPOWER; preserved verbatim)."
+            },
+            "kind": {
+              "$ref": "#/$defs/BusType"
+            },
+            "location": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Location"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional bus coordinates in the network coordinate space."
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uid": {
+              "description": "Stable row identity for `.pio.json` payloads and operating point updates:\nthe source record uid where the format defines one (GOC3), synthesized at\npackage build otherwise. `#[serde(default)]` so JSON written before the\nfield existed still deserializes.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "va": {
+              "description": "Voltage angle (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "vm": {
+              "description": "Voltage magnitude (p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "vmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "vmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "zone": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "id",
+            "kind",
+            "vm",
+            "va",
+            "base_kv",
+            "vmax",
+            "vmin",
+            "area",
+            "zone",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "BusId": {
+          "description": "A source bus ID, preserved from the input format.\n\nMATPOWER IDs are 1-based and can contain gaps. They are distinct from the\nzero based dense indices produced by\n[`IndexedNetwork::bus_index`](crate::IndexedNetwork::bus_index). JSON stores\nthis type as an integer.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "BusType": {
+          "description": "Bus type per MATPOWER convention: 1=PQ, 2=PV, 3=ref/slack, 4=isolated.",
+          "enum": [
+            "PQ",
+            "PV",
+            "REF",
+            "ISOLATED"
+          ],
+          "type": "string"
+        },
+        "Canvas": {
+          "description": "Diagram canvas metadata.",
+          "properties": {
+            "height": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "units": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "CapacityPlanIteration": {
+          "description": "One recorded search step: the direction the gradient named, the rating\ntrial, the first order prediction, the exact outcome, and\nwhether the step was kept.",
+          "properties": {
+            "accepted": {
+              "type": "boolean"
+            },
+            "delta_mw": {
+              "description": "The trial rating changes, MW.",
+              "items": {
+                "$ref": "#/$defs/RatingChange"
+              },
+              "type": "array"
+            },
+            "exact_phi_delta": {
+              "description": "Exact `Phi(after) - Phi(before)` from the trial re-solve;\n`None` when the trial solve failed.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "first_order_error": {
+              "description": "`|exact - predicted|` and its ratio to `|exact|`, when the trial\nsolved.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "first_order_error_rel": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "gradient": {
+              "description": "`dPhi/dc` at the step's starting point for every candidate, in outer\nobjective units per MW.",
+              "items": {
+                "$ref": "#/$defs/GradientEntry"
+              },
+              "type": "array"
+            },
+            "predicted_phi_delta": {
+              "description": "First order prediction `Σ g_e · delta_e`.",
+              "format": "double",
+              "type": "number"
+            },
+            "reason": {
+              "description": "Why the step was kept or dropped, one short sentence.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "gradient",
+            "delta_mw",
+            "predicted_phi_delta",
+            "accepted",
+            "reason"
+          ],
+          "type": "object"
+        },
+        "CapacityPlanOutcome": {
+          "description": "The outcome of one bounded planning search and its unapplied\nproposal.",
+          "properties": {
+            "baseline": {
+              "$ref": "#/$defs/CapacityPlanResultSummary",
+              "description": "Summary of the baseline and the final accepted exact solve. The solve\nnumbers refer to this planning operation's exact solve budget."
+            },
+            "baseline_phi": {
+              "description": "`Phi` at the starting exact solve.",
+              "format": "double",
+              "type": "number"
+            },
+            "exact_solves": {
+              "description": "Exact OPF solves consumed, including the baseline.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "exact_verified_result": {
+              "$ref": "#/$defs/CapacityPlanResultSummary"
+            },
+            "final_phi": {
+              "description": "`Phi` at the final accepted exact solve.",
+              "format": "double",
+              "type": "number"
+            },
+            "iterations": {
+              "description": "Every trial in order, accepted and rejected.",
+              "items": {
+                "$ref": "#/$defs/CapacityPlanIteration"
+              },
+              "type": "array"
+            },
+            "proposal": {
+              "description": "The accumulated accepted rating changes: the unapplied proposal.",
+              "items": {
+                "$ref": "#/$defs/RatingChange"
+              },
+              "type": "array"
+            },
+            "spent_budget_mw": {
+              "description": "Total accepted movement `Σ |delta|`, MW, against the budget.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "baseline",
+            "exact_verified_result",
+            "baseline_phi",
+            "final_phi",
+            "proposal",
+            "spent_budget_mw",
+            "iterations",
+            "exact_solves"
+          ],
+          "type": "object"
+        },
+        "CapacityPlanResultSummary": {
+          "description": "One exact result retained in the serializable planning record.",
+          "properties": {
+            "declared_objective": {
+              "format": "double",
+              "type": "number"
+            },
+            "exact_solve": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "phi": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "phi",
+            "declared_objective",
+            "exact_solve"
+          ],
+          "type": "object"
+        },
+        "Configuration": {
+          "enum": [
+            "wye",
+            "delta",
+            "single_phase"
+          ],
+          "type": "string"
+        },
+        "ConstraintSelection": {
+          "description": "Which elements of one constraint family are active, by stable element\nidentity (the payload `uid`, else `{table}:{row}`; buses by their id).",
+          "oneOf": [
+            {
+              "description": "Every element with a stated limit.",
+              "properties": {
+                "select": {
+                  "const": "all",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "No element; the family is relaxed.",
+              "properties": {
+                "select": {
+                  "const": "none",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exactly the named elements.",
+              "properties": {
+                "identities": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "select": {
+                  "const": "only",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select",
+                "identities"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ControlVoltageReference": {
+          "enum": [
+            "PN_PER_PHASE",
+            "PP_PER_PHASE",
+            "PP_AVERAGED",
+            "PG_AVERAGED",
+            "PN_AVERAGED",
+            "PG_PER_PHASE"
+          ],
+          "type": "string"
+        },
+        "CoordsKind": {
+          "description": "Coordinate origin.",
+          "enum": [
+            "source",
+            "synthetic",
+            "manual",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "DcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "approximation": {
+              "description": "Frozen `powerio.module/1` key from 0.10. The value is the selected\n[`BranchSusceptanceFormula`](powerio_tx::BranchSusceptanceFormula) stable name.",
+              "type": "string"
+            },
+            "constraints": {
+              "$ref": "#/$defs/ActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1",
+              "description": "The typed objective the instance states, in the calculation crate's\nown serialization."
+            }
+          },
+          "required": [
+            "network",
+            "approximation",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "DcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_flow_dual": {
+              "description": "Read only 0.10 signed thermal dual (`from - to`). The 1.x reader splits\nit into the two directional multiplier columns.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_limit_multiplier": {
+              "description": "Nonnegative multiplier on the from-side thermal bound, by branch.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_limit_multiplier": {
+              "description": "Nonnegative multiplier on the to-side thermal bound, by branch.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_power_marginal": {
+              "description": "Optimal objective derivative per added MW of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_price": {
+              "description": "Read only 0.10 name for the active demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/DcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "branch_from_active_flow",
+            "branch_to_active_flow",
+            "generator_active_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "DcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "approximation": {
+              "description": "Frozen `powerio.module/1` key from 0.10. The value is the selected\n[`BranchSusceptanceFormula`](powerio_tx::BranchSusceptanceFormula) stable name.",
+              "type": "string"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network",
+            "approximation"
+          ],
+          "type": "object"
+        },
+        "DcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_dispatch": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeneratorDispatchV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "instance": {
+              "$ref": "#/$defs/DcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "branch_from_active_flow",
+            "branch_to_active_flow"
+          ],
+          "type": "object"
+        },
+        "DiagnosticV1": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "related": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "severity": {
+              "$ref": "#/$defs/SeverityV1"
+            },
+            "spans": {
+              "items": {
+                "$ref": "#/$defs/SourceSpanV1"
+              },
+              "type": "array"
+            },
+            "suggested_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "target": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "severity",
+            "code",
+            "message"
+          ],
+          "type": "object"
+        },
+        "DigestAlgorithmV1": {
+          "enum": [
+            "sha256"
+          ],
+          "type": "string"
+        },
+        "DigestV1": {
+          "additionalProperties": false,
+          "properties": {
+            "algorithm": {
+              "$ref": "#/$defs/DigestAlgorithmV1"
+            },
+            "value": {
+              "description": "Lowercase hexadecimal, without a prefix.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "algorithm",
+            "value"
+          ],
+          "type": "object"
+        },
+        "DistBus": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "grounded": {
+              "description": "Terminals tied to ground with zero impedance.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "location": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistLocation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional bus coordinates in the network coordinate space."
+            },
+            "terminals": {
+              "description": "Ordered terminal names; OpenDSS node numbers as strings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "v_min": {
+              "description": "Voltage magnitude bounds, volts: the scalar pair plus the phase to\nneutral and phase to phase families, and the per-sequence scalars\n(BMOPF schema 0.1.0: positive sequence has both bounds, negative and\nzero sequence and neutral to ground are magnitude caps whose lower\nbound is always 0).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vn_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vneg_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpn_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpn_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpos_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpos_min": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpp_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpp_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vzero_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "terminals",
+            "grounded",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistCanvas": {
+          "description": "Diagram canvas metadata.",
+          "properties": {
+            "height": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "units": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "DistCapacitor": {
+          "description": "A rated capacitor bank (BMOPF schema 0.1.0 `capacitor`): `q_rated` vars\ndelivered at `v_nom` volts across the element terminals, distinct from the\nraw admittance [`DistShunt`]. The DSS converter still lowers OpenDSS\ncapacitors to shunt B matrices; this element carries capacitors that arrive\nas BMOPF input.",
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "q_rated": {
+              "description": "Nameplate rated reactive power of the whole bank, vars.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_nom": {
+              "description": "Nameplate nominal voltage, volts: line to line for the three phase\nconfigurations, across the terminals for SINGLE_PHASE.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "q_rated",
+            "v_nom",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistControlProfile": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "power_factor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/PowerFactorControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volt_var": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/VoltVarControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volt_watt": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/VoltWattControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistCoordsKind": {
+          "description": "Coordinate origin.",
+          "enum": [
+            "source",
+            "synthetic",
+            "manual",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "DistGenerator": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "cost": {
+              "description": "Generation cost, $/kWh per phase conductor, exactly as the source\nstates it: one entry per phase, or a single entry for a scalar\nstatement. No OpenDSS equivalent, so it is None until a format\nsupplies it.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_min": {
+              "default": null,
+              "description": "Bounds per phase. A `null` element reads as -Inf in a lower bound\nand +Inf in an upper bound: the PMD unbounded spelling (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_nom": {
+              "description": "Setpoint, watts per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "s_max": {
+              "description": "Per-conductor apparent power and current limits, VA and amps (BMOPF\ngenerator fields, alongside the p/q bounds).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "p_nom",
+            "q_nom",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistGeoMeta": {
+          "description": "Network level coordinate metadata.",
+          "oneOf": [
+            {
+              "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "geographic",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Planar coordinates, with the CRS named when known.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "projected",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Drawing coordinates with no earth referent.",
+              "properties": {
+                "canvas": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/DistCanvas"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "space": {
+                  "const": "diagram",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source did not declare a coordinate space.",
+              "properties": {
+                "space": {
+                  "const": "unknown",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            }
+          ],
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistCoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Default origin for points without their own `kind`."
+            }
+          },
+          "type": "object"
+        },
+        "DistIbr": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "control_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Per conductor current limits, amperes.",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_avail": {
+              "description": "Available active power, watts.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "prime_mover": {
+              "$ref": "#/$defs/IbrPrimeMover"
+            },
+            "q_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "s_max": {
+              "description": "Per phase apparent power nameplate ratings, volt amperes.",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": "array"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "topology": {
+              "$ref": "#/$defs/IbrTopology"
+            },
+            "voltage_aggregation": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/IbrVoltageAggregation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "topology",
+            "prime_mover",
+            "s_max",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLine": {
+          "properties": {
+            "bus_from": {
+              "type": "string"
+            },
+            "bus_to": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "description": "Per-conductor ampacity and apparent power limits, amps and VA\n(BMOPF schema 0.1.0 line fields, alongside the linecode's own).\nA `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "length": {
+              "description": "Meters. A `null` reads as NaN: a BMOPF line without a length (#268).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "linecode": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "route": {
+              "description": "Polyline route in the network's coordinate space (`MulticonductorNetwork.geo`),\npresent only when a source provides intermediate geometry.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes.",
+              "items": {
+                "$ref": "#/$defs/DistLocation"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "s_max": {
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_map_from": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "terminal_map_to": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus_from",
+            "bus_to",
+            "terminal_map_from",
+            "terminal_map_to",
+            "linecode",
+            "length",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLineCode": {
+          "properties": {
+            "b_from": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "b_to": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g_from": {
+              "description": "Shunt admittance halves at each end, S per meter.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "g_to": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "n_conductors": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "r_series": {
+              "description": "Series impedance, ohm per meter.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "s_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "source": {
+              "description": "Origin of the impedance matrices (BMOPF `source`, e.g. \"fem\",\n\"datasheet\", \"import\").",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x_series": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "n_conductors",
+            "r_series",
+            "x_series",
+            "g_from",
+            "b_from",
+            "g_to",
+            "b_to",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLoad": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_nom": {
+              "description": "Watts per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_nom": {
+              "description": "Vars per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "voltage_model": {
+              "$ref": "#/$defs/DistLoadVoltageModel"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "p_nom",
+            "q_nom",
+            "voltage_model",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLoadVoltageModel": {
+          "oneOf": [
+            {
+              "description": "Constant power load. `v_nom` is volts per active phase when the source\nstates it.",
+              "properties": {
+                "model": {
+                  "const": "constant_power",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Constant current load. `v_nom` is volts per active phase.",
+              "properties": {
+                "model": {
+                  "const": "constant_current",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Constant impedance load. `v_nom` is volts per active phase.",
+              "properties": {
+                "model": {
+                  "const": "constant_impedance",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "ZIP load coefficients by active phase. `v_nom` is volts per active\nphase; alpha terms apply to active power and beta terms to reactive\npower.",
+              "properties": {
+                "alpha_i": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "alpha_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "alpha_z": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_i": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_z": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "model": {
+                  "const": "zip",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom",
+                "alpha_z",
+                "alpha_i",
+                "alpha_p",
+                "beta_z",
+                "beta_i",
+                "beta_p"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exponential voltage model by active phase. `v_nom` is volts per active\nphase.",
+              "properties": {
+                "gamma_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "gamma_q": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "model": {
+                  "const": "exponential",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom",
+                "gamma_p",
+                "gamma_q"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "DistLocation": {
+          "description": "A point attached to one model element.",
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistCoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Point origin when it differs from the network default."
+            },
+            "x": {
+              "description": "X coordinate. In geographic space this is longitude.",
+              "format": "double",
+              "type": "number"
+            },
+            "y": {
+              "description": "Y coordinate. In geographic space this is latitude.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ],
+          "type": "object"
+        },
+        "DistShunt": {
+          "properties": {
+            "b": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g": {
+              "description": "Total siemens in conductor order.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "g",
+            "b",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistSourceFormat": {
+          "description": "Where the network came from; fixes the echo tier target.",
+          "enum": [
+            "dss",
+            "bmopf-json",
+            "pmd-json"
+          ],
+          "type": "string"
+        },
+        "DistSwitch": {
+          "properties": {
+            "bus_from": {
+              "type": "string"
+            },
+            "bus_to": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "open": {
+              "type": "boolean"
+            },
+            "terminal_map_from": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "terminal_map_to": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus_from",
+            "bus_to",
+            "terminal_map_from",
+            "terminal_map_to",
+            "open",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistTransformer": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "phases": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "windings": {
+              "items": {
+                "$ref": "#/$defs/DistWinding"
+              },
+              "type": "array"
+            },
+            "xsc_pct": {
+              "description": "Short circuit reactances between winding pairs, percent:\n`[xhl]` for two windings, `[xhl, xht, xlt]` for three.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "windings",
+            "xsc_pct",
+            "phases",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistWinding": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "conn": {
+              "$ref": "#/$defs/DistWindingConn"
+            },
+            "r_neutral": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "r_pct": {
+              "description": "Winding resistance, percent of the winding base.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "s_rating": {
+              "description": "Volt amperes.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "tap": {
+              "format": "double",
+              "type": "number"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_ref": {
+              "description": "Rated winding voltage, volts (line to line for 2 and 3 phase).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "x_neutral": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "bus",
+            "terminal_map",
+            "conn",
+            "v_ref",
+            "s_rating",
+            "r_pct",
+            "tap"
+          ],
+          "type": "object"
+        },
+        "DistWindingConn": {
+          "enum": [
+            "wye",
+            "delta"
+          ],
+          "type": "string"
+        },
+        "DurationV1": {
+          "additionalProperties": false,
+          "description": "A stored duration: unsigned seconds plus a nanosecond remainder below one\nbillion, exactly.",
+          "properties": {
+            "nanos": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "secs": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "secs",
+            "nanos"
+          ],
+          "type": "object"
+        },
+        "GenCost": {
+          "description": "A generator cost curve (`mpc.gencost` row).",
+          "properties": {
+            "coeffs": {
+              "description": "Raw coefficients, highest order first for the polynomial model:\n`[c_{k-1}, …, c1, c0]`.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "model": {
+              "description": "1 = piecewise linear, 2 = polynomial.",
+              "format": "uint8",
+              "maximum": 255,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "ncost": {
+              "description": "Number of cost coefficients (polynomial) or breakpoints (piecewise).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "shutdown": {
+              "format": "double",
+              "type": "number"
+            },
+            "startup": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "model",
+            "startup",
+            "shutdown",
+            "ncost",
+            "coeffs"
+          ],
+          "type": "object"
+        },
+        "Generator": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "caps": {
+              "additionalProperties": {
+                "format": "double",
+                "type": "number"
+              },
+              "default": {},
+              "description": "The MATPOWER gen capability / ramp columns past `PMIN`, aligned to\n`GEN_EXTRA_KEYS` by index (`None` for a column the source omitted).\nA fixed array, not an [`Extras`] map: a string-keyed map per generator\ncosts 11 heap allocations each, which dominates the parse of a large\ngenerator-heavy case. Surfaced into formats that name them (PowerModels).\nOn the JSON snapshot it is a name-keyed object (see `caps_serde`) so the\nschema stays additive when `GEN_EXTRA_KEYS` grows; `#[serde(default)]` so a\nsnapshot that omits it deserializes to the empty set.",
+              "type": "object"
+            },
+            "cost": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GenCost"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "mbase": {
+              "format": "double",
+              "type": "number"
+            },
+            "pg": {
+              "description": "Real power set point (MW).",
+              "format": "double",
+              "type": "number"
+            },
+            "pmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "qg": {
+              "description": "Reactive power set point (MVAr).",
+              "format": "double",
+              "type": "number"
+            },
+            "qmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "regulated_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "The remote bus whose voltage this generator regulates, when that is not its\nown terminal bus (PSS/E `IREG`). `None` means it regulates its own bus.\nPart of the cross-element voltage-control graph: a format that names a\nremote regulated bus (PSS/E) keeps it across a round trip instead of\ncollapsing every generator onto its own terminal. `#[serde(default)]` so\nJSON written before the field existed still deserializes."
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "vg": {
+              "description": "Voltage set point (p.u.).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "pg",
+            "qg",
+            "pmax",
+            "pmin",
+            "qmax",
+            "qmin",
+            "vg",
+            "mbase",
+            "in_service"
+          ],
+          "type": "object"
+        },
+        "GeneratorDispatchV1": {
+          "additionalProperties": false,
+          "description": "A solution's producer stated generator dispatch.",
+          "properties": {
+            "p_mw": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "q_mvar": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "p_mw",
+            "q_mvar"
+          ],
+          "type": "object"
+        },
+        "GeoMeta": {
+          "description": "Network level coordinate metadata.",
+          "oneOf": [
+            {
+              "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "geographic",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Planar coordinates, with the CRS named when known.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "projected",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Drawing coordinates with no earth referent.",
+              "properties": {
+                "canvas": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/Canvas"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "space": {
+                  "const": "diagram",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source did not declare a coordinate space.",
+              "properties": {
+                "space": {
+                  "const": "unknown",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            }
+          ],
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/CoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Default origin for points without their own `kind`."
+            }
+          },
+          "type": "object"
+        },
+        "GradientEntry": {
+          "description": "One implicit gradient entry, in outer objective units per MW, by canonical\nPowerIO identity.",
+          "properties": {
+            "branch": {
+              "type": "string"
+            },
+            "value": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "branch",
+            "value"
+          ],
+          "type": "object"
+        },
+        "HistoryEntryV1": {
+          "additionalProperties": false,
+          "description": "Describes an operation that produced the current value. Not a replay\nprogram; replayable revisions require their own typed value.",
+          "properties": {
+            "assumptions": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "input_kind": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "$ref": "#/$defs/HistoryKindV1"
+            },
+            "losses": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Stable registered operation name.",
+              "type": "string"
+            },
+            "output_kind": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "parameters": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "required": [
+            "id",
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        "HistoryKindV1": {
+          "enum": [
+            "parse",
+            "upgrade",
+            "transform",
+            "edit",
+            "repair"
+          ],
+          "type": "string"
+        },
+        "Hvdc": {
+          "description": "A two-terminal HVDC line (MATPOWER `dcline`).\n\n`pf`/`pt`/`qf`/`qt` are stored in MATPOWER's sign convention regardless of\nsource: the PowerModels reader un-flips `pt`/`qf`/`qt` on the way in, and the\nPowerModels writer re-flips them on the way out (PowerModels.jl uses the\nopposite sign). The flip is a format-boundary translation, so a derived view\nlike `to_normalized` keeps the MATPOWER convention and only scales to per unit.",
+          "properties": {
+            "cost": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GenCost"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "loss0": {
+              "format": "double",
+              "type": "number"
+            },
+            "loss1": {
+              "format": "double",
+              "type": "number"
+            },
+            "pf": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "pt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmaxf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmaxt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qminf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmint": {
+              "format": "double",
+              "type": "number"
+            },
+            "qt": {
+              "format": "double",
+              "type": "number"
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "vf": {
+              "format": "double",
+              "type": "number"
+            },
+            "vt": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "in_service",
+            "pf",
+            "pt",
+            "qf",
+            "qt",
+            "vf",
+            "vt",
+            "pmin",
+            "pmax",
+            "qminf",
+            "qmaxf",
+            "qmint",
+            "qmaxt",
+            "loss0",
+            "loss1",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "IbrPrimeMover": {
+          "enum": [
+            "PV",
+            "BATTERY",
+            "GENERIC",
+            "STATCOM",
+            "DSTATCOM"
+          ],
+          "type": "string"
+        },
+        "IbrTopology": {
+          "enum": [
+            "SINGLE_PHASE",
+            "THREE_LEG",
+            "FOUR_LEG"
+          ],
+          "type": "string"
+        },
+        "IbrVoltageAggregation": {
+          "enum": [
+            "PER_PHASE",
+            "AVERAGE"
+          ],
+          "type": "string"
+        },
+        "Impedance": {
+          "description": "A series impedance with the MVA base it is expressed on. Used pairwise by\n[`Transformer3W`]; a self-contained unit so the base travels with the value\ninstead of being implied by position.\n\n`r`/`x` are per unit on the *system* base (the same `CZ = 1` convention as\n[`Branch::r`]/[`Branch::x`], so the matrix math needs no rebasing); `base_mva`\nrecords the winding-pair MVA base the source file declared (PSS/E `SBASE1-2`\nand friends), kept so a write-back reproduces it and so a future `CZ = 2`\nreader has somewhere to put the winding base it must rebase from. Room to grow\n(winding voltage base, turns-ratio units) as the transformer control work\nlands without reshaping the [`Transformer3W::z`] array.",
+          "properties": {
+            "base_mva": {
+              "format": "double",
+              "type": "number"
+            },
+            "r": {
+              "format": "double",
+              "type": "number"
+            },
+            "x": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "r",
+            "x",
+            "base_mva"
+          ],
+          "type": "object"
+        },
+        "Load": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "p": {
+              "description": "Active demand (MW).",
+              "format": "double",
+              "type": "number"
+            },
+            "q": {
+              "description": "Reactive demand (MVAr).",
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "voltage_model": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LoadVoltageModel"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Voltage dependence, when the source states one. `None` is constant power."
+            }
+          },
+          "required": [
+            "bus",
+            "p",
+            "q",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "LoadVoltageModel": {
+          "description": "Voltage dependence for a transmission load.",
+          "oneOf": [
+            {
+              "description": "Explicit constant power marker.",
+              "properties": {
+                "kind": {
+                  "const": "constant_power",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "ZIP load split in source units. The three active parts sum to\n[`Load::p`], and the three reactive parts sum to [`Load::q`].",
+              "properties": {
+                "kind": {
+                  "const": "zip",
+                  "type": "string"
+                },
+                "load_type": {
+                  "default": null,
+                  "description": "Source load type code, when a format has one (PSS/E `ID`/`LOADTYPE`\nstyle metadata).",
+                  "format": "int32",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "p_constant_current": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "p_constant_impedance": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "p_constant_power": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_current": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_impedance": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_power": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "scaling": {
+                  "default": null,
+                  "description": "Source scaling factor, when a format has one.",
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "v_nom": {
+                  "default": null,
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "p_constant_power",
+                "q_constant_power",
+                "p_constant_current",
+                "q_constant_current",
+                "p_constant_impedance",
+                "q_constant_impedance"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exponential voltage model: `P = p * (V / v_nom)^gamma_p`,\n`Q = q * (V / v_nom)^gamma_q`.",
+              "properties": {
+                "gamma_p": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "gamma_q": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "kind": {
+                  "const": "exponential",
+                  "type": "string"
+                },
+                "p": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "v_nom": {
+                  "default": null,
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "p",
+                "q",
+                "gamma_p",
+                "gamma_q"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "Location": {
+          "description": "A point attached to one model element.",
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/CoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Point origin when it differs from the network default."
+            },
+            "x": {
+              "description": "X coordinate. In geographic space this is longitude.",
+              "format": "double",
+              "type": "number"
+            },
+            "y": {
+              "description": "Y coordinate. In geographic space this is latitude.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ],
+          "type": "object"
+        },
+        "McAcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "constraints": {
+              "$ref": "#/$defs/MulticonductorActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1"
+            }
+          },
+          "required": [
+            "network",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "McAcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/McAcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "source_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_current_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "terminal_voltage_magnitude",
+            "terminal_voltage_angle",
+            "source_active_injection",
+            "generator_active_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "McAcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            }
+          },
+          "required": [
+            "network"
+          ],
+          "type": "object"
+        },
+        "McAcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "instance": {
+              "$ref": "#/$defs/McAcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "source_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_current_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "terminal_voltage_magnitude",
+            "terminal_voltage_angle",
+            "source_active_injection"
+          ],
+          "type": "object"
+        },
+        "MulticonductorActiveConstraints": {
+          "description": "The active constraint families of a multiconductor OPF instance.",
+          "properties": {
+            "conductor_limits": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Conductor current or apparent power limits."
+            },
+            "generator_capability": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Per phase generator capability bounds."
+            },
+            "terminal_voltage_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Terminal voltage magnitude bounds."
+            }
+          },
+          "required": [
+            "terminal_voltage_bounds",
+            "conductor_limits",
+            "generator_capability"
+          ],
+          "type": "object"
+        },
+        "MulticonductorNetwork": {
+          "description": "A multiconductor distribution network.\n\n`source` retains the original text for the byte exact echo tier;\n`defaulted` records, per element (`\"class.name\"` key), the fields the\nreader materialized from format defaults rather than the source text.",
+          "properties": {
+            "base_frequency": {
+              "description": "Hz.",
+              "format": "double",
+              "type": "number"
+            },
+            "buses": {
+              "items": {
+                "$ref": "#/$defs/DistBus"
+              },
+              "type": "array"
+            },
+            "capacitors": {
+              "items": {
+                "$ref": "#/$defs/DistCapacitor"
+              },
+              "type": "array"
+            },
+            "commands": {
+              "description": "Source commands and options the typed model does not interpret\n(`solve`, `set mode=...`), in order, as (verb, args).",
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "control_profiles": {
+              "items": {
+                "$ref": "#/$defs/DistControlProfile"
+              },
+              "type": "array"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "generators": {
+              "items": {
+                "$ref": "#/$defs/DistGenerator"
+              },
+              "type": "array"
+            },
+            "geo": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistGeoMeta"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "ibrs": {
+              "items": {
+                "$ref": "#/$defs/DistIbr"
+              },
+              "type": "array"
+            },
+            "linecodes": {
+              "items": {
+                "$ref": "#/$defs/DistLineCode"
+              },
+              "type": "array"
+            },
+            "lines": {
+              "items": {
+                "$ref": "#/$defs/DistLine"
+              },
+              "type": "array"
+            },
+            "loads": {
+              "items": {
+                "$ref": "#/$defs/DistLoad"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "options": {
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "shunts": {
+              "items": {
+                "$ref": "#/$defs/DistShunt"
+              },
+              "type": "array"
+            },
+            "source_format": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistSourceFormat"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "sources": {
+              "description": "BMOPF allows exactly one; the model allows any number and the BMOPF\nwriter warns beyond the first.",
+              "items": {
+                "$ref": "#/$defs/VoltageSource"
+              },
+              "type": "array"
+            },
+            "switches": {
+              "items": {
+                "$ref": "#/$defs/DistSwitch"
+              },
+              "type": "array"
+            },
+            "transformers": {
+              "items": {
+                "$ref": "#/$defs/DistTransformer"
+              },
+              "type": "array"
+            },
+            "untyped": {
+              "items": {
+                "$ref": "#/$defs/UntypedObject"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "base_frequency",
+            "buses",
+            "linecodes",
+            "lines",
+            "switches",
+            "transformers",
+            "loads",
+            "generators",
+            "shunts",
+            "sources",
+            "untyped",
+            "commands",
+            "options",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "MulticonductorOperatingPointTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            },
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "description": "Quantity name → dense columns, the multiconductor instantaneous\nvocabulary.",
+              "type": "object"
+            },
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "network",
+            "time_points",
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "ObjectiveTermV1": {
+          "description": "One typed objective term, mirroring `powerio_prob::ObjectiveTerm` with its\nweight wrapped for the nonfinite spelling: an internally tagged enum's\nderived `Deserialize` re-decodes its variant from a buffered generic\nvalue rather than the deserializer callers pass in, so wrapping the whole\ndocument's deserializer (as [`StoredModuleV1`] does for every plain\nstruct field) never reaches this `f64`.",
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "term": {
+                  "const": "network_generator_cost",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "term"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "term": {
+                  "const": "network_per_phase_cost",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "term"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Read only compatibility for 0.10 documents. The runtime removes this\nterm and records `READ.MODULE.OBJECTIVE_TERM_RETIRED` because the token\ndid not define a portable quantity or unit.",
+              "properties": {
+                "term": {
+                  "const": "differentiability_regularization",
+                  "type": "string"
+                },
+                "weight": {
+                  "$ref": "#/$defs/StoredF64"
+                }
+              },
+              "required": [
+                "term",
+                "weight"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ObjectiveV1": {
+          "additionalProperties": false,
+          "description": "The complete typed objective, mirroring `powerio_prob::Objective`.",
+          "properties": {
+            "terms": {
+              "items": {
+                "$ref": "#/$defs/ObjectiveTermV1"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "PowerFactorControl": {
+          "properties": {
+            "pf": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "pf"
+          ],
+          "type": "object"
+        },
+        "ProducerV1": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "RatingChange": {
+          "description": "One branch rating change of a proposal, MW, by canonical PowerIO identity.",
+          "properties": {
+            "branch": {
+              "type": "string"
+            },
+            "delta_mw": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "branch",
+            "delta_mw"
+          ],
+          "type": "object"
+        },
+        "ReactivePowerReference": {
+          "enum": [
+            "VAR_MAX",
+            "VAR_AVAILABLE"
+          ],
+          "type": "string"
+        },
+        "ReactivePowerUnit": {
+          "enum": [
+            "VA_FRACTION",
+            "VAR"
+          ],
+          "type": "string"
+        },
+        "Residuals": {
+          "description": "Numerical residuals of the solved equations, in the problem's power unit.\nA field is `None` when the producer did not report it.",
+          "properties": {
+            "max_active_power_mismatch": {
+              "description": "Largest absolute active power balance mismatch, MW.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "max_reactive_power_mismatch": {
+              "description": "Largest absolute reactive power balance mismatch, MVAr.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "ScopfAcContingencySurvivors": {
+          "description": "Per-contingency surviving AC lines and transformers, one group per\ncontingency in `reliability.contingency` document order.",
+          "properties": {
+            "ln": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/ScopfAcLineSurvivorRow"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "xf": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/ScopfTransformerSurvivorRow"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "ln",
+            "xf"
+          ],
+          "type": "object"
+        },
+        "ScopfAcLineRow": {
+          "description": "One AC line row.",
+          "properties": {
+            "b_ch": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_ln",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "c_su",
+            "c_sd",
+            "u_0",
+            "s_max",
+            "g_sr",
+            "b_sr",
+            "b_ch",
+            "g_fr",
+            "g_to",
+            "b_fr",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "ScopfAcLineSurvivorRow": {
+          "description": "One AC line surviving a contingency.",
+          "properties": {
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max_ctg": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ctg",
+            "j_ln",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "b_sr",
+            "s_max_ctg"
+          ],
+          "type": "object"
+        },
+        "ScopfActiveReserveRow": {
+          "description": "One active power zonal reserve row.",
+          "properties": {
+            "c_nsc": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rgd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rgu": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rrd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rru": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_scr": {
+              "format": "double",
+              "type": "number"
+            },
+            "n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_rrd_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_rru_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "sigma_nsc": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_rgd": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_rgu": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_scr": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "n_p",
+            "uid",
+            "c_rgu",
+            "c_rgd",
+            "c_scr",
+            "c_nsc",
+            "c_rru",
+            "c_rrd",
+            "sigma_rgu",
+            "sigma_rgd",
+            "sigma_scr",
+            "sigma_nsc",
+            "p_rru_min",
+            "p_rrd_min"
+          ],
+          "type": "object"
+        },
+        "ScopfActiveReserveSetRow": {
+          "description": "One (bus, active reserve zone, device) membership row.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dev": {
+              "description": "The member device's ordinals ([`ScopfDeviceRow::j_dev`],\n[`ScopfDeviceRow::j_sdd`]).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "i",
+            "n_p",
+            "uid",
+            "j_dev",
+            "j_sdd"
+          ],
+          "type": "object"
+        },
+        "ScopfBusRow": {
+          "description": "One bus row: `(i, uid, v_min, v_max)`.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "v_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "v_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "i",
+            "uid",
+            "v_min",
+            "v_max"
+          ],
+          "type": "object"
+        },
+        "ScopfDcContingencyFlowRow": {
+          "description": "One surviving DC line in one contingency and period.",
+          "properties": {
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "flat_jtk_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            }
+          },
+          "required": [
+            "flat_jtk_dc",
+            "ctg",
+            "j_dc",
+            "to_bus",
+            "fr_bus",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfDcLineRow": {
+          "description": "One DC line row.",
+          "properties": {
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pdc_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_fr_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_fr_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_to_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_to_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_dc",
+            "uid",
+            "pdc_max",
+            "qdc_fr_min",
+            "qdc_to_min",
+            "qdc_fr_max",
+            "qdc_to_max",
+            "to_bus",
+            "fr_bus"
+          ],
+          "type": "object"
+        },
+        "ScopfDeviceClassLayout": {
+          "description": "How the two device classes sit in the `simple_dispatchable_device` section.\n\nA model that stacks producers and consumers into one variable vector\naddresses a device by a per class offset, which is a bijection only when\neach class owns one unbroken run. Reading the order without that\nprecondition is the one mistake this type makes unavailable.",
+          "oneOf": [
+            {
+              "description": "Each class is one unbroken run. `producers_first` says which run\nstarts first.",
+              "properties": {
+                "kind": {
+                  "const": "contiguous",
+                  "type": "string"
+                },
+                "producers_first": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "kind",
+                "producers_first"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The two classes interleave, so no per class offset addresses a device.",
+              "properties": {
+                "kind": {
+                  "const": "interleaved",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ScopfDeviceRow": {
+          "description": "One simple dispatchable device row.\n\nProducers and consumers share this layout. Vector fields use the internal\nzero based period order.\n\nThe reactive capability block is the `q_bound_cap`/`q_linear_cap` pair and\nthe parameters of the mode each one selects. The two modes are mutually\nexclusive and a device can select neither. A parameter of a mode the device\ndid not select is `None`. Read the two flags before the parameters.",
+          "properties": {
+            "beta": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "beta_lb": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "beta_ub": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "c_nsc": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_on": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_qrd": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_qru": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rgd": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rgu": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rrd_off": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rrd_on": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rru_off": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rru_on": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_scr": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_dev": {
+              "description": "0-based position within the row's own class list (`prod` or `cons`),\nin document order. Serialization can retain base 0 or select base 1.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "description": "0-based position in the canonical device stacking: the producer block,\nthen the consumer block, document order within each. Sound for every\nuid spelling, including interleaved classes.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_0": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_nsc_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rd": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rd_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rgd_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rgu_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rrd_off_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rrd_on_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rru_off_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rru_on_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_ru": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_ru_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_scr_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_0": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_0_lb": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_0_ub": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_bound_cap": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "q_linear_cap": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "q_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_p0": {
+              "description": "The intercept of the linear capability line. The GOC3 document calls\nthis `q_0`, which this row already uses for `initial_status.q`.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "sus": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "bus",
+            "uid",
+            "j_dev",
+            "j_sdd",
+            "c_on",
+            "c_su",
+            "c_sd",
+            "p_ru",
+            "p_rd",
+            "p_ru_su",
+            "p_rd_sd",
+            "c_rgu",
+            "c_rgd",
+            "c_scr",
+            "c_nsc",
+            "c_rru_on",
+            "c_rru_off",
+            "c_rrd_on",
+            "c_rrd_off",
+            "c_qru",
+            "c_qrd",
+            "p_rgu_max",
+            "p_rgd_max",
+            "p_scr_max",
+            "p_nsc_max",
+            "p_rru_on_max",
+            "p_rru_off_max",
+            "p_rrd_on_max",
+            "p_rrd_off_max",
+            "p_0",
+            "q_0",
+            "u_0",
+            "p_max",
+            "p_min",
+            "q_max",
+            "q_min",
+            "sus",
+            "q_bound_cap",
+            "q_linear_cap"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMaxCsRow": {
+          "properties": {
+            "a_en_max_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_max_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_cs_ind",
+            "uid",
+            "a_en_max_start",
+            "a_en_max_end",
+            "e_max"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMaxPrRow": {
+          "properties": {
+            "a_en_max_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_max_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_pr_ind",
+            "uid",
+            "a_en_max_start",
+            "a_en_max_end",
+            "e_max"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMinCsRow": {
+          "properties": {
+            "a_en_min_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_min_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_cs_ind",
+            "uid",
+            "a_en_min_start",
+            "a_en_min_end",
+            "e_min"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMinPrRow": {
+          "properties": {
+            "a_en_min_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_min_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_pr_ind",
+            "uid",
+            "a_en_min_start",
+            "a_en_min_end",
+            "e_min"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMaxCsRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_cs_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMaxPrRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_pr_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMinCsRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_cs_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMinPrRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_pr_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindows": {
+          "description": "Energy requirement windows and their period memberships.",
+          "properties": {
+            "t_w_en_max_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMaxCsRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_max_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMaxPrRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_min_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMinCsRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_min_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMinPrRow"
+              },
+              "type": "array"
+            },
+            "w_en_max_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMaxCsRow"
+              },
+              "type": "array"
+            },
+            "w_en_max_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMaxPrRow"
+              },
+              "type": "array"
+            },
+            "w_en_min_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMinCsRow"
+              },
+              "type": "array"
+            },
+            "w_en_min_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMinPrRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "w_en_max_pr",
+            "w_en_max_cs",
+            "w_en_min_pr",
+            "w_en_min_cs",
+            "t_w_en_max_pr",
+            "t_w_en_max_cs",
+            "t_w_en_min_pr",
+            "t_w_en_min_cs"
+          ],
+          "type": "object"
+        },
+        "ScopfFixedPhaseRow": {
+          "description": "A transformer with a fixed phase shift (`fpd`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "phi_o": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "phi_o"
+          ],
+          "type": "object"
+        },
+        "ScopfFixedRatioRow": {
+          "description": "A transformer with a fixed winding ratio (`fwr`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tau_o": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "tau_o"
+          ],
+          "type": "object"
+        },
+        "ScopfLengths": {
+          "description": "Set sizes for each indexed device class.",
+          "properties": {
+            "i": {
+              "description": "Bus count.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "k": {
+              "description": "Contingency count.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_ac": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_br": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_cs": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_cspr": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_pr": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_sh": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "l_j_xf",
+            "l_j_ln",
+            "l_j_ac",
+            "l_j_dc",
+            "l_j_br",
+            "l_j_cs",
+            "l_j_pr",
+            "l_j_cspr",
+            "l_j_sh",
+            "i",
+            "l_t",
+            "l_n_p",
+            "l_n_q",
+            "k"
+          ],
+          "type": "object"
+        },
+        "ScopfPriceBlockRow": {
+          "description": "One flattened device, period, and price block row.",
+          "properties": {
+            "c_en": {
+              "format": "double",
+              "type": "number"
+            },
+            "flat_k": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "m": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "flat_k",
+            "uid",
+            "t",
+            "m",
+            "c_en",
+            "p_max"
+          ],
+          "type": "object"
+        },
+        "ScopfPriceBlocks": {
+          "description": "Flattened producer and consumer price blocks.",
+          "properties": {
+            "consumer": {
+              "items": {
+                "$ref": "#/$defs/ScopfPriceBlockRow"
+              },
+              "type": "array"
+            },
+            "producer": {
+              "items": {
+                "$ref": "#/$defs/ScopfPriceBlockRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "producer",
+            "consumer"
+          ],
+          "type": "object"
+        },
+        "ScopfReactiveReserveRow": {
+          "description": "One reactive (reactive-power) zonal reserve row.",
+          "properties": {
+            "c_qrd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_qru": {
+              "format": "double",
+              "type": "number"
+            },
+            "n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "q_qrd_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_qru_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "n_q",
+            "uid",
+            "c_qru",
+            "c_qrd",
+            "q_qru_min",
+            "q_qrd_min"
+          ],
+          "type": "object"
+        },
+        "ScopfReactiveReserveSetRow": {
+          "description": "One (bus, reactive reserve zone, device) membership row.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dev": {
+              "description": "The member device's ordinals ([`ScopfDeviceRow::j_dev`],\n[`ScopfDeviceRow::j_sdd`]).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "i",
+            "n_q",
+            "uid",
+            "j_dev",
+            "j_sdd"
+          ],
+          "type": "object"
+        },
+        "ScopfShuntRow": {
+          "description": "One shunt row.",
+          "properties": {
+            "b_sh": {
+              "format": "double",
+              "type": "number"
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_sh": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_sh": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_sh",
+            "uid",
+            "bus",
+            "g_sh",
+            "b_sh"
+          ],
+          "type": "object"
+        },
+        "ScopfStaticData": {
+          "description": "Static buses, branches, devices, controls, reserves, and memberships.",
+          "properties": {
+            "acl_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfAcLineRow"
+              },
+              "type": "array"
+            },
+            "active_reserve": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveRow"
+              },
+              "type": "array"
+            },
+            "active_reserve_set_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "active_reserve_set_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "acx_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfTransformerRow"
+              },
+              "type": "array"
+            },
+            "bus": {
+              "items": {
+                "$ref": "#/$defs/ScopfBusRow"
+              },
+              "type": "array"
+            },
+            "cons": {
+              "items": {
+                "$ref": "#/$defs/ScopfDeviceRow"
+              },
+              "type": "array"
+            },
+            "dc_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfDcLineRow"
+              },
+              "type": "array"
+            },
+            "fpd": {
+              "items": {
+                "$ref": "#/$defs/ScopfFixedPhaseRow"
+              },
+              "type": "array"
+            },
+            "fwr": {
+              "items": {
+                "$ref": "#/$defs/ScopfFixedRatioRow"
+              },
+              "type": "array"
+            },
+            "prod": {
+              "items": {
+                "$ref": "#/$defs/ScopfDeviceRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve_set_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve_set_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "shunt": {
+              "items": {
+                "$ref": "#/$defs/ScopfShuntRow"
+              },
+              "type": "array"
+            },
+            "vpd": {
+              "items": {
+                "$ref": "#/$defs/ScopfVariablePhaseRow"
+              },
+              "type": "array"
+            },
+            "vwr": {
+              "items": {
+                "$ref": "#/$defs/ScopfVariableRatioRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "bus",
+            "shunt",
+            "acl_branch",
+            "acx_branch",
+            "vpd",
+            "fpd",
+            "vwr",
+            "fwr",
+            "dc_branch",
+            "prod",
+            "cons",
+            "active_reserve",
+            "reactive_reserve",
+            "active_reserve_set_pr",
+            "active_reserve_set_cs",
+            "reactive_reserve_set_pr",
+            "reactive_reserve_set_cs"
+          ],
+          "type": "object"
+        },
+        "ScopfTransformerRow": {
+          "description": "One two winding transformer row.",
+          "properties": {
+            "b_ch": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_xf",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "c_su",
+            "c_sd",
+            "u_0",
+            "s_max",
+            "g_sr",
+            "b_sr",
+            "b_ch",
+            "g_fr",
+            "g_to",
+            "b_fr",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "ScopfTransformerSurvivorRow": {
+          "description": "One transformer surviving a contingency.",
+          "properties": {
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max_ctg": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ctg",
+            "j_xf",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "b_sr",
+            "s_max_ctg"
+          ],
+          "type": "object"
+        },
+        "ScopfVariablePhaseRow": {
+          "description": "A transformer with a variable phase-shift control range (`vpd`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "phi_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "phi_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "phi_min",
+            "phi_max"
+          ],
+          "type": "object"
+        },
+        "ScopfVariableRatioRow": {
+          "description": "A transformer with a variable winding ratio control range (`vwr`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tau_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "tau_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "tau_min",
+            "tau_max"
+          ],
+          "type": "object"
+        },
+        "ScopfViolationCost": {
+          "description": "The case's four violation prices. The GOC3 document spells them\n`p_bus_vio_cost`, `q_bus_vio_cost`, `s_vio_cost`, and `e_vio_cost` under\n`network.violation_cost`. Any one of them can be absent and is then `None`:\nGOCompetition's 14 bus validation case has no `e_vio_cost`.",
+          "properties": {
+            "e": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_bus": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_bus": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "s": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "ScucDeviceOutputsV1": {
+          "additionalProperties": false,
+          "properties": {
+            "on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_nsyn_res": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_on": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_ramp_res_down_online": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_ramp_res_up_online": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_reg_res_down": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_reg_res_up": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_syn_res": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q_res_down": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q_res_up": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "on_status",
+            "p_on",
+            "q",
+            "p_reg_res_up",
+            "p_reg_res_down",
+            "p_syn_res",
+            "p_nsyn_res",
+            "p_ramp_res_up_online",
+            "p_ramp_res_down_online",
+            "q_res_up",
+            "q_res_down"
+          ],
+          "type": "object"
+        },
+        "ScucInputs": {
+          "description": "Matrix free SCOPF input data.\n\nInternal class, period, contingency, window, and flattened row indices are\nzero based and follow the source document order of the section that owns\nthem. Source UIDs and external bus IDs remain separate fields.",
+          "properties": {
+            "ac_contingency_survivors": {
+              "$ref": "#/$defs/ScopfAcContingencySurvivors"
+            },
+            "dc_contingency_flows": {
+              "items": {
+                "$ref": "#/$defs/ScopfDcContingencyFlowRow"
+              },
+              "type": "array"
+            },
+            "device_class_layout": {
+              "$ref": "#/$defs/ScopfDeviceClassLayout"
+            },
+            "dt": {
+              "description": "The interval durations, so a model needs no raw-document read for its\ntime axis. `lengths.l_t` is this vector's length.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "energy_windows": {
+              "$ref": "#/$defs/ScopfEnergyWindows"
+            },
+            "lengths": {
+              "$ref": "#/$defs/ScopfLengths"
+            },
+            "price_blocks": {
+              "$ref": "#/$defs/ScopfPriceBlocks"
+            },
+            "static_data": {
+              "$ref": "#/$defs/ScopfStaticData",
+              "description": "Buses, branches, devices, controls, reserves, and memberships."
+            },
+            "violation_cost": {
+              "$ref": "#/$defs/ScopfViolationCost"
+            }
+          },
+          "required": [
+            "static_data",
+            "lengths",
+            "energy_windows",
+            "price_blocks",
+            "ac_contingency_survivors",
+            "dc_contingency_flows",
+            "violation_cost",
+            "device_class_layout",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScucNetworkOutputsV1": {
+          "additionalProperties": false,
+          "properties": {
+            "ac_line_on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus_va": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus_vm": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_pdc_fr": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_qdc_fr": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_qdc_to": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "shunt_step": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_ta": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_tm": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "bus_vm",
+            "bus_va",
+            "shunt_step",
+            "ac_line_on_status",
+            "transformer_tm",
+            "transformer_ta",
+            "transformer_on_status"
+          ],
+          "type": "object"
+        },
+        "SeverityV1": {
+          "enum": [
+            "error",
+            "warning",
+            "remark",
+            "note"
+          ],
+          "type": "string"
+        },
+        "Shunt": {
+          "properties": {
+            "b": {
+              "description": "Shunt susceptance (MVAr at V = 1 p.u.). For a switched shunt this is the\ninitial (steady-state) value within the [`control`](Shunt::control) blocks.",
+              "format": "double",
+              "type": "number"
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "control": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SwitchedShuntControl"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Switching-control data when this is a switched (adjustable) shunt; `None`\nfor a fixed shunt. `#[serde(default)]` so JSON written before the field\nexisted still deserializes."
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g": {
+              "description": "Shunt conductance (MW at V = 1 p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "bus",
+            "g",
+            "b",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "ShuntBlock": {
+          "description": "One block of a switched shunt: `steps` equal increments of susceptance `b`.",
+          "properties": {
+            "b": {
+              "description": "Susceptance increment per step (MVAr at V = 1 p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "steps": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "steps",
+            "b"
+          ],
+          "type": "object"
+        },
+        "SolverParams": {
+          "description": "Solver / solution-control metadata: the Newton tolerance and iteration cap,\nthe zero-impedance threshold, and the per-quantity adjustment-enable flags.\n\nEach field is optional because a source states only the ones it carries. No\npower flow physics, but it determines whether a downstream solver reproduces\nthe source tool's converged answer. Maps to the PSS/E v34+ system-wide block\n(`GENERAL THRSHZ`, `NEWTON TOLN`/`ITMXN`, `SOLVER ACTAPS`/`AREAIN`/`PHSHFT`/\n`DCTAPS`/`SWSHNT`).",
+          "properties": {
+            "adjust_area_interchange": {
+              "description": "Whether the solver adjusts area interchange (`SOLVER AREAIN`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_dc_taps": {
+              "description": "Whether the solver adjusts DC line taps (`SOLVER DCTAPS`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_phase_shift": {
+              "description": "Whether the solver adjusts phase-shift angles (`SOLVER PHSHFT`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_switched_shunt": {
+              "description": "Whether the solver adjusts switched shunts (`SOLVER SWSHNT`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_taps": {
+              "description": "Whether the solver adjusts transformer taps (`SOLVER ACTAPS`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "max_iterations": {
+              "description": "Newton iteration cap (`NEWTON ITMXN`).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "newton_tolerance": {
+              "description": "Newton power flow mismatch tolerance (`NEWTON TOLN`).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "zero_impedance_threshold": {
+              "description": "Branches with `|x|` below this are treated as zero impedance (`GENERAL THRSHZ`).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "SourceDescriptorV1": {
+          "additionalProperties": false,
+          "properties": {
+            "byte_length": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "digest": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DigestV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "format": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "byte_length"
+          ],
+          "type": "object"
+        },
+        "SourceFormat": {
+          "description": "Which format a [`BalancedNetwork`] was read from. Drives the same format byte exact\necho on write.\n\nSerializes as the same lowercase token [`name`](SourceFormat::name) reports\nand every string entry point accepts, so the value a document carries is\nvalid input to `from`. Documents written before 0.9.0 spelled the bare\nvariant name (\"Matpower\"); the read side still accepts those spellings.",
+          "oneOf": [
+            {
+              "enum": [
+                "matpower",
+                "powermodels-json",
+                "egret-json",
+                "psse",
+                "powerworld",
+                "pandapower-json"
+              ],
+              "type": "string"
+            },
+            {
+              "const": "pslf",
+              "description": "Read from a GE PSLF `.epc` case. Same source text is retained, so a\nsame-format write echoes it byte-for-byte; a cross-format or\nsource-dropped write goes through the `.epc` serializer\n([`write_pslf`](crate::write_pslf)).",
+              "type": "string"
+            },
+            {
+              "const": "powerworld-pwb",
+              "description": "Read from a PowerWorld `.pwb` binary case. Read only: there is no\n`.pwb` writer and no retained source text, so writing goes through\nanother format's writer.",
+              "type": "string"
+            },
+            {
+              "const": "in-memory",
+              "description": "Built in memory, for example from synth or an edited case; no source text.",
+              "type": "string"
+            },
+            {
+              "const": "normalized",
+              "description": "A normalized derived form ([`BalancedNetwork::to_normalized`]): per unit, radians,\nfiltered, source bus ids preserved. Distinct from\n[`InMemory`](SourceFormat::InMemory) so consumers can tell a per unit\nproduct from a raw in memory network; it has no source text and a different\nunit basis than a parsed network.",
+              "type": "string"
+            },
+            {
+              "const": "gridfm",
+              "description": "Read back from a gridfm-datakit Parquet dataset (the ML→classical bridge,\n`powerio-matrix`'s `read_gridfm_dataset`). A lossy, power flow complete\nreconstruction with no retained source text: original bus ids are\nsynthesized `1..n`, per element load/shunt granularity is folded to one\nsynthetic element per bus, and HVDC/storage/piecewise costs are absent.",
+              "type": "string"
+            },
+            {
+              "const": "pypsa-csv",
+              "description": "Read from a PyPSA CSV folder. This is a folder format rather than a\nsingle retained text document, so same-format writes are canonicalized.",
+              "type": "string"
+            },
+            {
+              "const": "goc3-json",
+              "description": "Read from a DOE GO Challenge 3 JSON input document. The source is a\nunit commitment data set; the neutral transmission model keeps a static\nfirst interval network and retains the source text for the full data.",
+              "type": "string"
+            },
+            {
+              "const": "surge-json",
+              "description": "Read from a Surge native JSON document.",
+              "type": "string"
+            },
+            {
+              "const": "opfdata-json",
+              "description": "Read from one raw JSON document in a DeepMind OPFData release. The\nsource carries both solver initial values and a solution. The balanced\nmodel represents the solved snapshot and retains the source for an\nexact write back to the same format.",
+              "type": "string"
+            }
+          ]
+        },
+        "SourceMapEntryV1": {
+          "additionalProperties": false,
+          "properties": {
+            "relation": {
+              "$ref": "#/$defs/SourceRelationV1"
+            },
+            "spans": {
+              "description": "Empty only for `defaulted`, `synthetic`, or `transformed`.",
+              "items": {
+                "$ref": "#/$defs/SourceSpanV1"
+              },
+              "type": "array"
+            },
+            "target": {
+              "description": "RFC 6901 pointer into `value.data`.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "target",
+            "relation"
+          ],
+          "type": "object"
+        },
+        "SourceRelationV1": {
+          "enum": [
+            "exact",
+            "defaulted",
+            "inferred",
+            "converted_units",
+            "aggregated",
+            "split",
+            "synthetic",
+            "transformed",
+            "retained_extra"
+          ],
+          "type": "string"
+        },
+        "SourceSpanV1": {
+          "additionalProperties": false,
+          "properties": {
+            "byte_end": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "byte_start": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "byte_start",
+            "byte_end"
+          ],
+          "type": "object"
+        },
+        "Storage": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "charge_efficiency": {
+              "format": "double",
+              "type": "number"
+            },
+            "charge_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "current_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "discharge_efficiency": {
+              "format": "double",
+              "type": "number"
+            },
+            "discharge_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "energy": {
+              "format": "double",
+              "type": "number"
+            },
+            "energy_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "p_loss": {
+              "format": "double",
+              "type": "number"
+            },
+            "ps": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_loss": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "qs": {
+              "format": "double",
+              "type": "number"
+            },
+            "r": {
+              "format": "double",
+              "type": "number"
+            },
+            "thermal_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "ps",
+            "qs",
+            "energy",
+            "energy_rating",
+            "charge_rating",
+            "discharge_rating",
+            "charge_efficiency",
+            "discharge_efficiency",
+            "thermal_rating",
+            "qmin",
+            "qmax",
+            "r",
+            "x",
+            "p_loss",
+            "q_loss",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "StoredF64": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ]
+            }
+          ]
+        },
+        "StoredModuleV1": {
+          "additionalProperties": false,
+          "properties": {
+            "diagnostics": {
+              "items": {
+                "$ref": "#/$defs/DiagnosticV1"
+              },
+              "type": "array"
+            },
+            "extensions": {
+              "additionalProperties": true,
+              "description": "Nonsemantic third party annotations. Keys must be namespaced.",
+              "type": "object"
+            },
+            "history": {
+              "items": {
+                "$ref": "#/$defs/HistoryEntryV1"
+              },
+              "type": "array"
+            },
+            "producer": {
+              "$ref": "#/$defs/ProducerV1"
+            },
+            "schema": {
+              "type": "string"
+            },
+            "source_map": {
+              "items": {
+                "$ref": "#/$defs/SourceMapEntryV1"
+              },
+              "type": "array"
+            },
+            "sources": {
+              "items": {
+                "$ref": "#/$defs/SourceDescriptorV1"
+              },
+              "type": "array"
+            },
+            "value": {
+              "$ref": "#/$defs/StoredValueV1"
+            },
+            "version": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "schema",
+            "version",
+            "producer",
+            "value"
+          ],
+          "type": "object"
+        },
+        "StoredOperatingPointV1": {
+          "additionalProperties": false,
+          "description": "One stored operating point: the state quantities of a single point,\nkeyed by the instantaneous vocabulary, each with its resolved identity\norder and one row of values.",
+          "properties": {
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "StoredQuantityV1": {
+          "additionalProperties": false,
+          "description": "One state quantity's dense columns: the resolved identity order, then the\npoint major values (`time_points.len() × identities.len()`).",
+          "properties": {
+            "identities": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "values": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "identities",
+            "values"
+          ],
+          "type": "object"
+        },
+        "StoredValueV1": {
+          "description": "The tagged value DTO. `data` is a typed record, never an untyped JSON\ncatchall; the network payloads are the typed serializations the network\ncrates own (which carry the nonfinite spellings themselves).",
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetwork"
+                },
+                "kind": {
+                  "const": "balanced_network",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/MulticonductorNetwork"
+                },
+                "kind": {
+                  "const": "multiconductor_network",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetworkTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "balanced_network_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedOperatingPointTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "balanced_operating_point_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/MulticonductorOperatingPointTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "multiconductor_operating_point_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetworkScenarioSetV1"
+                },
+                "kind": {
+                  "const": "balanced_network_scenario_set",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "dc_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "dc_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "mc_ac_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "mc_ac_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcScucInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_scuc_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "dc_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "dc_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "mc_ac_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "mc_ac_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcScucSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_scuc_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "Switch": {
+          "description": "A transmission switch. Closed switches are preserved as data; matrix builders\ndo not lower them into zero impedance branches.",
+          "properties": {
+            "closed": {
+              "type": "boolean"
+            },
+            "current_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "pf": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "pt": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "qf": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "qt": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "thermal_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "closed",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "SwitchedShuntControl": {
+          "description": "Switching-control data for a switched shunt ([`Shunt::control`]): the mode,\nthe regulated voltage band and bus, the reactive-range percentage, and the\nadjustable susceptance blocks. The shunt's [`b`](Shunt::b) is the initial\nvalue within the blocks' total range.",
+          "properties": {
+            "blocks": {
+              "items": {
+                "$ref": "#/$defs/ShuntBlock"
+              },
+              "type": "array"
+            },
+            "control_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The regulated bus; `None` means the shunt regulates its own bus."
+            },
+            "mode": {
+              "$ref": "#/$defs/SwitchedShuntMode"
+            },
+            "rmpct": {
+              "description": "Percent of the controlled device's reactive range to apply (PSS/E `RMPCT`).",
+              "format": "double",
+              "type": "number"
+            },
+            "vhigh": {
+              "description": "Regulated voltage band (per unit).",
+              "format": "double",
+              "type": "number"
+            },
+            "vlow": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "mode",
+            "vhigh",
+            "vlow",
+            "rmpct",
+            "blocks"
+          ],
+          "type": "object"
+        },
+        "SwitchedShuntMode": {
+          "description": "How a switched shunt adjusts its susceptance. Maps to the PSS/E `MODSW` code.",
+          "oneOf": [
+            {
+              "const": "locked",
+              "description": "Fixed at its initial susceptance, no automatic switching (`MODSW` 0).",
+              "type": "string"
+            },
+            {
+              "const": "continuous",
+              "description": "Continuous adjustment within the block range (`MODSW` 1).",
+              "type": "string"
+            },
+            {
+              "const": "discrete",
+              "description": "Discrete adjustment in fixed steps (`MODSW` 2 and up).",
+              "type": "string"
+            }
+          ]
+        },
+        "Termination": {
+          "description": "How the producing calculation ended.",
+          "oneOf": [
+            {
+              "description": "The calculation converged to its stated tolerance.",
+              "properties": {
+                "kind": {
+                  "const": "converged",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The iteration limit ended the calculation before convergence.",
+              "properties": {
+                "kind": {
+                  "const": "iteration_limit",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The solver proved the constraints admit no solution. The optimization\noutcome an OPF consumer acts on differently from a numerical failure:\nthe case is overconstrained, and no retry or setting change fixes it.",
+              "properties": {
+                "kind": {
+                  "const": "infeasible",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The solver proved the objective unbounded over the feasible set.",
+              "properties": {
+                "kind": {
+                  "const": "unbounded",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The calculation failed.",
+              "properties": {
+                "kind": {
+                  "const": "failed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source records a solved calculation without termination\ninformation (DeepMind OPFData does).",
+              "properties": {
+                "kind": {
+                  "const": "not_reported",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "TimePointV1": {
+          "additionalProperties": false,
+          "properties": {
+            "duration": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DurationV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "label": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "label"
+          ],
+          "type": "object"
+        },
+        "Transformer3W": {
+          "description": "A three winding transformer with three terminal buses joined at a star point.\n\nSeries impedance is stored for winding pairs 1-2, 2-3, and 3-1. The record\nalso retains star point voltage and per winding control data. PSS/E three\nwinding records and PSLF tertiary winding records map to this type.\n[`to_star_expansion`](Transformer3W::to_star_expansion) turns it into the synthetic\nstar bus plus three branches for a consumer that works in the bus-branch model;\n[`IndexedNetwork`](crate::IndexedNetwork) applies it before building any matrix,\nso a 3-winding transformer contributes to `Y_bus` and connectivity.",
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "mag_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "mag_g": {
+              "description": "Magnetizing shunt referred to the star point (p.u. on the system base).",
+              "format": "double",
+              "type": "number"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "star_va": {
+              "format": "double",
+              "type": "number"
+            },
+            "star_vm": {
+              "description": "Star-point voltage magnitude (p.u.) and angle (degrees), as solved.",
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "windings": {
+              "description": "The three windings, in order (primary, secondary, tertiary).",
+              "items": {
+                "$ref": "#/$defs/Winding"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            "z": {
+              "description": "Pairwise series impedance `[z12, z23, z31]` (primary-secondary,\nsecondary-tertiary, tertiary-primary), each per unit on the system base\nwith its declared MVA base.",
+              "items": {
+                "$ref": "#/$defs/Impedance"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            }
+          },
+          "required": [
+            "windings",
+            "z",
+            "star_vm",
+            "star_va",
+            "mag_g",
+            "mag_b",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "TransformerControl": {
+          "description": "Automatic-control data for a regulating transformer ([`Branch::control`]).\n\nThe limits carry whatever the [`mode`](TransformerControl::mode) regulates:\n`tap_min`/`tap_max` bound the tap ratio (or the phase angle, for\n[`ActiveFlow`](TransformerControlMode::ActiveFlow)), and `band_min`/`band_max`\nbound the controlled quantity (the regulated voltage band, or the\nscheduled MW/MVAr). `ntp` is the number of discrete tap positions and\n`controlled_bus` is the regulated bus (`None` = the transformer's own\nterminal). `mva_base` is the winding MVA base the impedance is referred to.",
+          "properties": {
+            "band_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "band_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "controlled_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "mode": {
+              "$ref": "#/$defs/TransformerControlMode"
+            },
+            "mva_base": {
+              "format": "double",
+              "type": "number"
+            },
+            "ntp": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tap_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "tap_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "mode",
+            "tap_min",
+            "tap_max",
+            "band_min",
+            "band_max",
+            "ntp",
+            "mva_base"
+          ],
+          "type": "object"
+        },
+        "TransformerControlMode": {
+          "description": "What a regulating transformer's tap (or phase shift) automatically controls.\nMaps to the PSS/E control code `COD` and the PSLF transformer `type`.",
+          "oneOf": [
+            {
+              "const": "fixed",
+              "description": "Fixed ratio, no automatic adjustment (PSS/E `COD` 0/±4, PSLF type 1).",
+              "type": "string"
+            },
+            {
+              "const": "voltage",
+              "description": "Bus voltage control via tap (LTC; PSS/E `COD` ±1, PSLF type 2).",
+              "type": "string"
+            },
+            {
+              "const": "reactive_flow",
+              "description": "Reactive power flow control via tap (PSS/E `COD` ±2).",
+              "type": "string"
+            },
+            {
+              "const": "active_flow",
+              "description": "Active power flow control via phase shift (PSS/E `COD` ±3, PSLF type 4).",
+              "type": "string"
+            }
+          ]
+        },
+        "UntypedObject": {
+          "description": "An object the reader recognized but does not type: preserved by class,\nname, and raw property text so conversions can warn precisely.",
+          "properties": {
+            "class": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "props": {
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "class",
+            "name",
+            "props"
+          ],
+          "type": "object"
+        },
+        "VoltVarControl": {
+          "properties": {
+            "breakpoints": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_min_for_q": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_min_for_q_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_limits": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_ref": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ReactivePowerReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "q_unit": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ReactivePowerUnit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "voltage_reference": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ControlVoltageReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "breakpoints",
+            "q_limits"
+          ],
+          "type": "object"
+        },
+        "VoltWattControl": {
+          "properties": {
+            "breakpoints": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_limits": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_ref": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActivePowerReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "p_unit": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActivePowerUnit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "voltage_reference": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ControlVoltageReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "breakpoints",
+            "p_limits"
+          ],
+          "type": "object"
+        },
+        "VoltageSource": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_angle": {
+              "description": "Radians per terminal.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "v_magnitude": {
+              "description": "Volts per terminal (0.0 on grounded terminals).",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "v_magnitude",
+            "v_angle",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "Winding": {
+          "description": "One winding of a [`Transformer3W`]: its terminal bus, off-nominal ratio, phase\nshift, nominal voltage, and thermal ratings.",
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "nominal_kv": {
+              "description": "Winding nominal voltage (kV); 0 defers to the terminal bus base kV.",
+              "format": "double",
+              "type": "number"
+            },
+            "rate_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_c": {
+              "format": "double",
+              "type": "number"
+            },
+            "shift": {
+              "description": "Phase shift (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "tap": {
+              "description": "Off-nominal turns ratio (1.0 = nominal); the PSS/E `WINDV`, `CW = 1`.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "tap",
+            "shift",
+            "nominal_kv",
+            "rate_a",
+            "rate_b",
+            "rate_c"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "plan": {
+          "$ref": "#/$defs/CapacityPlanOutcome"
+        },
+        "solution_module": {
+          "$ref": "#/$defs/StoredModuleV1"
+        }
+      },
+      "required": [
+        "plan",
+        "solution_module"
+      ],
+      "title": "PlanResponse",
+      "type": "object"
+    },
+    "powerio_module": {
+      "$defs": {
+        "AcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "constraints": {
+              "$ref": "#/$defs/ActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1"
+            }
+          },
+          "required": [
+            "network",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "AcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_limit_multiplier": {
+              "description": "Nonnegative multiplier on the from-terminal apparent power bound.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_from_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_limit_multiplier": {
+              "description": "Nonnegative multiplier on the to-terminal apparent power bound.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_to_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_power_marginal": {
+              "description": "Optimal objective derivative per added MW of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_active_price": {
+              "description": "Read only 0.10 name for the active demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_reactive_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_reactive_power_marginal": {
+              "description": "Optimal objective derivative per added MVAr of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_reactive_price": {
+              "description": "Read only 0.10 name for the reactive demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_reactive_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/AcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_magnitude",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "bus_reactive_injection",
+            "branch_from_active_flow",
+            "branch_from_reactive_flow",
+            "branch_to_active_flow",
+            "branch_to_reactive_flow",
+            "generator_active_power",
+            "generator_reactive_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "AcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network"
+          ],
+          "type": "object"
+        },
+        "AcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_reactive_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_dispatch": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeneratorDispatchV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "instance": {
+              "$ref": "#/$defs/AcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_magnitude",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "bus_reactive_injection",
+            "branch_from_active_flow",
+            "branch_from_reactive_flow",
+            "branch_to_active_flow",
+            "branch_to_reactive_flow"
+          ],
+          "type": "object"
+        },
+        "AcScucInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "inputs": {
+              "$ref": "#/$defs/ScucInputs",
+              "description": "The complete SCUC inputs, in the calculation crate's own\nserialization, typed through this document's schema."
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network",
+            "inputs"
+          ],
+          "type": "object"
+        },
+        "AcScucSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "device_outputs": {
+              "$ref": "#/$defs/ScucDeviceOutputsV1"
+            },
+            "instance": {
+              "$ref": "#/$defs/AcScucInstanceV1"
+            },
+            "network_outputs": {
+              "$ref": "#/$defs/ScucNetworkOutputsV1"
+            },
+            "objective": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "network_outputs",
+            "device_outputs"
+          ],
+          "type": "object"
+        },
+        "ActiveConstraints": {
+          "description": "The active constraint families of a balanced OPF instance.",
+          "properties": {
+            "angle_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Branch angle difference bounds."
+            },
+            "generator_capability": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Generator capability bounds (active and reactive limits)."
+            },
+            "thermal_limits": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Branch thermal limits."
+            },
+            "voltage_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Bus voltage magnitude bounds."
+            }
+          },
+          "required": [
+            "generator_capability",
+            "voltage_bounds",
+            "thermal_limits",
+            "angle_bounds"
+          ],
+          "type": "object"
+        },
+        "ActivePowerReference": {
+          "enum": [
+            "P_AVAILABLE",
+            "P_MAX",
+            "S_MAX"
+          ],
+          "type": "string"
+        },
+        "ActivePowerUnit": {
+          "enum": [
+            "VA_FRACTION",
+            "W"
+          ],
+          "type": "string"
+        },
+        "Area": {
+          "description": "An area record: the area's scheduled net interchange and its swing bus.\n\nThe [`number`](Area::number) matches the `area` field carried on each\n[`Bus`]; this table holds the per-area metadata (the interchange target and\nthe area slack) that the bus number alone can't. Maps to the PSS/E area record\n(`I, ISW, PDES, PTOL, ARNAME`).",
+          "properties": {
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "net_interchange": {
+              "description": "Scheduled net interchange (MW); positive is export out of the area.",
+              "format": "double",
+              "type": "number"
+            },
+            "number": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "slack_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The area swing (slack) bus, or `None` when unset."
+            },
+            "tolerance": {
+              "description": "Interchange tolerance bandwidth (MW).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "number",
+            "net_interchange",
+            "tolerance"
+          ],
+          "type": "object"
+        },
+        "BalancedNetwork": {
+          "description": "A balanced network with stable source bus IDs and separate element tables.\n\n`remote = \"Self\"` turns the derived serde impls into inherent functions;\nthe trait impls beneath the struct route them through [`crate::nonfinite`],\nso a nonfinite float spells as a string on every JSON route.",
+          "properties": {
+            "areas": {
+              "default": [],
+              "description": "Area records: scheduled interchange and per-area swing bus. Distinct from\nthe bare `area` number on each [`Bus`]; this is the area's metadata, which\nevery conversion dropped before. `#[serde(default)]` so older JSON still\ndeserializes.",
+              "items": {
+                "$ref": "#/$defs/Area"
+              },
+              "type": "array"
+            },
+            "base_frequency": {
+              "default": 60.0,
+              "description": "System base frequency in hertz (50 or 60). Threaded through the formats\nthat record it (PSS/E `BASFRQ`, pandapower `f_hz`) and defaulted to\n[`DEFAULT_BASE_FREQUENCY`] for the rest. Load-bearing for any\nreactance↔henry conversion (pandapower line charging) and reported as a\nfidelity loss when a non-default value writes to a format with no\nfrequency field.",
+              "format": "double",
+              "type": "number"
+            },
+            "base_mva": {
+              "format": "double",
+              "type": "number"
+            },
+            "branches": {
+              "items": {
+                "$ref": "#/$defs/Branch"
+              },
+              "type": "array"
+            },
+            "buses": {
+              "items": {
+                "$ref": "#/$defs/Bus"
+              },
+              "type": "array"
+            },
+            "generators": {
+              "items": {
+                "$ref": "#/$defs/Generator"
+              },
+              "type": "array"
+            },
+            "geo": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeoMeta"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "hvdc": {
+              "items": {
+                "$ref": "#/$defs/Hvdc"
+              },
+              "type": "array"
+            },
+            "loads": {
+              "items": {
+                "$ref": "#/$defs/Load"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "shunts": {
+              "items": {
+                "$ref": "#/$defs/Shunt"
+              },
+              "type": "array"
+            },
+            "solver": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SolverParams"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Solver / solution-control metadata when the source carries it, else `None`.\n`#[serde(default)]` so older JSON still deserializes."
+            },
+            "source_format": {
+              "$ref": "#/$defs/SourceFormat"
+            },
+            "storage": {
+              "items": {
+                "$ref": "#/$defs/Storage"
+              },
+              "type": "array"
+            },
+            "switches": {
+              "default": [],
+              "items": {
+                "$ref": "#/$defs/Switch"
+              },
+              "type": "array"
+            },
+            "transformers_3w": {
+              "default": [],
+              "description": "Three-winding transformers, kept as typed records rather than folded into\n`branches`, so a star point and the per-winding data survive a round trip.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes. [`IndexedNetwork`](crate::IndexedNetwork) lowers each\nin-service record into a star bus plus three branches (via\n[`Transformer3W::to_star_expansion`]) before building any matrix, so a\n3-winding transformer does appear in `Y_bus`/connectivity; the canonical\nmodel keeps the typed record for round-trip fidelity.",
+              "items": {
+                "$ref": "#/$defs/Transformer3W"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "base_mva",
+            "buses",
+            "loads",
+            "shunts",
+            "branches",
+            "generators",
+            "storage",
+            "hvdc",
+            "source_format"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkScenarioSetV1": {
+          "additionalProperties": false,
+          "properties": {
+            "scenarios": {
+              "items": {
+                "$ref": "#/$defs/BalancedNetworkScenarioV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "scenarios"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkScenarioV1": {
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "probability": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "value": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "id",
+            "value"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            },
+            "values": {
+              "items": {
+                "$ref": "#/$defs/BalancedNetwork"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "time_points",
+            "values"
+          ],
+          "type": "object"
+        },
+        "BalancedOperatingPointTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "description": "Quantity name → dense columns, the balanced instantaneous vocabulary.",
+              "type": "object"
+            },
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "network",
+            "time_points",
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "Branch": {
+          "properties": {
+            "angmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "angmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "b": {
+              "description": "MATPOWER compatible total line charging susceptance (p.u.). This is the\nlegacy total projection; when [`charging`](Branch::charging) is present,\nper terminal admittance is canonical and this field is compatibility data.",
+              "format": "double",
+              "type": "number"
+            },
+            "charging": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchCharging"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Per terminal shunt admittance (p.u.). If absent, derive symmetric\nsusceptance from [`b`](Branch::b)."
+            },
+            "control": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TransformerControl"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Regulating-transformer control data, when this branch is a transformer\nunder automatic tap or phase control. `None` for lines and for fixed-ratio\ntransformers. `#[serde(default)]` so JSON written before the field existed\nstill deserializes."
+            },
+            "current_ratings": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchCurrentRatings"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Current ratings, when the source distinguishes them from MVA ratings."
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "r": {
+              "description": "Series resistance (p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "rate_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_c": {
+              "format": "double",
+              "type": "number"
+            },
+            "rating_sets": {
+              "default": [],
+              "description": "Additional MVA rating sets beyond A/B/C. Matrix builders continue to use\n`rate_a` unless they opt into one of these named sets.",
+              "items": {
+                "$ref": "#/$defs/BranchRatingSet"
+              },
+              "type": "array"
+            },
+            "route": {
+              "description": "Polyline route in the network's coordinate space (`BalancedNetwork.geo`),\npresent only when a source provides intermediate geometry; endpoint\nonly rendering derives from the bus locations. `#[serde(default)]` so\nJSON written before the field existed still deserializes.",
+              "items": {
+                "$ref": "#/$defs/Location"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "shift": {
+              "description": "Phase shift (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "solution": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchSolution"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Solved branch flow values, when present in a case snapshot."
+            },
+            "tap": {
+              "description": "Tap ratio, MATPOWER convention: 0 means \"no tap\" (a line), treated as 1.",
+              "format": "double",
+              "type": "number"
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x": {
+              "description": "Series reactance (p.u.).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "r",
+            "x",
+            "b",
+            "rate_a",
+            "rate_b",
+            "rate_c",
+            "tap",
+            "shift",
+            "in_service",
+            "angmin",
+            "angmax",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "BranchCharging": {
+          "description": "Per terminal branch shunt admittance in p.u. This is the canonical\nphysical branch shunt model when present.",
+          "properties": {
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "g_fr",
+            "b_fr",
+            "g_to",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "BranchCurrentRatings": {
+          "description": "Current limits for a branch, in source units.",
+          "properties": {
+            "c_rating_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rating_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rating_c": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "c_rating_a",
+            "c_rating_b",
+            "c_rating_c"
+          ],
+          "type": "object"
+        },
+        "BranchRatingSet": {
+          "description": "Extra branch MVA rating set beyond the canonical A/B/C columns.",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "rate_mva": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "name",
+            "rate_mva"
+          ],
+          "type": "object"
+        },
+        "BranchSolution": {
+          "description": "Solved branch terminal flows in MW/MVAr.",
+          "properties": {
+            "pf": {
+              "format": "double",
+              "type": "number"
+            },
+            "pt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qt": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "pf",
+            "qf",
+            "pt",
+            "qt"
+          ],
+          "type": "object"
+        },
+        "Bus": {
+          "properties": {
+            "area": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "base_kv": {
+              "format": "double",
+              "type": "number"
+            },
+            "evhi": {
+              "default": null,
+              "description": "Emergency (short-term) voltage band, set only when the source states one\ndistinct from the normal [`vmax`](Bus::vmax)/[`vmin`](Bus::vmin) band (PSS/E\n`EVHI`/`EVLO`). `None` means the emergency band equals the normal band, so\nread `evhi.unwrap_or(vmax)` / `evlo.unwrap_or(vmin)`. `#[serde(default)]` so\nJSON written before the fields existed still deserializes.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "evlo": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "id": {
+              "$ref": "#/$defs/BusId",
+              "description": "Stable bus id (1-based in MATPOWER; preserved verbatim)."
+            },
+            "kind": {
+              "$ref": "#/$defs/BusType"
+            },
+            "location": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Location"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional bus coordinates in the network coordinate space."
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uid": {
+              "description": "Stable row identity for `.pio.json` payloads and operating point updates:\nthe source record uid where the format defines one (GOC3), synthesized at\npackage build otherwise. `#[serde(default)]` so JSON written before the\nfield existed still deserializes.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "va": {
+              "description": "Voltage angle (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "vm": {
+              "description": "Voltage magnitude (p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "vmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "vmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "zone": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "id",
+            "kind",
+            "vm",
+            "va",
+            "base_kv",
+            "vmax",
+            "vmin",
+            "area",
+            "zone",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "BusId": {
+          "description": "A source bus ID, preserved from the input format.\n\nMATPOWER IDs are 1-based and can contain gaps. They are distinct from the\nzero based dense indices produced by\n[`IndexedNetwork::bus_index`](crate::IndexedNetwork::bus_index). JSON stores\nthis type as an integer.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "BusType": {
+          "description": "Bus type per MATPOWER convention: 1=PQ, 2=PV, 3=ref/slack, 4=isolated.",
+          "enum": [
+            "PQ",
+            "PV",
+            "REF",
+            "ISOLATED"
+          ],
+          "type": "string"
+        },
+        "Canvas": {
+          "description": "Diagram canvas metadata.",
+          "properties": {
+            "height": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "units": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "Configuration": {
+          "enum": [
+            "wye",
+            "delta",
+            "single_phase"
+          ],
+          "type": "string"
+        },
+        "ConstraintSelection": {
+          "description": "Which elements of one constraint family are active, by stable element\nidentity (the payload `uid`, else `{table}:{row}`; buses by their id).",
+          "oneOf": [
+            {
+              "description": "Every element with a stated limit.",
+              "properties": {
+                "select": {
+                  "const": "all",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "No element; the family is relaxed.",
+              "properties": {
+                "select": {
+                  "const": "none",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exactly the named elements.",
+              "properties": {
+                "identities": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "select": {
+                  "const": "only",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select",
+                "identities"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ControlVoltageReference": {
+          "enum": [
+            "PN_PER_PHASE",
+            "PP_PER_PHASE",
+            "PP_AVERAGED",
+            "PG_AVERAGED",
+            "PN_AVERAGED",
+            "PG_PER_PHASE"
+          ],
+          "type": "string"
+        },
+        "CoordsKind": {
+          "description": "Coordinate origin.",
+          "enum": [
+            "source",
+            "synthetic",
+            "manual",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "DcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "approximation": {
+              "description": "Frozen `powerio.module/1` key from 0.10. The value is the selected\n[`BranchSusceptanceFormula`](powerio_tx::BranchSusceptanceFormula) stable name.",
+              "type": "string"
+            },
+            "constraints": {
+              "$ref": "#/$defs/ActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1",
+              "description": "The typed objective the instance states, in the calculation crate's\nown serialization."
+            }
+          },
+          "required": [
+            "network",
+            "approximation",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "DcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_flow_dual": {
+              "description": "Read only 0.10 signed thermal dual (`from - to`). The 1.x reader splits\nit into the two directional multiplier columns.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_limit_multiplier": {
+              "description": "Nonnegative multiplier on the from-side thermal bound, by branch.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_limit_multiplier": {
+              "description": "Nonnegative multiplier on the to-side thermal bound, by branch.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_power_marginal": {
+              "description": "Optimal objective derivative per added MW of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_price": {
+              "description": "Read only 0.10 name for the active demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/DcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "branch_from_active_flow",
+            "branch_to_active_flow",
+            "generator_active_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "DcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "approximation": {
+              "description": "Frozen `powerio.module/1` key from 0.10. The value is the selected\n[`BranchSusceptanceFormula`](powerio_tx::BranchSusceptanceFormula) stable name.",
+              "type": "string"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network",
+            "approximation"
+          ],
+          "type": "object"
+        },
+        "DcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_dispatch": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeneratorDispatchV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "instance": {
+              "$ref": "#/$defs/DcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "branch_from_active_flow",
+            "branch_to_active_flow"
+          ],
+          "type": "object"
+        },
+        "DiagnosticV1": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "related": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "severity": {
+              "$ref": "#/$defs/SeverityV1"
+            },
+            "spans": {
+              "items": {
+                "$ref": "#/$defs/SourceSpanV1"
+              },
+              "type": "array"
+            },
+            "suggested_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "target": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "severity",
+            "code",
+            "message"
+          ],
+          "type": "object"
+        },
+        "DigestAlgorithmV1": {
+          "enum": [
+            "sha256"
+          ],
+          "type": "string"
+        },
+        "DigestV1": {
+          "additionalProperties": false,
+          "properties": {
+            "algorithm": {
+              "$ref": "#/$defs/DigestAlgorithmV1"
+            },
+            "value": {
+              "description": "Lowercase hexadecimal, without a prefix.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "algorithm",
+            "value"
+          ],
+          "type": "object"
+        },
+        "DistBus": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "grounded": {
+              "description": "Terminals tied to ground with zero impedance.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "location": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistLocation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional bus coordinates in the network coordinate space."
+            },
+            "terminals": {
+              "description": "Ordered terminal names; OpenDSS node numbers as strings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "v_min": {
+              "description": "Voltage magnitude bounds, volts: the scalar pair plus the phase to\nneutral and phase to phase families, and the per-sequence scalars\n(BMOPF schema 0.1.0: positive sequence has both bounds, negative and\nzero sequence and neutral to ground are magnitude caps whose lower\nbound is always 0).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vn_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vneg_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpn_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpn_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpos_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpos_min": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpp_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpp_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vzero_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "terminals",
+            "grounded",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistCanvas": {
+          "description": "Diagram canvas metadata.",
+          "properties": {
+            "height": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "units": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "DistCapacitor": {
+          "description": "A rated capacitor bank (BMOPF schema 0.1.0 `capacitor`): `q_rated` vars\ndelivered at `v_nom` volts across the element terminals, distinct from the\nraw admittance [`DistShunt`]. The DSS converter still lowers OpenDSS\ncapacitors to shunt B matrices; this element carries capacitors that arrive\nas BMOPF input.",
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "q_rated": {
+              "description": "Nameplate rated reactive power of the whole bank, vars.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_nom": {
+              "description": "Nameplate nominal voltage, volts: line to line for the three phase\nconfigurations, across the terminals for SINGLE_PHASE.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "q_rated",
+            "v_nom",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistControlProfile": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "power_factor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/PowerFactorControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volt_var": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/VoltVarControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volt_watt": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/VoltWattControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistCoordsKind": {
+          "description": "Coordinate origin.",
+          "enum": [
+            "source",
+            "synthetic",
+            "manual",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "DistGenerator": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "cost": {
+              "description": "Generation cost, $/kWh per phase conductor, exactly as the source\nstates it: one entry per phase, or a single entry for a scalar\nstatement. No OpenDSS equivalent, so it is None until a format\nsupplies it.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_min": {
+              "default": null,
+              "description": "Bounds per phase. A `null` element reads as -Inf in a lower bound\nand +Inf in an upper bound: the PMD unbounded spelling (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_nom": {
+              "description": "Setpoint, watts per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "s_max": {
+              "description": "Per-conductor apparent power and current limits, VA and amps (BMOPF\ngenerator fields, alongside the p/q bounds).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "p_nom",
+            "q_nom",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistGeoMeta": {
+          "description": "Network level coordinate metadata.",
+          "oneOf": [
+            {
+              "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "geographic",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Planar coordinates, with the CRS named when known.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "projected",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Drawing coordinates with no earth referent.",
+              "properties": {
+                "canvas": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/DistCanvas"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "space": {
+                  "const": "diagram",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source did not declare a coordinate space.",
+              "properties": {
+                "space": {
+                  "const": "unknown",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            }
+          ],
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistCoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Default origin for points without their own `kind`."
+            }
+          },
+          "type": "object"
+        },
+        "DistIbr": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "control_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Per conductor current limits, amperes.",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_avail": {
+              "description": "Available active power, watts.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "prime_mover": {
+              "$ref": "#/$defs/IbrPrimeMover"
+            },
+            "q_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "s_max": {
+              "description": "Per phase apparent power nameplate ratings, volt amperes.",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": "array"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "topology": {
+              "$ref": "#/$defs/IbrTopology"
+            },
+            "voltage_aggregation": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/IbrVoltageAggregation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "topology",
+            "prime_mover",
+            "s_max",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLine": {
+          "properties": {
+            "bus_from": {
+              "type": "string"
+            },
+            "bus_to": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "description": "Per-conductor ampacity and apparent power limits, amps and VA\n(BMOPF schema 0.1.0 line fields, alongside the linecode's own).\nA `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "length": {
+              "description": "Meters. A `null` reads as NaN: a BMOPF line without a length (#268).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "linecode": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "route": {
+              "description": "Polyline route in the network's coordinate space (`MulticonductorNetwork.geo`),\npresent only when a source provides intermediate geometry.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes.",
+              "items": {
+                "$ref": "#/$defs/DistLocation"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "s_max": {
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_map_from": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "terminal_map_to": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus_from",
+            "bus_to",
+            "terminal_map_from",
+            "terminal_map_to",
+            "linecode",
+            "length",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLineCode": {
+          "properties": {
+            "b_from": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "b_to": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g_from": {
+              "description": "Shunt admittance halves at each end, S per meter.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "g_to": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "n_conductors": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "r_series": {
+              "description": "Series impedance, ohm per meter.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "s_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "source": {
+              "description": "Origin of the impedance matrices (BMOPF `source`, e.g. \"fem\",\n\"datasheet\", \"import\").",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x_series": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "n_conductors",
+            "r_series",
+            "x_series",
+            "g_from",
+            "b_from",
+            "g_to",
+            "b_to",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLoad": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_nom": {
+              "description": "Watts per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_nom": {
+              "description": "Vars per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "voltage_model": {
+              "$ref": "#/$defs/DistLoadVoltageModel"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "p_nom",
+            "q_nom",
+            "voltage_model",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLoadVoltageModel": {
+          "oneOf": [
+            {
+              "description": "Constant power load. `v_nom` is volts per active phase when the source\nstates it.",
+              "properties": {
+                "model": {
+                  "const": "constant_power",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Constant current load. `v_nom` is volts per active phase.",
+              "properties": {
+                "model": {
+                  "const": "constant_current",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Constant impedance load. `v_nom` is volts per active phase.",
+              "properties": {
+                "model": {
+                  "const": "constant_impedance",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "ZIP load coefficients by active phase. `v_nom` is volts per active\nphase; alpha terms apply to active power and beta terms to reactive\npower.",
+              "properties": {
+                "alpha_i": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "alpha_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "alpha_z": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_i": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_z": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "model": {
+                  "const": "zip",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom",
+                "alpha_z",
+                "alpha_i",
+                "alpha_p",
+                "beta_z",
+                "beta_i",
+                "beta_p"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exponential voltage model by active phase. `v_nom` is volts per active\nphase.",
+              "properties": {
+                "gamma_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "gamma_q": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "model": {
+                  "const": "exponential",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom",
+                "gamma_p",
+                "gamma_q"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "DistLocation": {
+          "description": "A point attached to one model element.",
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistCoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Point origin when it differs from the network default."
+            },
+            "x": {
+              "description": "X coordinate. In geographic space this is longitude.",
+              "format": "double",
+              "type": "number"
+            },
+            "y": {
+              "description": "Y coordinate. In geographic space this is latitude.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ],
+          "type": "object"
+        },
+        "DistShunt": {
+          "properties": {
+            "b": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g": {
+              "description": "Total siemens in conductor order.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "g",
+            "b",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistSourceFormat": {
+          "description": "Where the network came from; fixes the echo tier target.",
+          "enum": [
+            "dss",
+            "bmopf-json",
+            "pmd-json"
+          ],
+          "type": "string"
+        },
+        "DistSwitch": {
+          "properties": {
+            "bus_from": {
+              "type": "string"
+            },
+            "bus_to": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "open": {
+              "type": "boolean"
+            },
+            "terminal_map_from": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "terminal_map_to": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus_from",
+            "bus_to",
+            "terminal_map_from",
+            "terminal_map_to",
+            "open",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistTransformer": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "phases": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "windings": {
+              "items": {
+                "$ref": "#/$defs/DistWinding"
+              },
+              "type": "array"
+            },
+            "xsc_pct": {
+              "description": "Short circuit reactances between winding pairs, percent:\n`[xhl]` for two windings, `[xhl, xht, xlt]` for three.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "windings",
+            "xsc_pct",
+            "phases",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistWinding": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "conn": {
+              "$ref": "#/$defs/DistWindingConn"
+            },
+            "r_neutral": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "r_pct": {
+              "description": "Winding resistance, percent of the winding base.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "s_rating": {
+              "description": "Volt amperes.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "tap": {
+              "format": "double",
+              "type": "number"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_ref": {
+              "description": "Rated winding voltage, volts (line to line for 2 and 3 phase).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "x_neutral": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "bus",
+            "terminal_map",
+            "conn",
+            "v_ref",
+            "s_rating",
+            "r_pct",
+            "tap"
+          ],
+          "type": "object"
+        },
+        "DistWindingConn": {
+          "enum": [
+            "wye",
+            "delta"
+          ],
+          "type": "string"
+        },
+        "DurationV1": {
+          "additionalProperties": false,
+          "description": "A stored duration: unsigned seconds plus a nanosecond remainder below one\nbillion, exactly.",
+          "properties": {
+            "nanos": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "secs": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "secs",
+            "nanos"
+          ],
+          "type": "object"
+        },
+        "GenCost": {
+          "description": "A generator cost curve (`mpc.gencost` row).",
+          "properties": {
+            "coeffs": {
+              "description": "Raw coefficients, highest order first for the polynomial model:\n`[c_{k-1}, …, c1, c0]`.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "model": {
+              "description": "1 = piecewise linear, 2 = polynomial.",
+              "format": "uint8",
+              "maximum": 255,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "ncost": {
+              "description": "Number of cost coefficients (polynomial) or breakpoints (piecewise).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "shutdown": {
+              "format": "double",
+              "type": "number"
+            },
+            "startup": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "model",
+            "startup",
+            "shutdown",
+            "ncost",
+            "coeffs"
+          ],
+          "type": "object"
+        },
+        "Generator": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "caps": {
+              "additionalProperties": {
+                "format": "double",
+                "type": "number"
+              },
+              "default": {},
+              "description": "The MATPOWER gen capability / ramp columns past `PMIN`, aligned to\n`GEN_EXTRA_KEYS` by index (`None` for a column the source omitted).\nA fixed array, not an [`Extras`] map: a string-keyed map per generator\ncosts 11 heap allocations each, which dominates the parse of a large\ngenerator-heavy case. Surfaced into formats that name them (PowerModels).\nOn the JSON snapshot it is a name-keyed object (see `caps_serde`) so the\nschema stays additive when `GEN_EXTRA_KEYS` grows; `#[serde(default)]` so a\nsnapshot that omits it deserializes to the empty set.",
+              "type": "object"
+            },
+            "cost": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GenCost"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "mbase": {
+              "format": "double",
+              "type": "number"
+            },
+            "pg": {
+              "description": "Real power set point (MW).",
+              "format": "double",
+              "type": "number"
+            },
+            "pmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "qg": {
+              "description": "Reactive power set point (MVAr).",
+              "format": "double",
+              "type": "number"
+            },
+            "qmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "regulated_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "The remote bus whose voltage this generator regulates, when that is not its\nown terminal bus (PSS/E `IREG`). `None` means it regulates its own bus.\nPart of the cross-element voltage-control graph: a format that names a\nremote regulated bus (PSS/E) keeps it across a round trip instead of\ncollapsing every generator onto its own terminal. `#[serde(default)]` so\nJSON written before the field existed still deserializes."
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "vg": {
+              "description": "Voltage set point (p.u.).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "pg",
+            "qg",
+            "pmax",
+            "pmin",
+            "qmax",
+            "qmin",
+            "vg",
+            "mbase",
+            "in_service"
+          ],
+          "type": "object"
+        },
+        "GeneratorDispatchV1": {
+          "additionalProperties": false,
+          "description": "A solution's producer stated generator dispatch.",
+          "properties": {
+            "p_mw": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "q_mvar": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "p_mw",
+            "q_mvar"
+          ],
+          "type": "object"
+        },
+        "GeoMeta": {
+          "description": "Network level coordinate metadata.",
+          "oneOf": [
+            {
+              "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "geographic",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Planar coordinates, with the CRS named when known.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "projected",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Drawing coordinates with no earth referent.",
+              "properties": {
+                "canvas": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/Canvas"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "space": {
+                  "const": "diagram",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source did not declare a coordinate space.",
+              "properties": {
+                "space": {
+                  "const": "unknown",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            }
+          ],
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/CoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Default origin for points without their own `kind`."
+            }
+          },
+          "type": "object"
+        },
+        "HistoryEntryV1": {
+          "additionalProperties": false,
+          "description": "Describes an operation that produced the current value. Not a replay\nprogram; replayable revisions require their own typed value.",
+          "properties": {
+            "assumptions": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "input_kind": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "$ref": "#/$defs/HistoryKindV1"
+            },
+            "losses": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Stable registered operation name.",
+              "type": "string"
+            },
+            "output_kind": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "parameters": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "required": [
+            "id",
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        "HistoryKindV1": {
+          "enum": [
+            "parse",
+            "upgrade",
+            "transform",
+            "edit",
+            "repair"
+          ],
+          "type": "string"
+        },
+        "Hvdc": {
+          "description": "A two-terminal HVDC line (MATPOWER `dcline`).\n\n`pf`/`pt`/`qf`/`qt` are stored in MATPOWER's sign convention regardless of\nsource: the PowerModels reader un-flips `pt`/`qf`/`qt` on the way in, and the\nPowerModels writer re-flips them on the way out (PowerModels.jl uses the\nopposite sign). The flip is a format-boundary translation, so a derived view\nlike `to_normalized` keeps the MATPOWER convention and only scales to per unit.",
+          "properties": {
+            "cost": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GenCost"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "loss0": {
+              "format": "double",
+              "type": "number"
+            },
+            "loss1": {
+              "format": "double",
+              "type": "number"
+            },
+            "pf": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "pt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmaxf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmaxt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qminf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmint": {
+              "format": "double",
+              "type": "number"
+            },
+            "qt": {
+              "format": "double",
+              "type": "number"
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "vf": {
+              "format": "double",
+              "type": "number"
+            },
+            "vt": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "in_service",
+            "pf",
+            "pt",
+            "qf",
+            "qt",
+            "vf",
+            "vt",
+            "pmin",
+            "pmax",
+            "qminf",
+            "qmaxf",
+            "qmint",
+            "qmaxt",
+            "loss0",
+            "loss1",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "IbrPrimeMover": {
+          "enum": [
+            "PV",
+            "BATTERY",
+            "GENERIC",
+            "STATCOM",
+            "DSTATCOM"
+          ],
+          "type": "string"
+        },
+        "IbrTopology": {
+          "enum": [
+            "SINGLE_PHASE",
+            "THREE_LEG",
+            "FOUR_LEG"
+          ],
+          "type": "string"
+        },
+        "IbrVoltageAggregation": {
+          "enum": [
+            "PER_PHASE",
+            "AVERAGE"
+          ],
+          "type": "string"
+        },
+        "Impedance": {
+          "description": "A series impedance with the MVA base it is expressed on. Used pairwise by\n[`Transformer3W`]; a self-contained unit so the base travels with the value\ninstead of being implied by position.\n\n`r`/`x` are per unit on the *system* base (the same `CZ = 1` convention as\n[`Branch::r`]/[`Branch::x`], so the matrix math needs no rebasing); `base_mva`\nrecords the winding-pair MVA base the source file declared (PSS/E `SBASE1-2`\nand friends), kept so a write-back reproduces it and so a future `CZ = 2`\nreader has somewhere to put the winding base it must rebase from. Room to grow\n(winding voltage base, turns-ratio units) as the transformer control work\nlands without reshaping the [`Transformer3W::z`] array.",
+          "properties": {
+            "base_mva": {
+              "format": "double",
+              "type": "number"
+            },
+            "r": {
+              "format": "double",
+              "type": "number"
+            },
+            "x": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "r",
+            "x",
+            "base_mva"
+          ],
+          "type": "object"
+        },
+        "Load": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "p": {
+              "description": "Active demand (MW).",
+              "format": "double",
+              "type": "number"
+            },
+            "q": {
+              "description": "Reactive demand (MVAr).",
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "voltage_model": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LoadVoltageModel"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Voltage dependence, when the source states one. `None` is constant power."
+            }
+          },
+          "required": [
+            "bus",
+            "p",
+            "q",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "LoadVoltageModel": {
+          "description": "Voltage dependence for a transmission load.",
+          "oneOf": [
+            {
+              "description": "Explicit constant power marker.",
+              "properties": {
+                "kind": {
+                  "const": "constant_power",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "ZIP load split in source units. The three active parts sum to\n[`Load::p`], and the three reactive parts sum to [`Load::q`].",
+              "properties": {
+                "kind": {
+                  "const": "zip",
+                  "type": "string"
+                },
+                "load_type": {
+                  "default": null,
+                  "description": "Source load type code, when a format has one (PSS/E `ID`/`LOADTYPE`\nstyle metadata).",
+                  "format": "int32",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "p_constant_current": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "p_constant_impedance": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "p_constant_power": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_current": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_impedance": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_power": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "scaling": {
+                  "default": null,
+                  "description": "Source scaling factor, when a format has one.",
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "v_nom": {
+                  "default": null,
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "p_constant_power",
+                "q_constant_power",
+                "p_constant_current",
+                "q_constant_current",
+                "p_constant_impedance",
+                "q_constant_impedance"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exponential voltage model: `P = p * (V / v_nom)^gamma_p`,\n`Q = q * (V / v_nom)^gamma_q`.",
+              "properties": {
+                "gamma_p": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "gamma_q": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "kind": {
+                  "const": "exponential",
+                  "type": "string"
+                },
+                "p": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "v_nom": {
+                  "default": null,
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "p",
+                "q",
+                "gamma_p",
+                "gamma_q"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "Location": {
+          "description": "A point attached to one model element.",
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/CoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Point origin when it differs from the network default."
+            },
+            "x": {
+              "description": "X coordinate. In geographic space this is longitude.",
+              "format": "double",
+              "type": "number"
+            },
+            "y": {
+              "description": "Y coordinate. In geographic space this is latitude.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ],
+          "type": "object"
+        },
+        "McAcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "constraints": {
+              "$ref": "#/$defs/MulticonductorActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1"
+            }
+          },
+          "required": [
+            "network",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "McAcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/McAcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "source_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_current_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "terminal_voltage_magnitude",
+            "terminal_voltage_angle",
+            "source_active_injection",
+            "generator_active_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "McAcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            }
+          },
+          "required": [
+            "network"
+          ],
+          "type": "object"
+        },
+        "McAcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "instance": {
+              "$ref": "#/$defs/McAcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "source_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_current_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "terminal_voltage_magnitude",
+            "terminal_voltage_angle",
+            "source_active_injection"
+          ],
+          "type": "object"
+        },
+        "MulticonductorActiveConstraints": {
+          "description": "The active constraint families of a multiconductor OPF instance.",
+          "properties": {
+            "conductor_limits": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Conductor current or apparent power limits."
+            },
+            "generator_capability": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Per phase generator capability bounds."
+            },
+            "terminal_voltage_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Terminal voltage magnitude bounds."
+            }
+          },
+          "required": [
+            "terminal_voltage_bounds",
+            "conductor_limits",
+            "generator_capability"
+          ],
+          "type": "object"
+        },
+        "MulticonductorNetwork": {
+          "description": "A multiconductor distribution network.\n\n`source` retains the original text for the byte exact echo tier;\n`defaulted` records, per element (`\"class.name\"` key), the fields the\nreader materialized from format defaults rather than the source text.",
+          "properties": {
+            "base_frequency": {
+              "description": "Hz.",
+              "format": "double",
+              "type": "number"
+            },
+            "buses": {
+              "items": {
+                "$ref": "#/$defs/DistBus"
+              },
+              "type": "array"
+            },
+            "capacitors": {
+              "items": {
+                "$ref": "#/$defs/DistCapacitor"
+              },
+              "type": "array"
+            },
+            "commands": {
+              "description": "Source commands and options the typed model does not interpret\n(`solve`, `set mode=...`), in order, as (verb, args).",
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "control_profiles": {
+              "items": {
+                "$ref": "#/$defs/DistControlProfile"
+              },
+              "type": "array"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "generators": {
+              "items": {
+                "$ref": "#/$defs/DistGenerator"
+              },
+              "type": "array"
+            },
+            "geo": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistGeoMeta"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "ibrs": {
+              "items": {
+                "$ref": "#/$defs/DistIbr"
+              },
+              "type": "array"
+            },
+            "linecodes": {
+              "items": {
+                "$ref": "#/$defs/DistLineCode"
+              },
+              "type": "array"
+            },
+            "lines": {
+              "items": {
+                "$ref": "#/$defs/DistLine"
+              },
+              "type": "array"
+            },
+            "loads": {
+              "items": {
+                "$ref": "#/$defs/DistLoad"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "options": {
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "shunts": {
+              "items": {
+                "$ref": "#/$defs/DistShunt"
+              },
+              "type": "array"
+            },
+            "source_format": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistSourceFormat"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "sources": {
+              "description": "BMOPF allows exactly one; the model allows any number and the BMOPF\nwriter warns beyond the first.",
+              "items": {
+                "$ref": "#/$defs/VoltageSource"
+              },
+              "type": "array"
+            },
+            "switches": {
+              "items": {
+                "$ref": "#/$defs/DistSwitch"
+              },
+              "type": "array"
+            },
+            "transformers": {
+              "items": {
+                "$ref": "#/$defs/DistTransformer"
+              },
+              "type": "array"
+            },
+            "untyped": {
+              "items": {
+                "$ref": "#/$defs/UntypedObject"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "base_frequency",
+            "buses",
+            "linecodes",
+            "lines",
+            "switches",
+            "transformers",
+            "loads",
+            "generators",
+            "shunts",
+            "sources",
+            "untyped",
+            "commands",
+            "options",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "MulticonductorOperatingPointTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            },
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "description": "Quantity name → dense columns, the multiconductor instantaneous\nvocabulary.",
+              "type": "object"
+            },
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "network",
+            "time_points",
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "ObjectiveTermV1": {
+          "description": "One typed objective term, mirroring `powerio_prob::ObjectiveTerm` with its\nweight wrapped for the nonfinite spelling: an internally tagged enum's\nderived `Deserialize` re-decodes its variant from a buffered generic\nvalue rather than the deserializer callers pass in, so wrapping the whole\ndocument's deserializer (as [`StoredModuleV1`] does for every plain\nstruct field) never reaches this `f64`.",
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "term": {
+                  "const": "network_generator_cost",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "term"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "term": {
+                  "const": "network_per_phase_cost",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "term"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Read only compatibility for 0.10 documents. The runtime removes this\nterm and records `READ.MODULE.OBJECTIVE_TERM_RETIRED` because the token\ndid not define a portable quantity or unit.",
+              "properties": {
+                "term": {
+                  "const": "differentiability_regularization",
+                  "type": "string"
+                },
+                "weight": {
+                  "$ref": "#/$defs/StoredF64"
+                }
+              },
+              "required": [
+                "term",
+                "weight"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ObjectiveV1": {
+          "additionalProperties": false,
+          "description": "The complete typed objective, mirroring `powerio_prob::Objective`.",
+          "properties": {
+            "terms": {
+              "items": {
+                "$ref": "#/$defs/ObjectiveTermV1"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "PowerFactorControl": {
+          "properties": {
+            "pf": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "pf"
+          ],
+          "type": "object"
+        },
+        "ProducerV1": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "ReactivePowerReference": {
+          "enum": [
+            "VAR_MAX",
+            "VAR_AVAILABLE"
+          ],
+          "type": "string"
+        },
+        "ReactivePowerUnit": {
+          "enum": [
+            "VA_FRACTION",
+            "VAR"
+          ],
+          "type": "string"
+        },
+        "Residuals": {
+          "description": "Numerical residuals of the solved equations, in the problem's power unit.\nA field is `None` when the producer did not report it.",
+          "properties": {
+            "max_active_power_mismatch": {
+              "description": "Largest absolute active power balance mismatch, MW.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "max_reactive_power_mismatch": {
+              "description": "Largest absolute reactive power balance mismatch, MVAr.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "ScopfAcContingencySurvivors": {
+          "description": "Per-contingency surviving AC lines and transformers, one group per\ncontingency in `reliability.contingency` document order.",
+          "properties": {
+            "ln": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/ScopfAcLineSurvivorRow"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "xf": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/ScopfTransformerSurvivorRow"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "ln",
+            "xf"
+          ],
+          "type": "object"
+        },
+        "ScopfAcLineRow": {
+          "description": "One AC line row.",
+          "properties": {
+            "b_ch": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_ln",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "c_su",
+            "c_sd",
+            "u_0",
+            "s_max",
+            "g_sr",
+            "b_sr",
+            "b_ch",
+            "g_fr",
+            "g_to",
+            "b_fr",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "ScopfAcLineSurvivorRow": {
+          "description": "One AC line surviving a contingency.",
+          "properties": {
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max_ctg": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ctg",
+            "j_ln",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "b_sr",
+            "s_max_ctg"
+          ],
+          "type": "object"
+        },
+        "ScopfActiveReserveRow": {
+          "description": "One active power zonal reserve row.",
+          "properties": {
+            "c_nsc": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rgd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rgu": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rrd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rru": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_scr": {
+              "format": "double",
+              "type": "number"
+            },
+            "n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_rrd_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_rru_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "sigma_nsc": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_rgd": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_rgu": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_scr": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "n_p",
+            "uid",
+            "c_rgu",
+            "c_rgd",
+            "c_scr",
+            "c_nsc",
+            "c_rru",
+            "c_rrd",
+            "sigma_rgu",
+            "sigma_rgd",
+            "sigma_scr",
+            "sigma_nsc",
+            "p_rru_min",
+            "p_rrd_min"
+          ],
+          "type": "object"
+        },
+        "ScopfActiveReserveSetRow": {
+          "description": "One (bus, active reserve zone, device) membership row.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dev": {
+              "description": "The member device's ordinals ([`ScopfDeviceRow::j_dev`],\n[`ScopfDeviceRow::j_sdd`]).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "i",
+            "n_p",
+            "uid",
+            "j_dev",
+            "j_sdd"
+          ],
+          "type": "object"
+        },
+        "ScopfBusRow": {
+          "description": "One bus row: `(i, uid, v_min, v_max)`.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "v_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "v_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "i",
+            "uid",
+            "v_min",
+            "v_max"
+          ],
+          "type": "object"
+        },
+        "ScopfDcContingencyFlowRow": {
+          "description": "One surviving DC line in one contingency and period.",
+          "properties": {
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "flat_jtk_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            }
+          },
+          "required": [
+            "flat_jtk_dc",
+            "ctg",
+            "j_dc",
+            "to_bus",
+            "fr_bus",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfDcLineRow": {
+          "description": "One DC line row.",
+          "properties": {
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pdc_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_fr_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_fr_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_to_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_to_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_dc",
+            "uid",
+            "pdc_max",
+            "qdc_fr_min",
+            "qdc_to_min",
+            "qdc_fr_max",
+            "qdc_to_max",
+            "to_bus",
+            "fr_bus"
+          ],
+          "type": "object"
+        },
+        "ScopfDeviceClassLayout": {
+          "description": "How the two device classes sit in the `simple_dispatchable_device` section.\n\nA model that stacks producers and consumers into one variable vector\naddresses a device by a per class offset, which is a bijection only when\neach class owns one unbroken run. Reading the order without that\nprecondition is the one mistake this type makes unavailable.",
+          "oneOf": [
+            {
+              "description": "Each class is one unbroken run. `producers_first` says which run\nstarts first.",
+              "properties": {
+                "kind": {
+                  "const": "contiguous",
+                  "type": "string"
+                },
+                "producers_first": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "kind",
+                "producers_first"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The two classes interleave, so no per class offset addresses a device.",
+              "properties": {
+                "kind": {
+                  "const": "interleaved",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ScopfDeviceRow": {
+          "description": "One simple dispatchable device row.\n\nProducers and consumers share this layout. Vector fields use the internal\nzero based period order.\n\nThe reactive capability block is the `q_bound_cap`/`q_linear_cap` pair and\nthe parameters of the mode each one selects. The two modes are mutually\nexclusive and a device can select neither. A parameter of a mode the device\ndid not select is `None`. Read the two flags before the parameters.",
+          "properties": {
+            "beta": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "beta_lb": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "beta_ub": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "c_nsc": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_on": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_qrd": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_qru": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rgd": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rgu": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rrd_off": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rrd_on": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rru_off": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rru_on": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_scr": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_dev": {
+              "description": "0-based position within the row's own class list (`prod` or `cons`),\nin document order. Serialization can retain base 0 or select base 1.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "description": "0-based position in the canonical device stacking: the producer block,\nthen the consumer block, document order within each. Sound for every\nuid spelling, including interleaved classes.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_0": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_nsc_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rd": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rd_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rgd_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rgu_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rrd_off_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rrd_on_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rru_off_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rru_on_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_ru": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_ru_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_scr_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_0": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_0_lb": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_0_ub": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_bound_cap": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "q_linear_cap": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "q_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_p0": {
+              "description": "The intercept of the linear capability line. The GOC3 document calls\nthis `q_0`, which this row already uses for `initial_status.q`.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "sus": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "bus",
+            "uid",
+            "j_dev",
+            "j_sdd",
+            "c_on",
+            "c_su",
+            "c_sd",
+            "p_ru",
+            "p_rd",
+            "p_ru_su",
+            "p_rd_sd",
+            "c_rgu",
+            "c_rgd",
+            "c_scr",
+            "c_nsc",
+            "c_rru_on",
+            "c_rru_off",
+            "c_rrd_on",
+            "c_rrd_off",
+            "c_qru",
+            "c_qrd",
+            "p_rgu_max",
+            "p_rgd_max",
+            "p_scr_max",
+            "p_nsc_max",
+            "p_rru_on_max",
+            "p_rru_off_max",
+            "p_rrd_on_max",
+            "p_rrd_off_max",
+            "p_0",
+            "q_0",
+            "u_0",
+            "p_max",
+            "p_min",
+            "q_max",
+            "q_min",
+            "sus",
+            "q_bound_cap",
+            "q_linear_cap"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMaxCsRow": {
+          "properties": {
+            "a_en_max_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_max_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_cs_ind",
+            "uid",
+            "a_en_max_start",
+            "a_en_max_end",
+            "e_max"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMaxPrRow": {
+          "properties": {
+            "a_en_max_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_max_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_pr_ind",
+            "uid",
+            "a_en_max_start",
+            "a_en_max_end",
+            "e_max"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMinCsRow": {
+          "properties": {
+            "a_en_min_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_min_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_cs_ind",
+            "uid",
+            "a_en_min_start",
+            "a_en_min_end",
+            "e_min"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMinPrRow": {
+          "properties": {
+            "a_en_min_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_min_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_pr_ind",
+            "uid",
+            "a_en_min_start",
+            "a_en_min_end",
+            "e_min"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMaxCsRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_cs_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMaxPrRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_pr_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMinCsRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_cs_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMinPrRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_pr_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindows": {
+          "description": "Energy requirement windows and their period memberships.",
+          "properties": {
+            "t_w_en_max_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMaxCsRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_max_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMaxPrRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_min_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMinCsRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_min_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMinPrRow"
+              },
+              "type": "array"
+            },
+            "w_en_max_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMaxCsRow"
+              },
+              "type": "array"
+            },
+            "w_en_max_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMaxPrRow"
+              },
+              "type": "array"
+            },
+            "w_en_min_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMinCsRow"
+              },
+              "type": "array"
+            },
+            "w_en_min_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMinPrRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "w_en_max_pr",
+            "w_en_max_cs",
+            "w_en_min_pr",
+            "w_en_min_cs",
+            "t_w_en_max_pr",
+            "t_w_en_max_cs",
+            "t_w_en_min_pr",
+            "t_w_en_min_cs"
+          ],
+          "type": "object"
+        },
+        "ScopfFixedPhaseRow": {
+          "description": "A transformer with a fixed phase shift (`fpd`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "phi_o": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "phi_o"
+          ],
+          "type": "object"
+        },
+        "ScopfFixedRatioRow": {
+          "description": "A transformer with a fixed winding ratio (`fwr`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tau_o": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "tau_o"
+          ],
+          "type": "object"
+        },
+        "ScopfLengths": {
+          "description": "Set sizes for each indexed device class.",
+          "properties": {
+            "i": {
+              "description": "Bus count.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "k": {
+              "description": "Contingency count.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_ac": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_br": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_cs": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_cspr": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_pr": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_sh": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "l_j_xf",
+            "l_j_ln",
+            "l_j_ac",
+            "l_j_dc",
+            "l_j_br",
+            "l_j_cs",
+            "l_j_pr",
+            "l_j_cspr",
+            "l_j_sh",
+            "i",
+            "l_t",
+            "l_n_p",
+            "l_n_q",
+            "k"
+          ],
+          "type": "object"
+        },
+        "ScopfPriceBlockRow": {
+          "description": "One flattened device, period, and price block row.",
+          "properties": {
+            "c_en": {
+              "format": "double",
+              "type": "number"
+            },
+            "flat_k": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "m": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "flat_k",
+            "uid",
+            "t",
+            "m",
+            "c_en",
+            "p_max"
+          ],
+          "type": "object"
+        },
+        "ScopfPriceBlocks": {
+          "description": "Flattened producer and consumer price blocks.",
+          "properties": {
+            "consumer": {
+              "items": {
+                "$ref": "#/$defs/ScopfPriceBlockRow"
+              },
+              "type": "array"
+            },
+            "producer": {
+              "items": {
+                "$ref": "#/$defs/ScopfPriceBlockRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "producer",
+            "consumer"
+          ],
+          "type": "object"
+        },
+        "ScopfReactiveReserveRow": {
+          "description": "One reactive (reactive-power) zonal reserve row.",
+          "properties": {
+            "c_qrd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_qru": {
+              "format": "double",
+              "type": "number"
+            },
+            "n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "q_qrd_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_qru_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "n_q",
+            "uid",
+            "c_qru",
+            "c_qrd",
+            "q_qru_min",
+            "q_qrd_min"
+          ],
+          "type": "object"
+        },
+        "ScopfReactiveReserveSetRow": {
+          "description": "One (bus, reactive reserve zone, device) membership row.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dev": {
+              "description": "The member device's ordinals ([`ScopfDeviceRow::j_dev`],\n[`ScopfDeviceRow::j_sdd`]).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "i",
+            "n_q",
+            "uid",
+            "j_dev",
+            "j_sdd"
+          ],
+          "type": "object"
+        },
+        "ScopfShuntRow": {
+          "description": "One shunt row.",
+          "properties": {
+            "b_sh": {
+              "format": "double",
+              "type": "number"
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_sh": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_sh": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_sh",
+            "uid",
+            "bus",
+            "g_sh",
+            "b_sh"
+          ],
+          "type": "object"
+        },
+        "ScopfStaticData": {
+          "description": "Static buses, branches, devices, controls, reserves, and memberships.",
+          "properties": {
+            "acl_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfAcLineRow"
+              },
+              "type": "array"
+            },
+            "active_reserve": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveRow"
+              },
+              "type": "array"
+            },
+            "active_reserve_set_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "active_reserve_set_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "acx_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfTransformerRow"
+              },
+              "type": "array"
+            },
+            "bus": {
+              "items": {
+                "$ref": "#/$defs/ScopfBusRow"
+              },
+              "type": "array"
+            },
+            "cons": {
+              "items": {
+                "$ref": "#/$defs/ScopfDeviceRow"
+              },
+              "type": "array"
+            },
+            "dc_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfDcLineRow"
+              },
+              "type": "array"
+            },
+            "fpd": {
+              "items": {
+                "$ref": "#/$defs/ScopfFixedPhaseRow"
+              },
+              "type": "array"
+            },
+            "fwr": {
+              "items": {
+                "$ref": "#/$defs/ScopfFixedRatioRow"
+              },
+              "type": "array"
+            },
+            "prod": {
+              "items": {
+                "$ref": "#/$defs/ScopfDeviceRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve_set_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve_set_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "shunt": {
+              "items": {
+                "$ref": "#/$defs/ScopfShuntRow"
+              },
+              "type": "array"
+            },
+            "vpd": {
+              "items": {
+                "$ref": "#/$defs/ScopfVariablePhaseRow"
+              },
+              "type": "array"
+            },
+            "vwr": {
+              "items": {
+                "$ref": "#/$defs/ScopfVariableRatioRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "bus",
+            "shunt",
+            "acl_branch",
+            "acx_branch",
+            "vpd",
+            "fpd",
+            "vwr",
+            "fwr",
+            "dc_branch",
+            "prod",
+            "cons",
+            "active_reserve",
+            "reactive_reserve",
+            "active_reserve_set_pr",
+            "active_reserve_set_cs",
+            "reactive_reserve_set_pr",
+            "reactive_reserve_set_cs"
+          ],
+          "type": "object"
+        },
+        "ScopfTransformerRow": {
+          "description": "One two winding transformer row.",
+          "properties": {
+            "b_ch": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_xf",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "c_su",
+            "c_sd",
+            "u_0",
+            "s_max",
+            "g_sr",
+            "b_sr",
+            "b_ch",
+            "g_fr",
+            "g_to",
+            "b_fr",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "ScopfTransformerSurvivorRow": {
+          "description": "One transformer surviving a contingency.",
+          "properties": {
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max_ctg": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ctg",
+            "j_xf",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "b_sr",
+            "s_max_ctg"
+          ],
+          "type": "object"
+        },
+        "ScopfVariablePhaseRow": {
+          "description": "A transformer with a variable phase-shift control range (`vpd`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "phi_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "phi_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "phi_min",
+            "phi_max"
+          ],
+          "type": "object"
+        },
+        "ScopfVariableRatioRow": {
+          "description": "A transformer with a variable winding ratio control range (`vwr`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tau_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "tau_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "tau_min",
+            "tau_max"
+          ],
+          "type": "object"
+        },
+        "ScopfViolationCost": {
+          "description": "The case's four violation prices. The GOC3 document spells them\n`p_bus_vio_cost`, `q_bus_vio_cost`, `s_vio_cost`, and `e_vio_cost` under\n`network.violation_cost`. Any one of them can be absent and is then `None`:\nGOCompetition's 14 bus validation case has no `e_vio_cost`.",
+          "properties": {
+            "e": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_bus": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_bus": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "s": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "ScucDeviceOutputsV1": {
+          "additionalProperties": false,
+          "properties": {
+            "on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_nsyn_res": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_on": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_ramp_res_down_online": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_ramp_res_up_online": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_reg_res_down": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_reg_res_up": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_syn_res": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q_res_down": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q_res_up": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "on_status",
+            "p_on",
+            "q",
+            "p_reg_res_up",
+            "p_reg_res_down",
+            "p_syn_res",
+            "p_nsyn_res",
+            "p_ramp_res_up_online",
+            "p_ramp_res_down_online",
+            "q_res_up",
+            "q_res_down"
+          ],
+          "type": "object"
+        },
+        "ScucInputs": {
+          "description": "Matrix free SCOPF input data.\n\nInternal class, period, contingency, window, and flattened row indices are\nzero based and follow the source document order of the section that owns\nthem. Source UIDs and external bus IDs remain separate fields.",
+          "properties": {
+            "ac_contingency_survivors": {
+              "$ref": "#/$defs/ScopfAcContingencySurvivors"
+            },
+            "dc_contingency_flows": {
+              "items": {
+                "$ref": "#/$defs/ScopfDcContingencyFlowRow"
+              },
+              "type": "array"
+            },
+            "device_class_layout": {
+              "$ref": "#/$defs/ScopfDeviceClassLayout"
+            },
+            "dt": {
+              "description": "The interval durations, so a model needs no raw-document read for its\ntime axis. `lengths.l_t` is this vector's length.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "energy_windows": {
+              "$ref": "#/$defs/ScopfEnergyWindows"
+            },
+            "lengths": {
+              "$ref": "#/$defs/ScopfLengths"
+            },
+            "price_blocks": {
+              "$ref": "#/$defs/ScopfPriceBlocks"
+            },
+            "static_data": {
+              "$ref": "#/$defs/ScopfStaticData",
+              "description": "Buses, branches, devices, controls, reserves, and memberships."
+            },
+            "violation_cost": {
+              "$ref": "#/$defs/ScopfViolationCost"
+            }
+          },
+          "required": [
+            "static_data",
+            "lengths",
+            "energy_windows",
+            "price_blocks",
+            "ac_contingency_survivors",
+            "dc_contingency_flows",
+            "violation_cost",
+            "device_class_layout",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScucNetworkOutputsV1": {
+          "additionalProperties": false,
+          "properties": {
+            "ac_line_on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus_va": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus_vm": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_pdc_fr": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_qdc_fr": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_qdc_to": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "shunt_step": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_ta": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_tm": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "bus_vm",
+            "bus_va",
+            "shunt_step",
+            "ac_line_on_status",
+            "transformer_tm",
+            "transformer_ta",
+            "transformer_on_status"
+          ],
+          "type": "object"
+        },
+        "SeverityV1": {
+          "enum": [
+            "error",
+            "warning",
+            "remark",
+            "note"
+          ],
+          "type": "string"
+        },
+        "Shunt": {
+          "properties": {
+            "b": {
+              "description": "Shunt susceptance (MVAr at V = 1 p.u.). For a switched shunt this is the\ninitial (steady-state) value within the [`control`](Shunt::control) blocks.",
+              "format": "double",
+              "type": "number"
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "control": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SwitchedShuntControl"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Switching-control data when this is a switched (adjustable) shunt; `None`\nfor a fixed shunt. `#[serde(default)]` so JSON written before the field\nexisted still deserializes."
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g": {
+              "description": "Shunt conductance (MW at V = 1 p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "bus",
+            "g",
+            "b",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "ShuntBlock": {
+          "description": "One block of a switched shunt: `steps` equal increments of susceptance `b`.",
+          "properties": {
+            "b": {
+              "description": "Susceptance increment per step (MVAr at V = 1 p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "steps": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "steps",
+            "b"
+          ],
+          "type": "object"
+        },
+        "SolverParams": {
+          "description": "Solver / solution-control metadata: the Newton tolerance and iteration cap,\nthe zero-impedance threshold, and the per-quantity adjustment-enable flags.\n\nEach field is optional because a source states only the ones it carries. No\npower flow physics, but it determines whether a downstream solver reproduces\nthe source tool's converged answer. Maps to the PSS/E v34+ system-wide block\n(`GENERAL THRSHZ`, `NEWTON TOLN`/`ITMXN`, `SOLVER ACTAPS`/`AREAIN`/`PHSHFT`/\n`DCTAPS`/`SWSHNT`).",
+          "properties": {
+            "adjust_area_interchange": {
+              "description": "Whether the solver adjusts area interchange (`SOLVER AREAIN`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_dc_taps": {
+              "description": "Whether the solver adjusts DC line taps (`SOLVER DCTAPS`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_phase_shift": {
+              "description": "Whether the solver adjusts phase-shift angles (`SOLVER PHSHFT`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_switched_shunt": {
+              "description": "Whether the solver adjusts switched shunts (`SOLVER SWSHNT`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_taps": {
+              "description": "Whether the solver adjusts transformer taps (`SOLVER ACTAPS`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "max_iterations": {
+              "description": "Newton iteration cap (`NEWTON ITMXN`).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "newton_tolerance": {
+              "description": "Newton power flow mismatch tolerance (`NEWTON TOLN`).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "zero_impedance_threshold": {
+              "description": "Branches with `|x|` below this are treated as zero impedance (`GENERAL THRSHZ`).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "SourceDescriptorV1": {
+          "additionalProperties": false,
+          "properties": {
+            "byte_length": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "digest": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DigestV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "format": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "byte_length"
+          ],
+          "type": "object"
+        },
+        "SourceFormat": {
+          "description": "Which format a [`BalancedNetwork`] was read from. Drives the same format byte exact\necho on write.\n\nSerializes as the same lowercase token [`name`](SourceFormat::name) reports\nand every string entry point accepts, so the value a document carries is\nvalid input to `from`. Documents written before 0.9.0 spelled the bare\nvariant name (\"Matpower\"); the read side still accepts those spellings.",
+          "oneOf": [
+            {
+              "enum": [
+                "matpower",
+                "powermodels-json",
+                "egret-json",
+                "psse",
+                "powerworld",
+                "pandapower-json"
+              ],
+              "type": "string"
+            },
+            {
+              "const": "pslf",
+              "description": "Read from a GE PSLF `.epc` case. Same source text is retained, so a\nsame-format write echoes it byte-for-byte; a cross-format or\nsource-dropped write goes through the `.epc` serializer\n([`write_pslf`](crate::write_pslf)).",
+              "type": "string"
+            },
+            {
+              "const": "powerworld-pwb",
+              "description": "Read from a PowerWorld `.pwb` binary case. Read only: there is no\n`.pwb` writer and no retained source text, so writing goes through\nanother format's writer.",
+              "type": "string"
+            },
+            {
+              "const": "in-memory",
+              "description": "Built in memory, for example from synth or an edited case; no source text.",
+              "type": "string"
+            },
+            {
+              "const": "normalized",
+              "description": "A normalized derived form ([`BalancedNetwork::to_normalized`]): per unit, radians,\nfiltered, source bus ids preserved. Distinct from\n[`InMemory`](SourceFormat::InMemory) so consumers can tell a per unit\nproduct from a raw in memory network; it has no source text and a different\nunit basis than a parsed network.",
+              "type": "string"
+            },
+            {
+              "const": "gridfm",
+              "description": "Read back from a gridfm-datakit Parquet dataset (the ML→classical bridge,\n`powerio-matrix`'s `read_gridfm_dataset`). A lossy, power flow complete\nreconstruction with no retained source text: original bus ids are\nsynthesized `1..n`, per element load/shunt granularity is folded to one\nsynthetic element per bus, and HVDC/storage/piecewise costs are absent.",
+              "type": "string"
+            },
+            {
+              "const": "pypsa-csv",
+              "description": "Read from a PyPSA CSV folder. This is a folder format rather than a\nsingle retained text document, so same-format writes are canonicalized.",
+              "type": "string"
+            },
+            {
+              "const": "goc3-json",
+              "description": "Read from a DOE GO Challenge 3 JSON input document. The source is a\nunit commitment data set; the neutral transmission model keeps a static\nfirst interval network and retains the source text for the full data.",
+              "type": "string"
+            },
+            {
+              "const": "surge-json",
+              "description": "Read from a Surge native JSON document.",
+              "type": "string"
+            },
+            {
+              "const": "opfdata-json",
+              "description": "Read from one raw JSON document in a DeepMind OPFData release. The\nsource carries both solver initial values and a solution. The balanced\nmodel represents the solved snapshot and retains the source for an\nexact write back to the same format.",
+              "type": "string"
+            }
+          ]
+        },
+        "SourceMapEntryV1": {
+          "additionalProperties": false,
+          "properties": {
+            "relation": {
+              "$ref": "#/$defs/SourceRelationV1"
+            },
+            "spans": {
+              "description": "Empty only for `defaulted`, `synthetic`, or `transformed`.",
+              "items": {
+                "$ref": "#/$defs/SourceSpanV1"
+              },
+              "type": "array"
+            },
+            "target": {
+              "description": "RFC 6901 pointer into `value.data`.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "target",
+            "relation"
+          ],
+          "type": "object"
+        },
+        "SourceRelationV1": {
+          "enum": [
+            "exact",
+            "defaulted",
+            "inferred",
+            "converted_units",
+            "aggregated",
+            "split",
+            "synthetic",
+            "transformed",
+            "retained_extra"
+          ],
+          "type": "string"
+        },
+        "SourceSpanV1": {
+          "additionalProperties": false,
+          "properties": {
+            "byte_end": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "byte_start": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "byte_start",
+            "byte_end"
+          ],
+          "type": "object"
+        },
+        "Storage": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "charge_efficiency": {
+              "format": "double",
+              "type": "number"
+            },
+            "charge_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "current_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "discharge_efficiency": {
+              "format": "double",
+              "type": "number"
+            },
+            "discharge_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "energy": {
+              "format": "double",
+              "type": "number"
+            },
+            "energy_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "p_loss": {
+              "format": "double",
+              "type": "number"
+            },
+            "ps": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_loss": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "qs": {
+              "format": "double",
+              "type": "number"
+            },
+            "r": {
+              "format": "double",
+              "type": "number"
+            },
+            "thermal_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "ps",
+            "qs",
+            "energy",
+            "energy_rating",
+            "charge_rating",
+            "discharge_rating",
+            "charge_efficiency",
+            "discharge_efficiency",
+            "thermal_rating",
+            "qmin",
+            "qmax",
+            "r",
+            "x",
+            "p_loss",
+            "q_loss",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "StoredF64": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ]
+            }
+          ]
+        },
+        "StoredOperatingPointV1": {
+          "additionalProperties": false,
+          "description": "One stored operating point: the state quantities of a single point,\nkeyed by the instantaneous vocabulary, each with its resolved identity\norder and one row of values.",
+          "properties": {
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "StoredQuantityV1": {
+          "additionalProperties": false,
+          "description": "One state quantity's dense columns: the resolved identity order, then the\npoint major values (`time_points.len() × identities.len()`).",
+          "properties": {
+            "identities": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "values": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "identities",
+            "values"
+          ],
+          "type": "object"
+        },
+        "StoredValueV1": {
+          "description": "The tagged value DTO. `data` is a typed record, never an untyped JSON\ncatchall; the network payloads are the typed serializations the network\ncrates own (which carry the nonfinite spellings themselves).",
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetwork"
+                },
+                "kind": {
+                  "const": "balanced_network",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/MulticonductorNetwork"
+                },
+                "kind": {
+                  "const": "multiconductor_network",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetworkTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "balanced_network_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedOperatingPointTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "balanced_operating_point_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/MulticonductorOperatingPointTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "multiconductor_operating_point_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetworkScenarioSetV1"
+                },
+                "kind": {
+                  "const": "balanced_network_scenario_set",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "dc_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "dc_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "mc_ac_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "mc_ac_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcScucInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_scuc_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "dc_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "dc_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "mc_ac_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "mc_ac_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcScucSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_scuc_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "Switch": {
+          "description": "A transmission switch. Closed switches are preserved as data; matrix builders\ndo not lower them into zero impedance branches.",
+          "properties": {
+            "closed": {
+              "type": "boolean"
+            },
+            "current_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "pf": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "pt": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "qf": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "qt": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "thermal_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "closed",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "SwitchedShuntControl": {
+          "description": "Switching-control data for a switched shunt ([`Shunt::control`]): the mode,\nthe regulated voltage band and bus, the reactive-range percentage, and the\nadjustable susceptance blocks. The shunt's [`b`](Shunt::b) is the initial\nvalue within the blocks' total range.",
+          "properties": {
+            "blocks": {
+              "items": {
+                "$ref": "#/$defs/ShuntBlock"
+              },
+              "type": "array"
+            },
+            "control_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The regulated bus; `None` means the shunt regulates its own bus."
+            },
+            "mode": {
+              "$ref": "#/$defs/SwitchedShuntMode"
+            },
+            "rmpct": {
+              "description": "Percent of the controlled device's reactive range to apply (PSS/E `RMPCT`).",
+              "format": "double",
+              "type": "number"
+            },
+            "vhigh": {
+              "description": "Regulated voltage band (per unit).",
+              "format": "double",
+              "type": "number"
+            },
+            "vlow": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "mode",
+            "vhigh",
+            "vlow",
+            "rmpct",
+            "blocks"
+          ],
+          "type": "object"
+        },
+        "SwitchedShuntMode": {
+          "description": "How a switched shunt adjusts its susceptance. Maps to the PSS/E `MODSW` code.",
+          "oneOf": [
+            {
+              "const": "locked",
+              "description": "Fixed at its initial susceptance, no automatic switching (`MODSW` 0).",
+              "type": "string"
+            },
+            {
+              "const": "continuous",
+              "description": "Continuous adjustment within the block range (`MODSW` 1).",
+              "type": "string"
+            },
+            {
+              "const": "discrete",
+              "description": "Discrete adjustment in fixed steps (`MODSW` 2 and up).",
+              "type": "string"
+            }
+          ]
+        },
+        "Termination": {
+          "description": "How the producing calculation ended.",
+          "oneOf": [
+            {
+              "description": "The calculation converged to its stated tolerance.",
+              "properties": {
+                "kind": {
+                  "const": "converged",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The iteration limit ended the calculation before convergence.",
+              "properties": {
+                "kind": {
+                  "const": "iteration_limit",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The solver proved the constraints admit no solution. The optimization\noutcome an OPF consumer acts on differently from a numerical failure:\nthe case is overconstrained, and no retry or setting change fixes it.",
+              "properties": {
+                "kind": {
+                  "const": "infeasible",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The solver proved the objective unbounded over the feasible set.",
+              "properties": {
+                "kind": {
+                  "const": "unbounded",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The calculation failed.",
+              "properties": {
+                "kind": {
+                  "const": "failed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source records a solved calculation without termination\ninformation (DeepMind OPFData does).",
+              "properties": {
+                "kind": {
+                  "const": "not_reported",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "TimePointV1": {
+          "additionalProperties": false,
+          "properties": {
+            "duration": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DurationV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "label": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "label"
+          ],
+          "type": "object"
+        },
+        "Transformer3W": {
+          "description": "A three winding transformer with three terminal buses joined at a star point.\n\nSeries impedance is stored for winding pairs 1-2, 2-3, and 3-1. The record\nalso retains star point voltage and per winding control data. PSS/E three\nwinding records and PSLF tertiary winding records map to this type.\n[`to_star_expansion`](Transformer3W::to_star_expansion) turns it into the synthetic\nstar bus plus three branches for a consumer that works in the bus-branch model;\n[`IndexedNetwork`](crate::IndexedNetwork) applies it before building any matrix,\nso a 3-winding transformer contributes to `Y_bus` and connectivity.",
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "mag_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "mag_g": {
+              "description": "Magnetizing shunt referred to the star point (p.u. on the system base).",
+              "format": "double",
+              "type": "number"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "star_va": {
+              "format": "double",
+              "type": "number"
+            },
+            "star_vm": {
+              "description": "Star-point voltage magnitude (p.u.) and angle (degrees), as solved.",
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "windings": {
+              "description": "The three windings, in order (primary, secondary, tertiary).",
+              "items": {
+                "$ref": "#/$defs/Winding"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            "z": {
+              "description": "Pairwise series impedance `[z12, z23, z31]` (primary-secondary,\nsecondary-tertiary, tertiary-primary), each per unit on the system base\nwith its declared MVA base.",
+              "items": {
+                "$ref": "#/$defs/Impedance"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            }
+          },
+          "required": [
+            "windings",
+            "z",
+            "star_vm",
+            "star_va",
+            "mag_g",
+            "mag_b",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "TransformerControl": {
+          "description": "Automatic-control data for a regulating transformer ([`Branch::control`]).\n\nThe limits carry whatever the [`mode`](TransformerControl::mode) regulates:\n`tap_min`/`tap_max` bound the tap ratio (or the phase angle, for\n[`ActiveFlow`](TransformerControlMode::ActiveFlow)), and `band_min`/`band_max`\nbound the controlled quantity (the regulated voltage band, or the\nscheduled MW/MVAr). `ntp` is the number of discrete tap positions and\n`controlled_bus` is the regulated bus (`None` = the transformer's own\nterminal). `mva_base` is the winding MVA base the impedance is referred to.",
+          "properties": {
+            "band_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "band_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "controlled_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "mode": {
+              "$ref": "#/$defs/TransformerControlMode"
+            },
+            "mva_base": {
+              "format": "double",
+              "type": "number"
+            },
+            "ntp": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tap_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "tap_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "mode",
+            "tap_min",
+            "tap_max",
+            "band_min",
+            "band_max",
+            "ntp",
+            "mva_base"
+          ],
+          "type": "object"
+        },
+        "TransformerControlMode": {
+          "description": "What a regulating transformer's tap (or phase shift) automatically controls.\nMaps to the PSS/E control code `COD` and the PSLF transformer `type`.",
+          "oneOf": [
+            {
+              "const": "fixed",
+              "description": "Fixed ratio, no automatic adjustment (PSS/E `COD` 0/±4, PSLF type 1).",
+              "type": "string"
+            },
+            {
+              "const": "voltage",
+              "description": "Bus voltage control via tap (LTC; PSS/E `COD` ±1, PSLF type 2).",
+              "type": "string"
+            },
+            {
+              "const": "reactive_flow",
+              "description": "Reactive power flow control via tap (PSS/E `COD` ±2).",
+              "type": "string"
+            },
+            {
+              "const": "active_flow",
+              "description": "Active power flow control via phase shift (PSS/E `COD` ±3, PSLF type 4).",
+              "type": "string"
+            }
+          ]
+        },
+        "UntypedObject": {
+          "description": "An object the reader recognized but does not type: preserved by class,\nname, and raw property text so conversions can warn precisely.",
+          "properties": {
+            "class": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "props": {
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "class",
+            "name",
+            "props"
+          ],
+          "type": "object"
+        },
+        "VoltVarControl": {
+          "properties": {
+            "breakpoints": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_min_for_q": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_min_for_q_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_limits": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_ref": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ReactivePowerReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "q_unit": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ReactivePowerUnit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "voltage_reference": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ControlVoltageReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "breakpoints",
+            "q_limits"
+          ],
+          "type": "object"
+        },
+        "VoltWattControl": {
+          "properties": {
+            "breakpoints": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_limits": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_ref": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActivePowerReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "p_unit": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActivePowerUnit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "voltage_reference": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ControlVoltageReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "breakpoints",
+            "p_limits"
+          ],
+          "type": "object"
+        },
+        "VoltageSource": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_angle": {
+              "description": "Radians per terminal.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "v_magnitude": {
+              "description": "Volts per terminal (0.0 on grounded terminals).",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "v_magnitude",
+            "v_angle",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "Winding": {
+          "description": "One winding of a [`Transformer3W`]: its terminal bus, off-nominal ratio, phase\nshift, nominal voltage, and thermal ratings.",
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "nominal_kv": {
+              "description": "Winding nominal voltage (kV); 0 defers to the terminal bus base kV.",
+              "format": "double",
+              "type": "number"
+            },
+            "rate_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_c": {
+              "format": "double",
+              "type": "number"
+            },
+            "shift": {
+              "description": "Phase shift (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "tap": {
+              "description": "Off-nominal turns ratio (1.0 = nominal); the PSS/E `WINDV`, `CW = 1`.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "tap",
+            "shift",
+            "nominal_kv",
+            "rate_a",
+            "rate_b",
+            "rate_c"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "diagnostics": {
+          "items": {
+            "$ref": "#/$defs/DiagnosticV1"
+          },
+          "type": "array"
+        },
+        "extensions": {
+          "additionalProperties": true,
+          "description": "Nonsemantic third party annotations. Keys must be namespaced.",
+          "type": "object"
+        },
+        "history": {
+          "items": {
+            "$ref": "#/$defs/HistoryEntryV1"
+          },
+          "type": "array"
+        },
+        "producer": {
+          "$ref": "#/$defs/ProducerV1"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "source_map": {
+          "items": {
+            "$ref": "#/$defs/SourceMapEntryV1"
+          },
+          "type": "array"
+        },
+        "sources": {
+          "items": {
+            "$ref": "#/$defs/SourceDescriptorV1"
+          },
+          "type": "array"
+        },
+        "value": {
+          "$ref": "#/$defs/StoredValueV1"
+        },
+        "version": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "schema",
+        "version",
+        "producer",
+        "value"
+      ],
+      "title": "StoredModuleV1",
+      "type": "object"
+    },
+    "solve_response": {
+      "$defs": {
+        "AcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "constraints": {
+              "$ref": "#/$defs/ActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1"
+            }
+          },
+          "required": [
+            "network",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "AcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_limit_multiplier": {
+              "description": "Nonnegative multiplier on the from-terminal apparent power bound.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_from_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_limit_multiplier": {
+              "description": "Nonnegative multiplier on the to-terminal apparent power bound.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_to_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_power_marginal": {
+              "description": "Optimal objective derivative per added MW of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_active_price": {
+              "description": "Read only 0.10 name for the active demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_reactive_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_reactive_power_marginal": {
+              "description": "Optimal objective derivative per added MVAr of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_reactive_price": {
+              "description": "Read only 0.10 name for the reactive demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_reactive_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/AcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_magnitude",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "bus_reactive_injection",
+            "branch_from_active_flow",
+            "branch_from_reactive_flow",
+            "branch_to_active_flow",
+            "branch_to_reactive_flow",
+            "generator_active_power",
+            "generator_reactive_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "AcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network"
+          ],
+          "type": "object"
+        },
+        "AcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_reactive_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_reactive_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_dispatch": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeneratorDispatchV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "instance": {
+              "$ref": "#/$defs/AcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_magnitude",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "bus_reactive_injection",
+            "branch_from_active_flow",
+            "branch_from_reactive_flow",
+            "branch_to_active_flow",
+            "branch_to_reactive_flow"
+          ],
+          "type": "object"
+        },
+        "AcScucInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "inputs": {
+              "$ref": "#/$defs/ScucInputs",
+              "description": "The complete SCUC inputs, in the calculation crate's own\nserialization, typed through this document's schema."
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network",
+            "inputs"
+          ],
+          "type": "object"
+        },
+        "AcScucSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "device_outputs": {
+              "$ref": "#/$defs/ScucDeviceOutputsV1"
+            },
+            "instance": {
+              "$ref": "#/$defs/AcScucInstanceV1"
+            },
+            "network_outputs": {
+              "$ref": "#/$defs/ScucNetworkOutputsV1"
+            },
+            "objective": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "network_outputs",
+            "device_outputs"
+          ],
+          "type": "object"
+        },
+        "ActiveConstraints": {
+          "description": "The active constraint families of a balanced OPF instance.",
+          "properties": {
+            "angle_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Branch angle difference bounds."
+            },
+            "generator_capability": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Generator capability bounds (active and reactive limits)."
+            },
+            "thermal_limits": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Branch thermal limits."
+            },
+            "voltage_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Bus voltage magnitude bounds."
+            }
+          },
+          "required": [
+            "generator_capability",
+            "voltage_bounds",
+            "thermal_limits",
+            "angle_bounds"
+          ],
+          "type": "object"
+        },
+        "ActivePowerReference": {
+          "enum": [
+            "P_AVAILABLE",
+            "P_MAX",
+            "S_MAX"
+          ],
+          "type": "string"
+        },
+        "ActivePowerUnit": {
+          "enum": [
+            "VA_FRACTION",
+            "W"
+          ],
+          "type": "string"
+        },
+        "Area": {
+          "description": "An area record: the area's scheduled net interchange and its swing bus.\n\nThe [`number`](Area::number) matches the `area` field carried on each\n[`Bus`]; this table holds the per-area metadata (the interchange target and\nthe area slack) that the bus number alone can't. Maps to the PSS/E area record\n(`I, ISW, PDES, PTOL, ARNAME`).",
+          "properties": {
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "net_interchange": {
+              "description": "Scheduled net interchange (MW); positive is export out of the area.",
+              "format": "double",
+              "type": "number"
+            },
+            "number": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "slack_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The area swing (slack) bus, or `None` when unset."
+            },
+            "tolerance": {
+              "description": "Interchange tolerance bandwidth (MW).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "number",
+            "net_interchange",
+            "tolerance"
+          ],
+          "type": "object"
+        },
+        "BalancedNetwork": {
+          "description": "A balanced network with stable source bus IDs and separate element tables.\n\n`remote = \"Self\"` turns the derived serde impls into inherent functions;\nthe trait impls beneath the struct route them through [`crate::nonfinite`],\nso a nonfinite float spells as a string on every JSON route.",
+          "properties": {
+            "areas": {
+              "default": [],
+              "description": "Area records: scheduled interchange and per-area swing bus. Distinct from\nthe bare `area` number on each [`Bus`]; this is the area's metadata, which\nevery conversion dropped before. `#[serde(default)]` so older JSON still\ndeserializes.",
+              "items": {
+                "$ref": "#/$defs/Area"
+              },
+              "type": "array"
+            },
+            "base_frequency": {
+              "default": 60.0,
+              "description": "System base frequency in hertz (50 or 60). Threaded through the formats\nthat record it (PSS/E `BASFRQ`, pandapower `f_hz`) and defaulted to\n[`DEFAULT_BASE_FREQUENCY`] for the rest. Load-bearing for any\nreactance↔henry conversion (pandapower line charging) and reported as a\nfidelity loss when a non-default value writes to a format with no\nfrequency field.",
+              "format": "double",
+              "type": "number"
+            },
+            "base_mva": {
+              "format": "double",
+              "type": "number"
+            },
+            "branches": {
+              "items": {
+                "$ref": "#/$defs/Branch"
+              },
+              "type": "array"
+            },
+            "buses": {
+              "items": {
+                "$ref": "#/$defs/Bus"
+              },
+              "type": "array"
+            },
+            "generators": {
+              "items": {
+                "$ref": "#/$defs/Generator"
+              },
+              "type": "array"
+            },
+            "geo": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeoMeta"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "hvdc": {
+              "items": {
+                "$ref": "#/$defs/Hvdc"
+              },
+              "type": "array"
+            },
+            "loads": {
+              "items": {
+                "$ref": "#/$defs/Load"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "shunts": {
+              "items": {
+                "$ref": "#/$defs/Shunt"
+              },
+              "type": "array"
+            },
+            "solver": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SolverParams"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Solver / solution-control metadata when the source carries it, else `None`.\n`#[serde(default)]` so older JSON still deserializes."
+            },
+            "source_format": {
+              "$ref": "#/$defs/SourceFormat"
+            },
+            "storage": {
+              "items": {
+                "$ref": "#/$defs/Storage"
+              },
+              "type": "array"
+            },
+            "switches": {
+              "default": [],
+              "items": {
+                "$ref": "#/$defs/Switch"
+              },
+              "type": "array"
+            },
+            "transformers_3w": {
+              "default": [],
+              "description": "Three-winding transformers, kept as typed records rather than folded into\n`branches`, so a star point and the per-winding data survive a round trip.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes. [`IndexedNetwork`](crate::IndexedNetwork) lowers each\nin-service record into a star bus plus three branches (via\n[`Transformer3W::to_star_expansion`]) before building any matrix, so a\n3-winding transformer does appear in `Y_bus`/connectivity; the canonical\nmodel keeps the typed record for round-trip fidelity.",
+              "items": {
+                "$ref": "#/$defs/Transformer3W"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "base_mva",
+            "buses",
+            "loads",
+            "shunts",
+            "branches",
+            "generators",
+            "storage",
+            "hvdc",
+            "source_format"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkScenarioSetV1": {
+          "additionalProperties": false,
+          "properties": {
+            "scenarios": {
+              "items": {
+                "$ref": "#/$defs/BalancedNetworkScenarioV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "scenarios"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkScenarioV1": {
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "probability": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "value": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "id",
+            "value"
+          ],
+          "type": "object"
+        },
+        "BalancedNetworkTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            },
+            "values": {
+              "items": {
+                "$ref": "#/$defs/BalancedNetwork"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "time_points",
+            "values"
+          ],
+          "type": "object"
+        },
+        "BalancedOperatingPointTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "description": "Quantity name → dense columns, the balanced instantaneous vocabulary.",
+              "type": "object"
+            },
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "network",
+            "time_points",
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "Branch": {
+          "properties": {
+            "angmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "angmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "b": {
+              "description": "MATPOWER compatible total line charging susceptance (p.u.). This is the\nlegacy total projection; when [`charging`](Branch::charging) is present,\nper terminal admittance is canonical and this field is compatibility data.",
+              "format": "double",
+              "type": "number"
+            },
+            "charging": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchCharging"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Per terminal shunt admittance (p.u.). If absent, derive symmetric\nsusceptance from [`b`](Branch::b)."
+            },
+            "control": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TransformerControl"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Regulating-transformer control data, when this branch is a transformer\nunder automatic tap or phase control. `None` for lines and for fixed-ratio\ntransformers. `#[serde(default)]` so JSON written before the field existed\nstill deserializes."
+            },
+            "current_ratings": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchCurrentRatings"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Current ratings, when the source distinguishes them from MVA ratings."
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "r": {
+              "description": "Series resistance (p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "rate_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_c": {
+              "format": "double",
+              "type": "number"
+            },
+            "rating_sets": {
+              "default": [],
+              "description": "Additional MVA rating sets beyond A/B/C. Matrix builders continue to use\n`rate_a` unless they opt into one of these named sets.",
+              "items": {
+                "$ref": "#/$defs/BranchRatingSet"
+              },
+              "type": "array"
+            },
+            "route": {
+              "description": "Polyline route in the network's coordinate space (`BalancedNetwork.geo`),\npresent only when a source provides intermediate geometry; endpoint\nonly rendering derives from the bus locations. `#[serde(default)]` so\nJSON written before the field existed still deserializes.",
+              "items": {
+                "$ref": "#/$defs/Location"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "shift": {
+              "description": "Phase shift (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "solution": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BranchSolution"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Solved branch flow values, when present in a case snapshot."
+            },
+            "tap": {
+              "description": "Tap ratio, MATPOWER convention: 0 means \"no tap\" (a line), treated as 1.",
+              "format": "double",
+              "type": "number"
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x": {
+              "description": "Series reactance (p.u.).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "r",
+            "x",
+            "b",
+            "rate_a",
+            "rate_b",
+            "rate_c",
+            "tap",
+            "shift",
+            "in_service",
+            "angmin",
+            "angmax",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "BranchCharging": {
+          "description": "Per terminal branch shunt admittance in p.u. This is the canonical\nphysical branch shunt model when present.",
+          "properties": {
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "g_fr",
+            "b_fr",
+            "g_to",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "BranchCurrentRatings": {
+          "description": "Current limits for a branch, in source units.",
+          "properties": {
+            "c_rating_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rating_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rating_c": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "c_rating_a",
+            "c_rating_b",
+            "c_rating_c"
+          ],
+          "type": "object"
+        },
+        "BranchRatingSet": {
+          "description": "Extra branch MVA rating set beyond the canonical A/B/C columns.",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "rate_mva": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "name",
+            "rate_mva"
+          ],
+          "type": "object"
+        },
+        "BranchSolution": {
+          "description": "Solved branch terminal flows in MW/MVAr.",
+          "properties": {
+            "pf": {
+              "format": "double",
+              "type": "number"
+            },
+            "pt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qt": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "pf",
+            "qf",
+            "pt",
+            "qt"
+          ],
+          "type": "object"
+        },
+        "Bus": {
+          "properties": {
+            "area": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "base_kv": {
+              "format": "double",
+              "type": "number"
+            },
+            "evhi": {
+              "default": null,
+              "description": "Emergency (short-term) voltage band, set only when the source states one\ndistinct from the normal [`vmax`](Bus::vmax)/[`vmin`](Bus::vmin) band (PSS/E\n`EVHI`/`EVLO`). `None` means the emergency band equals the normal band, so\nread `evhi.unwrap_or(vmax)` / `evlo.unwrap_or(vmin)`. `#[serde(default)]` so\nJSON written before the fields existed still deserializes.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "evlo": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "id": {
+              "$ref": "#/$defs/BusId",
+              "description": "Stable bus id (1-based in MATPOWER; preserved verbatim)."
+            },
+            "kind": {
+              "$ref": "#/$defs/BusType"
+            },
+            "location": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Location"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional bus coordinates in the network coordinate space."
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uid": {
+              "description": "Stable row identity for `.pio.json` payloads and operating point updates:\nthe source record uid where the format defines one (GOC3), synthesized at\npackage build otherwise. `#[serde(default)]` so JSON written before the\nfield existed still deserializes.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "va": {
+              "description": "Voltage angle (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "vm": {
+              "description": "Voltage magnitude (p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "vmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "vmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "zone": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "id",
+            "kind",
+            "vm",
+            "va",
+            "base_kv",
+            "vmax",
+            "vmin",
+            "area",
+            "zone",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "BusId": {
+          "description": "A source bus ID, preserved from the input format.\n\nMATPOWER IDs are 1-based and can contain gaps. They are distinct from the\nzero based dense indices produced by\n[`IndexedNetwork::bus_index`](crate::IndexedNetwork::bus_index). JSON stores\nthis type as an integer.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "BusType": {
+          "description": "Bus type per MATPOWER convention: 1=PQ, 2=PV, 3=ref/slack, 4=isolated.",
+          "enum": [
+            "PQ",
+            "PV",
+            "REF",
+            "ISOLATED"
+          ],
+          "type": "string"
+        },
+        "Canvas": {
+          "description": "Diagram canvas metadata.",
+          "properties": {
+            "height": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "units": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "Configuration": {
+          "enum": [
+            "wye",
+            "delta",
+            "single_phase"
+          ],
+          "type": "string"
+        },
+        "ConstraintSelection": {
+          "description": "Which elements of one constraint family are active, by stable element\nidentity (the payload `uid`, else `{table}:{row}`; buses by their id).",
+          "oneOf": [
+            {
+              "description": "Every element with a stated limit.",
+              "properties": {
+                "select": {
+                  "const": "all",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "No element; the family is relaxed.",
+              "properties": {
+                "select": {
+                  "const": "none",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exactly the named elements.",
+              "properties": {
+                "identities": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "select": {
+                  "const": "only",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "select",
+                "identities"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ControlVoltageReference": {
+          "enum": [
+            "PN_PER_PHASE",
+            "PP_PER_PHASE",
+            "PP_AVERAGED",
+            "PG_AVERAGED",
+            "PN_AVERAGED",
+            "PG_PER_PHASE"
+          ],
+          "type": "string"
+        },
+        "CoordsKind": {
+          "description": "Coordinate origin.",
+          "enum": [
+            "source",
+            "synthetic",
+            "manual",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "DcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "approximation": {
+              "description": "Frozen `powerio.module/1` key from 0.10. The value is the selected\n[`BranchSusceptanceFormula`](powerio_tx::BranchSusceptanceFormula) stable name.",
+              "type": "string"
+            },
+            "constraints": {
+              "$ref": "#/$defs/ActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1",
+              "description": "The typed objective the instance states, in the calculation crate's\nown serialization."
+            }
+          },
+          "required": [
+            "network",
+            "approximation",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "DcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_flow_dual": {
+              "description": "Read only 0.10 signed thermal dual (`from - to`). The 1.x reader splits\nit into the two directional multiplier columns.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_from_limit_multiplier": {
+              "description": "Nonnegative multiplier on the from-side thermal bound, by branch.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_limit_multiplier": {
+              "description": "Nonnegative multiplier on the to-side thermal bound, by branch.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_power_marginal": {
+              "description": "Optimal objective derivative per added MW of demand, by bus.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "bus_price": {
+              "description": "Read only 0.10 name for the active demand marginal.",
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ],
+              "writeOnly": true
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/DcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "branch_from_active_flow",
+            "branch_to_active_flow",
+            "generator_active_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "DcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "approximation": {
+              "description": "Frozen `powerio.module/1` key from 0.10. The value is the selected\n[`BranchSusceptanceFormula`](powerio_tx::BranchSusceptanceFormula) stable name.",
+              "type": "string"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/BalancedNetwork"
+            }
+          },
+          "required": [
+            "network",
+            "approximation"
+          ],
+          "type": "object"
+        },
+        "DcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "branch_from_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "branch_to_active_flow": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "bus_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "generator_dispatch": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GeneratorDispatchV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "instance": {
+              "$ref": "#/$defs/DcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "bus_voltage_angle",
+            "bus_active_injection",
+            "branch_from_active_flow",
+            "branch_to_active_flow"
+          ],
+          "type": "object"
+        },
+        "DiagnosticV1": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "details": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "related": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "severity": {
+              "$ref": "#/$defs/SeverityV1"
+            },
+            "spans": {
+              "items": {
+                "$ref": "#/$defs/SourceSpanV1"
+              },
+              "type": "array"
+            },
+            "suggested_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "target": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "severity",
+            "code",
+            "message"
+          ],
+          "type": "object"
+        },
+        "DigestAlgorithmV1": {
+          "enum": [
+            "sha256"
+          ],
+          "type": "string"
+        },
+        "DigestV1": {
+          "additionalProperties": false,
+          "properties": {
+            "algorithm": {
+              "$ref": "#/$defs/DigestAlgorithmV1"
+            },
+            "value": {
+              "description": "Lowercase hexadecimal, without a prefix.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "algorithm",
+            "value"
+          ],
+          "type": "object"
+        },
+        "DistBus": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "grounded": {
+              "description": "Terminals tied to ground with zero impedance.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "location": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistLocation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional bus coordinates in the network coordinate space."
+            },
+            "terminals": {
+              "description": "Ordered terminal names; OpenDSS node numbers as strings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "v_min": {
+              "description": "Voltage magnitude bounds, volts: the scalar pair plus the phase to\nneutral and phase to phase families, and the per-sequence scalars\n(BMOPF schema 0.1.0: positive sequence has both bounds, negative and\nzero sequence and neutral to ground are magnitude caps whose lower\nbound is always 0).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vn_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vneg_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpn_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpn_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpos_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpos_min": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "vpp_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vpp_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "vzero_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "terminals",
+            "grounded",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistCanvas": {
+          "description": "Diagram canvas metadata.",
+          "properties": {
+            "height": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "units": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "DistCapacitor": {
+          "description": "A rated capacitor bank (BMOPF schema 0.1.0 `capacitor`): `q_rated` vars\ndelivered at `v_nom` volts across the element terminals, distinct from the\nraw admittance [`DistShunt`]. The DSS converter still lowers OpenDSS\ncapacitors to shunt B matrices; this element carries capacitors that arrive\nas BMOPF input.",
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "q_rated": {
+              "description": "Nameplate rated reactive power of the whole bank, vars.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_nom": {
+              "description": "Nameplate nominal voltage, volts: line to line for the three phase\nconfigurations, across the terminals for SINGLE_PHASE.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "q_rated",
+            "v_nom",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistControlProfile": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "power_factor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/PowerFactorControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volt_var": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/VoltVarControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volt_watt": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/VoltWattControl"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistCoordsKind": {
+          "description": "Coordinate origin.",
+          "enum": [
+            "source",
+            "synthetic",
+            "manual",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "DistGenerator": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "cost": {
+              "description": "Generation cost, $/kWh per phase conductor, exactly as the source\nstates it: one entry per phase, or a single entry for a scalar\nstatement. No OpenDSS equivalent, so it is None until a format\nsupplies it.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_min": {
+              "default": null,
+              "description": "Bounds per phase. A `null` element reads as -Inf in a lower bound\nand +Inf in an upper bound: the PMD unbounded spelling (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_nom": {
+              "description": "Setpoint, watts per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "s_max": {
+              "description": "Per-conductor apparent power and current limits, VA and amps (BMOPF\ngenerator fields, alongside the p/q bounds).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "p_nom",
+            "q_nom",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistGeoMeta": {
+          "description": "Network level coordinate metadata.",
+          "oneOf": [
+            {
+              "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "geographic",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Planar coordinates, with the CRS named when known.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "projected",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Drawing coordinates with no earth referent.",
+              "properties": {
+                "canvas": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/DistCanvas"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "space": {
+                  "const": "diagram",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source did not declare a coordinate space.",
+              "properties": {
+                "space": {
+                  "const": "unknown",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            }
+          ],
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistCoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Default origin for points without their own `kind`."
+            }
+          },
+          "type": "object"
+        },
+        "DistIbr": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "control_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Per conductor current limits, amperes.",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_avail": {
+              "description": "Available active power, watts.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "p_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "prime_mover": {
+              "$ref": "#/$defs/IbrPrimeMover"
+            },
+            "q_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "q_min": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "s_max": {
+              "description": "Per phase apparent power nameplate ratings, volt amperes.",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": "array"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "topology": {
+              "$ref": "#/$defs/IbrTopology"
+            },
+            "voltage_aggregation": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/IbrVoltageAggregation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "topology",
+            "prime_mover",
+            "s_max",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLine": {
+          "properties": {
+            "bus_from": {
+              "type": "string"
+            },
+            "bus_to": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "description": "Per-conductor ampacity and apparent power limits, amps and VA\n(BMOPF schema 0.1.0 line fields, alongside the linecode's own).\nA `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "length": {
+              "description": "Meters. A `null` reads as NaN: a BMOPF line without a length (#268).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "linecode": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "route": {
+              "description": "Polyline route in the network's coordinate space (`MulticonductorNetwork.geo`),\npresent only when a source provides intermediate geometry.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes.",
+              "items": {
+                "$ref": "#/$defs/DistLocation"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "s_max": {
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_map_from": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "terminal_map_to": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus_from",
+            "bus_to",
+            "terminal_map_from",
+            "terminal_map_to",
+            "linecode",
+            "length",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLineCode": {
+          "properties": {
+            "b_from": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "b_to": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g_from": {
+              "description": "Shunt admittance halves at each end, S per meter.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "g_to": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "n_conductors": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "r_series": {
+              "description": "Series impedance, ohm per meter.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "s_max": {
+              "default": null,
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "source": {
+              "description": "Origin of the impedance matrices (BMOPF `source`, e.g. \"fem\",\n\"datasheet\", \"import\").",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x_series": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "n_conductors",
+            "r_series",
+            "x_series",
+            "g_from",
+            "b_from",
+            "g_to",
+            "b_to",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLoad": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "configuration": {
+              "$ref": "#/$defs/Configuration"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "p_nom": {
+              "description": "Watts per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_nom": {
+              "description": "Vars per phase.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "voltage_model": {
+              "$ref": "#/$defs/DistLoadVoltageModel"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "configuration",
+            "p_nom",
+            "q_nom",
+            "voltage_model",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistLoadVoltageModel": {
+          "oneOf": [
+            {
+              "description": "Constant power load. `v_nom` is volts per active phase when the source\nstates it.",
+              "properties": {
+                "model": {
+                  "const": "constant_power",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Constant current load. `v_nom` is volts per active phase.",
+              "properties": {
+                "model": {
+                  "const": "constant_current",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Constant impedance load. `v_nom` is volts per active phase.",
+              "properties": {
+                "model": {
+                  "const": "constant_impedance",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "ZIP load coefficients by active phase. `v_nom` is volts per active\nphase; alpha terms apply to active power and beta terms to reactive\npower.",
+              "properties": {
+                "alpha_i": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "alpha_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "alpha_z": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_i": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "beta_z": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "model": {
+                  "const": "zip",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom",
+                "alpha_z",
+                "alpha_i",
+                "alpha_p",
+                "beta_z",
+                "beta_i",
+                "beta_p"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exponential voltage model by active phase. `v_nom` is volts per active\nphase.",
+              "properties": {
+                "gamma_p": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "gamma_q": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "model": {
+                  "const": "exponential",
+                  "type": "string"
+                },
+                "v_nom": {
+                  "items": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "model",
+                "v_nom",
+                "gamma_p",
+                "gamma_q"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "DistLocation": {
+          "description": "A point attached to one model element.",
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistCoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Point origin when it differs from the network default."
+            },
+            "x": {
+              "description": "X coordinate. In geographic space this is longitude.",
+              "format": "double",
+              "type": "number"
+            },
+            "y": {
+              "description": "Y coordinate. In geographic space this is latitude.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ],
+          "type": "object"
+        },
+        "DistShunt": {
+          "properties": {
+            "b": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g": {
+              "description": "Total siemens in conductor order.",
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "g",
+            "b",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistSourceFormat": {
+          "description": "Where the network came from; fixes the echo tier target.",
+          "enum": [
+            "dss",
+            "bmopf-json",
+            "pmd-json"
+          ],
+          "type": "string"
+        },
+        "DistSwitch": {
+          "properties": {
+            "bus_from": {
+              "type": "string"
+            },
+            "bus_to": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "i_max": {
+              "default": null,
+              "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
+              "items": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "open": {
+              "type": "boolean"
+            },
+            "terminal_map_from": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "terminal_map_to": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus_from",
+            "bus_to",
+            "terminal_map_from",
+            "terminal_map_to",
+            "open",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistTransformer": {
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "phases": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "windings": {
+              "items": {
+                "$ref": "#/$defs/DistWinding"
+              },
+              "type": "array"
+            },
+            "xsc_pct": {
+              "description": "Short circuit reactances between winding pairs, percent:\n`[xhl]` for two windings, `[xhl, xht, xlt]` for three.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "windings",
+            "xsc_pct",
+            "phases",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "DistWinding": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "conn": {
+              "$ref": "#/$defs/DistWindingConn"
+            },
+            "r_neutral": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "r_pct": {
+              "description": "Winding resistance, percent of the winding base.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "s_rating": {
+              "description": "Volt amperes.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "tap": {
+              "format": "double",
+              "type": "number"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_ref": {
+              "description": "Rated winding voltage, volts (line to line for 2 and 3 phase).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "x_neutral": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "bus",
+            "terminal_map",
+            "conn",
+            "v_ref",
+            "s_rating",
+            "r_pct",
+            "tap"
+          ],
+          "type": "object"
+        },
+        "DistWindingConn": {
+          "enum": [
+            "wye",
+            "delta"
+          ],
+          "type": "string"
+        },
+        "DurationV1": {
+          "additionalProperties": false,
+          "description": "A stored duration: unsigned seconds plus a nanosecond remainder below one\nbillion, exactly.",
+          "properties": {
+            "nanos": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "secs": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "secs",
+            "nanos"
+          ],
+          "type": "object"
+        },
+        "GenCost": {
+          "description": "A generator cost curve (`mpc.gencost` row).",
+          "properties": {
+            "coeffs": {
+              "description": "Raw coefficients, highest order first for the polynomial model:\n`[c_{k-1}, …, c1, c0]`.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "model": {
+              "description": "1 = piecewise linear, 2 = polynomial.",
+              "format": "uint8",
+              "maximum": 255,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "ncost": {
+              "description": "Number of cost coefficients (polynomial) or breakpoints (piecewise).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "shutdown": {
+              "format": "double",
+              "type": "number"
+            },
+            "startup": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "model",
+            "startup",
+            "shutdown",
+            "ncost",
+            "coeffs"
+          ],
+          "type": "object"
+        },
+        "Generator": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "caps": {
+              "additionalProperties": {
+                "format": "double",
+                "type": "number"
+              },
+              "default": {},
+              "description": "The MATPOWER gen capability / ramp columns past `PMIN`, aligned to\n`GEN_EXTRA_KEYS` by index (`None` for a column the source omitted).\nA fixed array, not an [`Extras`] map: a string-keyed map per generator\ncosts 11 heap allocations each, which dominates the parse of a large\ngenerator-heavy case. Surfaced into formats that name them (PowerModels).\nOn the JSON snapshot it is a name-keyed object (see `caps_serde`) so the\nschema stays additive when `GEN_EXTRA_KEYS` grows; `#[serde(default)]` so a\nsnapshot that omits it deserializes to the empty set.",
+              "type": "object"
+            },
+            "cost": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GenCost"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "mbase": {
+              "format": "double",
+              "type": "number"
+            },
+            "pg": {
+              "description": "Real power set point (MW).",
+              "format": "double",
+              "type": "number"
+            },
+            "pmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "qg": {
+              "description": "Reactive power set point (MVAr).",
+              "format": "double",
+              "type": "number"
+            },
+            "qmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "regulated_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "The remote bus whose voltage this generator regulates, when that is not its\nown terminal bus (PSS/E `IREG`). `None` means it regulates its own bus.\nPart of the cross-element voltage-control graph: a format that names a\nremote regulated bus (PSS/E) keeps it across a round trip instead of\ncollapsing every generator onto its own terminal. `#[serde(default)]` so\nJSON written before the field existed still deserializes."
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "vg": {
+              "description": "Voltage set point (p.u.).",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "pg",
+            "qg",
+            "pmax",
+            "pmin",
+            "qmax",
+            "qmin",
+            "vg",
+            "mbase",
+            "in_service"
+          ],
+          "type": "object"
+        },
+        "GeneratorDispatchV1": {
+          "additionalProperties": false,
+          "description": "A solution's producer stated generator dispatch.",
+          "properties": {
+            "p_mw": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "q_mvar": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "p_mw",
+            "q_mvar"
+          ],
+          "type": "object"
+        },
+        "GeoMeta": {
+          "description": "Network level coordinate metadata.",
+          "oneOf": [
+            {
+              "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "geographic",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Planar coordinates, with the CRS named when known.",
+              "properties": {
+                "crs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "space": {
+                  "const": "projected",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Drawing coordinates with no earth referent.",
+              "properties": {
+                "canvas": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/Canvas"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "space": {
+                  "const": "diagram",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source did not declare a coordinate space.",
+              "properties": {
+                "space": {
+                  "const": "unknown",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "space"
+              ],
+              "type": "object"
+            }
+          ],
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/CoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Default origin for points without their own `kind`."
+            }
+          },
+          "type": "object"
+        },
+        "HistoryEntryV1": {
+          "additionalProperties": false,
+          "description": "Describes an operation that produced the current value. Not a replay\nprogram; replayable revisions require their own typed value.",
+          "properties": {
+            "assumptions": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "input_kind": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "$ref": "#/$defs/HistoryKindV1"
+            },
+            "losses": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Stable registered operation name.",
+              "type": "string"
+            },
+            "output_kind": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "parameters": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "required": [
+            "id",
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        "HistoryKindV1": {
+          "enum": [
+            "parse",
+            "upgrade",
+            "transform",
+            "edit",
+            "repair"
+          ],
+          "type": "string"
+        },
+        "Hvdc": {
+          "description": "A two-terminal HVDC line (MATPOWER `dcline`).\n\n`pf`/`pt`/`qf`/`qt` are stored in MATPOWER's sign convention regardless of\nsource: the PowerModels reader un-flips `pt`/`qf`/`qt` on the way in, and the\nPowerModels writer re-flips them on the way out (PowerModels.jl uses the\nopposite sign). The flip is a format-boundary translation, so a derived view\nlike `to_normalized` keeps the MATPOWER convention and only scales to per unit.",
+          "properties": {
+            "cost": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/GenCost"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "loss0": {
+              "format": "double",
+              "type": "number"
+            },
+            "loss1": {
+              "format": "double",
+              "type": "number"
+            },
+            "pf": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "pmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "pt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmaxf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmaxt": {
+              "format": "double",
+              "type": "number"
+            },
+            "qminf": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmint": {
+              "format": "double",
+              "type": "number"
+            },
+            "qt": {
+              "format": "double",
+              "type": "number"
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "vf": {
+              "format": "double",
+              "type": "number"
+            },
+            "vt": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "in_service",
+            "pf",
+            "pt",
+            "qf",
+            "qt",
+            "vf",
+            "vt",
+            "pmin",
+            "pmax",
+            "qminf",
+            "qmaxf",
+            "qmint",
+            "qmaxt",
+            "loss0",
+            "loss1",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "IbrPrimeMover": {
+          "enum": [
+            "PV",
+            "BATTERY",
+            "GENERIC",
+            "STATCOM",
+            "DSTATCOM"
+          ],
+          "type": "string"
+        },
+        "IbrTopology": {
+          "enum": [
+            "SINGLE_PHASE",
+            "THREE_LEG",
+            "FOUR_LEG"
+          ],
+          "type": "string"
+        },
+        "IbrVoltageAggregation": {
+          "enum": [
+            "PER_PHASE",
+            "AVERAGE"
+          ],
+          "type": "string"
+        },
+        "Impedance": {
+          "description": "A series impedance with the MVA base it is expressed on. Used pairwise by\n[`Transformer3W`]; a self-contained unit so the base travels with the value\ninstead of being implied by position.\n\n`r`/`x` are per unit on the *system* base (the same `CZ = 1` convention as\n[`Branch::r`]/[`Branch::x`], so the matrix math needs no rebasing); `base_mva`\nrecords the winding-pair MVA base the source file declared (PSS/E `SBASE1-2`\nand friends), kept so a write-back reproduces it and so a future `CZ = 2`\nreader has somewhere to put the winding base it must rebase from. Room to grow\n(winding voltage base, turns-ratio units) as the transformer control work\nlands without reshaping the [`Transformer3W::z`] array.",
+          "properties": {
+            "base_mva": {
+              "format": "double",
+              "type": "number"
+            },
+            "r": {
+              "format": "double",
+              "type": "number"
+            },
+            "x": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "r",
+            "x",
+            "base_mva"
+          ],
+          "type": "object"
+        },
+        "Load": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "p": {
+              "description": "Active demand (MW).",
+              "format": "double",
+              "type": "number"
+            },
+            "q": {
+              "description": "Reactive demand (MVAr).",
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "voltage_model": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LoadVoltageModel"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Voltage dependence, when the source states one. `None` is constant power."
+            }
+          },
+          "required": [
+            "bus",
+            "p",
+            "q",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "LoadVoltageModel": {
+          "description": "Voltage dependence for a transmission load.",
+          "oneOf": [
+            {
+              "description": "Explicit constant power marker.",
+              "properties": {
+                "kind": {
+                  "const": "constant_power",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "ZIP load split in source units. The three active parts sum to\n[`Load::p`], and the three reactive parts sum to [`Load::q`].",
+              "properties": {
+                "kind": {
+                  "const": "zip",
+                  "type": "string"
+                },
+                "load_type": {
+                  "default": null,
+                  "description": "Source load type code, when a format has one (PSS/E `ID`/`LOADTYPE`\nstyle metadata).",
+                  "format": "int32",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "p_constant_current": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "p_constant_impedance": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "p_constant_power": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_current": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_impedance": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q_constant_power": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "scaling": {
+                  "default": null,
+                  "description": "Source scaling factor, when a format has one.",
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "v_nom": {
+                  "default": null,
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "p_constant_power",
+                "q_constant_power",
+                "p_constant_current",
+                "q_constant_current",
+                "p_constant_impedance",
+                "q_constant_impedance"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Exponential voltage model: `P = p * (V / v_nom)^gamma_p`,\n`Q = q * (V / v_nom)^gamma_q`.",
+              "properties": {
+                "gamma_p": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "gamma_q": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "kind": {
+                  "const": "exponential",
+                  "type": "string"
+                },
+                "p": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "q": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "v_nom": {
+                  "default": null,
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "p",
+                "q",
+                "gamma_p",
+                "gamma_q"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "Location": {
+          "description": "A point attached to one model element.",
+          "properties": {
+            "kind": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/CoordsKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Point origin when it differs from the network default."
+            },
+            "x": {
+              "description": "X coordinate. In geographic space this is longitude.",
+              "format": "double",
+              "type": "number"
+            },
+            "y": {
+              "description": "Y coordinate. In geographic space this is latitude.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ],
+          "type": "object"
+        },
+        "McAcOpfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "constraints": {
+              "$ref": "#/$defs/MulticonductorActiveConstraints"
+            },
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            },
+            "objective": {
+              "$ref": "#/$defs/ObjectiveV1"
+            }
+          },
+          "required": [
+            "network",
+            "objective",
+            "constraints"
+          ],
+          "type": "object"
+        },
+        "McAcOpfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "generator_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "instance": {
+              "$ref": "#/$defs/McAcOpfInstanceV1"
+            },
+            "objective": {
+              "$ref": "#/$defs/StoredF64"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "source_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_current_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "terminal_voltage_magnitude",
+            "terminal_voltage_angle",
+            "source_active_injection",
+            "generator_active_power",
+            "objective"
+          ],
+          "type": "object"
+        },
+        "McAcPfInstanceV1": {
+          "additionalProperties": false,
+          "properties": {
+            "initial_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoredOperatingPointV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            }
+          },
+          "required": [
+            "network"
+          ],
+          "type": "object"
+        },
+        "McAcPfSolutionV1": {
+          "additionalProperties": false,
+          "properties": {
+            "instance": {
+              "$ref": "#/$defs/McAcPfInstanceV1"
+            },
+            "producer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "residuals": {
+              "$ref": "#/$defs/Residuals"
+            },
+            "source_active_injection": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_active_power": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_current_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "terminal_voltage_angle": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "terminal_voltage_magnitude": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            },
+            "termination": {
+              "$ref": "#/$defs/Termination"
+            }
+          },
+          "required": [
+            "instance",
+            "termination",
+            "residuals",
+            "terminal_voltage_magnitude",
+            "terminal_voltage_angle",
+            "source_active_injection"
+          ],
+          "type": "object"
+        },
+        "MulticonductorActiveConstraints": {
+          "description": "The active constraint families of a multiconductor OPF instance.",
+          "properties": {
+            "conductor_limits": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Conductor current or apparent power limits."
+            },
+            "generator_capability": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Per phase generator capability bounds."
+            },
+            "terminal_voltage_bounds": {
+              "$ref": "#/$defs/ConstraintSelection",
+              "description": "Terminal voltage magnitude bounds."
+            }
+          },
+          "required": [
+            "terminal_voltage_bounds",
+            "conductor_limits",
+            "generator_capability"
+          ],
+          "type": "object"
+        },
+        "MulticonductorNetwork": {
+          "description": "A multiconductor distribution network.\n\n`source` retains the original text for the byte exact echo tier;\n`defaulted` records, per element (`\"class.name\"` key), the fields the\nreader materialized from format defaults rather than the source text.",
+          "properties": {
+            "base_frequency": {
+              "description": "Hz.",
+              "format": "double",
+              "type": "number"
+            },
+            "buses": {
+              "items": {
+                "$ref": "#/$defs/DistBus"
+              },
+              "type": "array"
+            },
+            "capacitors": {
+              "items": {
+                "$ref": "#/$defs/DistCapacitor"
+              },
+              "type": "array"
+            },
+            "commands": {
+              "description": "Source commands and options the typed model does not interpret\n(`solve`, `set mode=...`), in order, as (verb, args).",
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "control_profiles": {
+              "items": {
+                "$ref": "#/$defs/DistControlProfile"
+              },
+              "type": "array"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "generators": {
+              "items": {
+                "$ref": "#/$defs/DistGenerator"
+              },
+              "type": "array"
+            },
+            "geo": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistGeoMeta"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "ibrs": {
+              "items": {
+                "$ref": "#/$defs/DistIbr"
+              },
+              "type": "array"
+            },
+            "linecodes": {
+              "items": {
+                "$ref": "#/$defs/DistLineCode"
+              },
+              "type": "array"
+            },
+            "lines": {
+              "items": {
+                "$ref": "#/$defs/DistLine"
+              },
+              "type": "array"
+            },
+            "loads": {
+              "items": {
+                "$ref": "#/$defs/DistLoad"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "options": {
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "shunts": {
+              "items": {
+                "$ref": "#/$defs/DistShunt"
+              },
+              "type": "array"
+            },
+            "source_format": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DistSourceFormat"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "sources": {
+              "description": "BMOPF allows exactly one; the model allows any number and the BMOPF\nwriter warns beyond the first.",
+              "items": {
+                "$ref": "#/$defs/VoltageSource"
+              },
+              "type": "array"
+            },
+            "switches": {
+              "items": {
+                "$ref": "#/$defs/DistSwitch"
+              },
+              "type": "array"
+            },
+            "transformers": {
+              "items": {
+                "$ref": "#/$defs/DistTransformer"
+              },
+              "type": "array"
+            },
+            "untyped": {
+              "items": {
+                "$ref": "#/$defs/UntypedObject"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "base_frequency",
+            "buses",
+            "linecodes",
+            "lines",
+            "switches",
+            "transformers",
+            "loads",
+            "generators",
+            "shunts",
+            "sources",
+            "untyped",
+            "commands",
+            "options",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "MulticonductorOperatingPointTimeSeriesV1": {
+          "additionalProperties": false,
+          "properties": {
+            "network": {
+              "$ref": "#/$defs/MulticonductorNetwork"
+            },
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "description": "Quantity name → dense columns, the multiconductor instantaneous\nvocabulary.",
+              "type": "object"
+            },
+            "time_points": {
+              "items": {
+                "$ref": "#/$defs/TimePointV1"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "network",
+            "time_points",
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "ObjectiveTermV1": {
+          "description": "One typed objective term, mirroring `powerio_prob::ObjectiveTerm` with its\nweight wrapped for the nonfinite spelling: an internally tagged enum's\nderived `Deserialize` re-decodes its variant from a buffered generic\nvalue rather than the deserializer callers pass in, so wrapping the whole\ndocument's deserializer (as [`StoredModuleV1`] does for every plain\nstruct field) never reaches this `f64`.",
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "term": {
+                  "const": "network_generator_cost",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "term"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "term": {
+                  "const": "network_per_phase_cost",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "term"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "Read only compatibility for 0.10 documents. The runtime removes this\nterm and records `READ.MODULE.OBJECTIVE_TERM_RETIRED` because the token\ndid not define a portable quantity or unit.",
+              "properties": {
+                "term": {
+                  "const": "differentiability_regularization",
+                  "type": "string"
+                },
+                "weight": {
+                  "$ref": "#/$defs/StoredF64"
+                }
+              },
+              "required": [
+                "term",
+                "weight"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ObjectiveV1": {
+          "additionalProperties": false,
+          "description": "The complete typed objective, mirroring `powerio_prob::Objective`.",
+          "properties": {
+            "terms": {
+              "items": {
+                "$ref": "#/$defs/ObjectiveTermV1"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "PowerFactorControl": {
+          "properties": {
+            "pf": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "pf"
+          ],
+          "type": "object"
+        },
+        "ProducerV1": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "ReactivePowerReference": {
+          "enum": [
+            "VAR_MAX",
+            "VAR_AVAILABLE"
+          ],
+          "type": "string"
+        },
+        "ReactivePowerUnit": {
+          "enum": [
+            "VA_FRACTION",
+            "VAR"
+          ],
+          "type": "string"
+        },
+        "Residuals": {
+          "description": "Numerical residuals of the solved equations, in the problem's power unit.\nA field is `None` when the producer did not report it.",
+          "properties": {
+            "max_active_power_mismatch": {
+              "description": "Largest absolute active power balance mismatch, MW.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "max_reactive_power_mismatch": {
+              "description": "Largest absolute reactive power balance mismatch, MVAr.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "ScopfAcContingencySurvivors": {
+          "description": "Per-contingency surviving AC lines and transformers, one group per\ncontingency in `reliability.contingency` document order.",
+          "properties": {
+            "ln": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/ScopfAcLineSurvivorRow"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "xf": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/ScopfTransformerSurvivorRow"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "ln",
+            "xf"
+          ],
+          "type": "object"
+        },
+        "ScopfAcLineRow": {
+          "description": "One AC line row.",
+          "properties": {
+            "b_ch": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_ln",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "c_su",
+            "c_sd",
+            "u_0",
+            "s_max",
+            "g_sr",
+            "b_sr",
+            "b_ch",
+            "g_fr",
+            "g_to",
+            "b_fr",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "ScopfAcLineSurvivorRow": {
+          "description": "One AC line surviving a contingency.",
+          "properties": {
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max_ctg": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ctg",
+            "j_ln",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "b_sr",
+            "s_max_ctg"
+          ],
+          "type": "object"
+        },
+        "ScopfActiveReserveRow": {
+          "description": "One active power zonal reserve row.",
+          "properties": {
+            "c_nsc": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rgd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rgu": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rrd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_rru": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_scr": {
+              "format": "double",
+              "type": "number"
+            },
+            "n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_rrd_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_rru_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "sigma_nsc": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_rgd": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_rgu": {
+              "format": "double",
+              "type": "number"
+            },
+            "sigma_scr": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "n_p",
+            "uid",
+            "c_rgu",
+            "c_rgd",
+            "c_scr",
+            "c_nsc",
+            "c_rru",
+            "c_rrd",
+            "sigma_rgu",
+            "sigma_rgd",
+            "sigma_scr",
+            "sigma_nsc",
+            "p_rru_min",
+            "p_rrd_min"
+          ],
+          "type": "object"
+        },
+        "ScopfActiveReserveSetRow": {
+          "description": "One (bus, active reserve zone, device) membership row.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dev": {
+              "description": "The member device's ordinals ([`ScopfDeviceRow::j_dev`],\n[`ScopfDeviceRow::j_sdd`]).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "i",
+            "n_p",
+            "uid",
+            "j_dev",
+            "j_sdd"
+          ],
+          "type": "object"
+        },
+        "ScopfBusRow": {
+          "description": "One bus row: `(i, uid, v_min, v_max)`.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "v_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "v_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "i",
+            "uid",
+            "v_min",
+            "v_max"
+          ],
+          "type": "object"
+        },
+        "ScopfDcContingencyFlowRow": {
+          "description": "One surviving DC line in one contingency and period.",
+          "properties": {
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "flat_jtk_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            }
+          },
+          "required": [
+            "flat_jtk_dc",
+            "ctg",
+            "j_dc",
+            "to_bus",
+            "fr_bus",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfDcLineRow": {
+          "description": "One DC line row.",
+          "properties": {
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pdc_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_fr_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_fr_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_to_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "qdc_to_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_dc",
+            "uid",
+            "pdc_max",
+            "qdc_fr_min",
+            "qdc_to_min",
+            "qdc_fr_max",
+            "qdc_to_max",
+            "to_bus",
+            "fr_bus"
+          ],
+          "type": "object"
+        },
+        "ScopfDeviceClassLayout": {
+          "description": "How the two device classes sit in the `simple_dispatchable_device` section.\n\nA model that stacks producers and consumers into one variable vector\naddresses a device by a per class offset, which is a bijection only when\neach class owns one unbroken run. Reading the order without that\nprecondition is the one mistake this type makes unavailable.",
+          "oneOf": [
+            {
+              "description": "Each class is one unbroken run. `producers_first` says which run\nstarts first.",
+              "properties": {
+                "kind": {
+                  "const": "contiguous",
+                  "type": "string"
+                },
+                "producers_first": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "kind",
+                "producers_first"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The two classes interleave, so no per class offset addresses a device.",
+              "properties": {
+                "kind": {
+                  "const": "interleaved",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ScopfDeviceRow": {
+          "description": "One simple dispatchable device row.\n\nProducers and consumers share this layout. Vector fields use the internal\nzero based period order.\n\nThe reactive capability block is the `q_bound_cap`/`q_linear_cap` pair and\nthe parameters of the mode each one selects. The two modes are mutually\nexclusive and a device can select neither. A parameter of a mode the device\ndid not select is `None`. Read the two flags before the parameters.",
+          "properties": {
+            "beta": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "beta_lb": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "beta_ub": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "c_nsc": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_on": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_qrd": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_qru": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rgd": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rgu": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rrd_off": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rrd_on": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rru_off": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_rru_on": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_scr": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_dev": {
+              "description": "0-based position within the row's own class list (`prod` or `cons`),\nin document order. Serialization can retain base 0 or select base 1.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "description": "0-based position in the canonical device stacking: the producer block,\nthen the consumer block, document order within each. Sound for every\nuid spelling, including interleaved classes.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_0": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_nsc_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rd": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rd_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rgd_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rgu_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rrd_off_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rrd_on_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rru_off_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_rru_on_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_ru": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_ru_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_scr_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_0": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_0_lb": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_0_ub": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_bound_cap": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "q_linear_cap": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "q_max": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_p0": {
+              "description": "The intercept of the linear capability line. The GOC3 document calls\nthis `q_0`, which this row already uses for `initial_status.q`.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "sus": {
+              "items": {
+                "items": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "bus",
+            "uid",
+            "j_dev",
+            "j_sdd",
+            "c_on",
+            "c_su",
+            "c_sd",
+            "p_ru",
+            "p_rd",
+            "p_ru_su",
+            "p_rd_sd",
+            "c_rgu",
+            "c_rgd",
+            "c_scr",
+            "c_nsc",
+            "c_rru_on",
+            "c_rru_off",
+            "c_rrd_on",
+            "c_rrd_off",
+            "c_qru",
+            "c_qrd",
+            "p_rgu_max",
+            "p_rgd_max",
+            "p_scr_max",
+            "p_nsc_max",
+            "p_rru_on_max",
+            "p_rru_off_max",
+            "p_rrd_on_max",
+            "p_rrd_off_max",
+            "p_0",
+            "q_0",
+            "u_0",
+            "p_max",
+            "p_min",
+            "q_max",
+            "q_min",
+            "sus",
+            "q_bound_cap",
+            "q_linear_cap"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMaxCsRow": {
+          "properties": {
+            "a_en_max_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_max_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_cs_ind",
+            "uid",
+            "a_en_max_start",
+            "a_en_max_end",
+            "e_max"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMaxPrRow": {
+          "properties": {
+            "a_en_max_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_max_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_pr_ind",
+            "uid",
+            "a_en_max_start",
+            "a_en_max_end",
+            "e_max"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMinCsRow": {
+          "properties": {
+            "a_en_min_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_min_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_cs_ind",
+            "uid",
+            "a_en_min_start",
+            "a_en_min_end",
+            "e_min"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowMinPrRow": {
+          "properties": {
+            "a_en_min_end": {
+              "format": "double",
+              "type": "number"
+            },
+            "a_en_min_start": {
+              "format": "double",
+              "type": "number"
+            },
+            "e_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_pr_ind",
+            "uid",
+            "a_en_min_start",
+            "a_en_min_end",
+            "e_min"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMaxCsRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_cs_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMaxPrRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_max_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_max_pr_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMinCsRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_cs_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_cs_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindowPeriodMinPrRow": {
+          "description": "Period membership of one energy window: the period belongs when\nits midpoint falls within the window's `(start, end]` interval.",
+          "properties": {
+            "dt": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "w_en_min_pr_ind": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "w_en_min_pr_ind",
+            "uid",
+            "t",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScopfEnergyWindows": {
+          "description": "Energy requirement windows and their period memberships.",
+          "properties": {
+            "t_w_en_max_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMaxCsRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_max_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMaxPrRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_min_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMinCsRow"
+              },
+              "type": "array"
+            },
+            "t_w_en_min_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowPeriodMinPrRow"
+              },
+              "type": "array"
+            },
+            "w_en_max_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMaxCsRow"
+              },
+              "type": "array"
+            },
+            "w_en_max_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMaxPrRow"
+              },
+              "type": "array"
+            },
+            "w_en_min_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMinCsRow"
+              },
+              "type": "array"
+            },
+            "w_en_min_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfEnergyWindowMinPrRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "w_en_max_pr",
+            "w_en_max_cs",
+            "w_en_min_pr",
+            "w_en_min_cs",
+            "t_w_en_max_pr",
+            "t_w_en_max_cs",
+            "t_w_en_min_pr",
+            "t_w_en_min_cs"
+          ],
+          "type": "object"
+        },
+        "ScopfFixedPhaseRow": {
+          "description": "A transformer with a fixed phase shift (`fpd`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "phi_o": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "phi_o"
+          ],
+          "type": "object"
+        },
+        "ScopfFixedRatioRow": {
+          "description": "A transformer with a fixed winding ratio (`fwr`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tau_o": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "tau_o"
+          ],
+          "type": "object"
+        },
+        "ScopfLengths": {
+          "description": "Set sizes for each indexed device class.",
+          "properties": {
+            "i": {
+              "description": "Bus count.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "k": {
+              "description": "Contingency count.",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_ac": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_br": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_cs": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_cspr": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_dc": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_ln": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_pr": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_sh": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_n_p": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "l_t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "l_j_xf",
+            "l_j_ln",
+            "l_j_ac",
+            "l_j_dc",
+            "l_j_br",
+            "l_j_cs",
+            "l_j_pr",
+            "l_j_cspr",
+            "l_j_sh",
+            "i",
+            "l_t",
+            "l_n_p",
+            "l_n_q",
+            "k"
+          ],
+          "type": "object"
+        },
+        "ScopfPriceBlockRow": {
+          "description": "One flattened device, period, and price block row.",
+          "properties": {
+            "c_en": {
+              "format": "double",
+              "type": "number"
+            },
+            "flat_k": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "m": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "p_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "t": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "flat_k",
+            "uid",
+            "t",
+            "m",
+            "c_en",
+            "p_max"
+          ],
+          "type": "object"
+        },
+        "ScopfPriceBlocks": {
+          "description": "Flattened producer and consumer price blocks.",
+          "properties": {
+            "consumer": {
+              "items": {
+                "$ref": "#/$defs/ScopfPriceBlockRow"
+              },
+              "type": "array"
+            },
+            "producer": {
+              "items": {
+                "$ref": "#/$defs/ScopfPriceBlockRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "producer",
+            "consumer"
+          ],
+          "type": "object"
+        },
+        "ScopfReactiveReserveRow": {
+          "description": "One reactive (reactive-power) zonal reserve row.",
+          "properties": {
+            "c_qrd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_qru": {
+              "format": "double",
+              "type": "number"
+            },
+            "n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "q_qrd_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_qru_min": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "n_q",
+            "uid",
+            "c_qru",
+            "c_qrd",
+            "q_qru_min",
+            "q_qrd_min"
+          ],
+          "type": "object"
+        },
+        "ScopfReactiveReserveSetRow": {
+          "description": "One (bus, reactive reserve zone, device) membership row.",
+          "properties": {
+            "i": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_dev": {
+              "description": "The member device's ordinals ([`ScopfDeviceRow::j_dev`],\n[`ScopfDeviceRow::j_sdd`]).",
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "j_sdd": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "n_q": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "i",
+            "n_q",
+            "uid",
+            "j_dev",
+            "j_sdd"
+          ],
+          "type": "object"
+        },
+        "ScopfShuntRow": {
+          "description": "One shunt row.",
+          "properties": {
+            "b_sh": {
+              "format": "double",
+              "type": "number"
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_sh": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_sh": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_sh",
+            "uid",
+            "bus",
+            "g_sh",
+            "b_sh"
+          ],
+          "type": "object"
+        },
+        "ScopfStaticData": {
+          "description": "Static buses, branches, devices, controls, reserves, and memberships.",
+          "properties": {
+            "acl_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfAcLineRow"
+              },
+              "type": "array"
+            },
+            "active_reserve": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveRow"
+              },
+              "type": "array"
+            },
+            "active_reserve_set_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "active_reserve_set_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfActiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "acx_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfTransformerRow"
+              },
+              "type": "array"
+            },
+            "bus": {
+              "items": {
+                "$ref": "#/$defs/ScopfBusRow"
+              },
+              "type": "array"
+            },
+            "cons": {
+              "items": {
+                "$ref": "#/$defs/ScopfDeviceRow"
+              },
+              "type": "array"
+            },
+            "dc_branch": {
+              "items": {
+                "$ref": "#/$defs/ScopfDcLineRow"
+              },
+              "type": "array"
+            },
+            "fpd": {
+              "items": {
+                "$ref": "#/$defs/ScopfFixedPhaseRow"
+              },
+              "type": "array"
+            },
+            "fwr": {
+              "items": {
+                "$ref": "#/$defs/ScopfFixedRatioRow"
+              },
+              "type": "array"
+            },
+            "prod": {
+              "items": {
+                "$ref": "#/$defs/ScopfDeviceRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve_set_cs": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "reactive_reserve_set_pr": {
+              "items": {
+                "$ref": "#/$defs/ScopfReactiveReserveSetRow"
+              },
+              "type": "array"
+            },
+            "shunt": {
+              "items": {
+                "$ref": "#/$defs/ScopfShuntRow"
+              },
+              "type": "array"
+            },
+            "vpd": {
+              "items": {
+                "$ref": "#/$defs/ScopfVariablePhaseRow"
+              },
+              "type": "array"
+            },
+            "vwr": {
+              "items": {
+                "$ref": "#/$defs/ScopfVariableRatioRow"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "bus",
+            "shunt",
+            "acl_branch",
+            "acx_branch",
+            "vpd",
+            "fpd",
+            "vwr",
+            "fwr",
+            "dc_branch",
+            "prod",
+            "cons",
+            "active_reserve",
+            "reactive_reserve",
+            "active_reserve_set_pr",
+            "active_reserve_set_cs",
+            "reactive_reserve_set_pr",
+            "reactive_reserve_set_cs"
+          ],
+          "type": "object"
+        },
+        "ScopfTransformerRow": {
+          "description": "One two winding transformer row.",
+          "properties": {
+            "b_ch": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "b_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_sd": {
+              "format": "double",
+              "type": "number"
+            },
+            "c_su": {
+              "format": "double",
+              "type": "number"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "g_fr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "g_to": {
+              "format": "double",
+              "type": "number"
+            },
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "u_0": {
+              "description": "The document's `initial_status.on_status`.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "j_xf",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "c_su",
+            "c_sd",
+            "u_0",
+            "s_max",
+            "g_sr",
+            "b_sr",
+            "b_ch",
+            "g_fr",
+            "g_to",
+            "b_fr",
+            "b_to"
+          ],
+          "type": "object"
+        },
+        "ScopfTransformerSurvivorRow": {
+          "description": "One transformer surviving a contingency.",
+          "properties": {
+            "b_sr": {
+              "format": "double",
+              "type": "number"
+            },
+            "ctg": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "fr_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "s_max_ctg": {
+              "format": "double",
+              "type": "number"
+            },
+            "to_bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ctg",
+            "j_xf",
+            "uid",
+            "to_bus",
+            "fr_bus",
+            "b_sr",
+            "s_max_ctg"
+          ],
+          "type": "object"
+        },
+        "ScopfVariablePhaseRow": {
+          "description": "A transformer with a variable phase-shift control range (`vpd`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "phi_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "phi_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "phi_min",
+            "phi_max"
+          ],
+          "type": "object"
+        },
+        "ScopfVariableRatioRow": {
+          "description": "A transformer with a variable winding ratio control range (`vwr`).",
+          "properties": {
+            "j_xf": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tau_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "tau_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "j_xf",
+            "tau_min",
+            "tau_max"
+          ],
+          "type": "object"
+        },
+        "ScopfViolationCost": {
+          "description": "The case's four violation prices. The GOC3 document spells them\n`p_bus_vio_cost`, `q_bus_vio_cost`, `s_vio_cost`, and `e_vio_cost` under\n`network.violation_cost`. Any one of them can be absent and is then `None`:\nGOCompetition's 14 bus validation case has no `e_vio_cost`.",
+          "properties": {
+            "e": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_bus": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_bus": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "s": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "ScucDeviceOutputsV1": {
+          "additionalProperties": false,
+          "properties": {
+            "on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_nsyn_res": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_on": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_ramp_res_down_online": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_ramp_res_up_online": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_reg_res_down": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_reg_res_up": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "p_syn_res": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q_res_down": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "q_res_up": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "on_status",
+            "p_on",
+            "q",
+            "p_reg_res_up",
+            "p_reg_res_down",
+            "p_syn_res",
+            "p_nsyn_res",
+            "p_ramp_res_up_online",
+            "p_ramp_res_down_online",
+            "q_res_up",
+            "q_res_down"
+          ],
+          "type": "object"
+        },
+        "ScucInputs": {
+          "description": "Matrix free SCOPF input data.\n\nInternal class, period, contingency, window, and flattened row indices are\nzero based and follow the source document order of the section that owns\nthem. Source UIDs and external bus IDs remain separate fields.",
+          "properties": {
+            "ac_contingency_survivors": {
+              "$ref": "#/$defs/ScopfAcContingencySurvivors"
+            },
+            "dc_contingency_flows": {
+              "items": {
+                "$ref": "#/$defs/ScopfDcContingencyFlowRow"
+              },
+              "type": "array"
+            },
+            "device_class_layout": {
+              "$ref": "#/$defs/ScopfDeviceClassLayout"
+            },
+            "dt": {
+              "description": "The interval durations, so a model needs no raw-document read for its\ntime axis. `lengths.l_t` is this vector's length.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "energy_windows": {
+              "$ref": "#/$defs/ScopfEnergyWindows"
+            },
+            "lengths": {
+              "$ref": "#/$defs/ScopfLengths"
+            },
+            "price_blocks": {
+              "$ref": "#/$defs/ScopfPriceBlocks"
+            },
+            "static_data": {
+              "$ref": "#/$defs/ScopfStaticData",
+              "description": "Buses, branches, devices, controls, reserves, and memberships."
+            },
+            "violation_cost": {
+              "$ref": "#/$defs/ScopfViolationCost"
+            }
+          },
+          "required": [
+            "static_data",
+            "lengths",
+            "energy_windows",
+            "price_blocks",
+            "ac_contingency_survivors",
+            "dc_contingency_flows",
+            "violation_cost",
+            "device_class_layout",
+            "dt"
+          ],
+          "type": "object"
+        },
+        "ScucNetworkOutputsV1": {
+          "additionalProperties": false,
+          "properties": {
+            "ac_line_on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus_va": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "bus_vm": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_pdc_fr": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_qdc_fr": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "dc_line_qdc_to": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "shunt_step": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_on_status": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_ta": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "transformer_tm": {
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/StoredF64"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "bus_vm",
+            "bus_va",
+            "shunt_step",
+            "ac_line_on_status",
+            "transformer_tm",
+            "transformer_ta",
+            "transformer_on_status"
+          ],
+          "type": "object"
+        },
+        "SeverityV1": {
+          "enum": [
+            "error",
+            "warning",
+            "remark",
+            "note"
+          ],
+          "type": "string"
+        },
+        "Shunt": {
+          "properties": {
+            "b": {
+              "description": "Shunt susceptance (MVAr at V = 1 p.u.). For a switched shunt this is the\ninitial (steady-state) value within the [`control`](Shunt::control) blocks.",
+              "format": "double",
+              "type": "number"
+            },
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "control": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SwitchedShuntControl"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Switching-control data when this is a switched (adjustable) shunt; `None`\nfor a fixed shunt. `#[serde(default)]` so JSON written before the field\nexisted still deserializes."
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "g": {
+              "description": "Shunt conductance (MW at V = 1 p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "bus",
+            "g",
+            "b",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "ShuntBlock": {
+          "description": "One block of a switched shunt: `steps` equal increments of susceptance `b`.",
+          "properties": {
+            "b": {
+              "description": "Susceptance increment per step (MVAr at V = 1 p.u.).",
+              "format": "double",
+              "type": "number"
+            },
+            "steps": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "steps",
+            "b"
+          ],
+          "type": "object"
+        },
+        "SolverParams": {
+          "description": "Solver / solution-control metadata: the Newton tolerance and iteration cap,\nthe zero-impedance threshold, and the per-quantity adjustment-enable flags.\n\nEach field is optional because a source states only the ones it carries. No\npower flow physics, but it determines whether a downstream solver reproduces\nthe source tool's converged answer. Maps to the PSS/E v34+ system-wide block\n(`GENERAL THRSHZ`, `NEWTON TOLN`/`ITMXN`, `SOLVER ACTAPS`/`AREAIN`/`PHSHFT`/\n`DCTAPS`/`SWSHNT`).",
+          "properties": {
+            "adjust_area_interchange": {
+              "description": "Whether the solver adjusts area interchange (`SOLVER AREAIN`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_dc_taps": {
+              "description": "Whether the solver adjusts DC line taps (`SOLVER DCTAPS`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_phase_shift": {
+              "description": "Whether the solver adjusts phase-shift angles (`SOLVER PHSHFT`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_switched_shunt": {
+              "description": "Whether the solver adjusts switched shunts (`SOLVER SWSHNT`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adjust_taps": {
+              "description": "Whether the solver adjusts transformer taps (`SOLVER ACTAPS`).",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "max_iterations": {
+              "description": "Newton iteration cap (`NEWTON ITMXN`).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "newton_tolerance": {
+              "description": "Newton power flow mismatch tolerance (`NEWTON TOLN`).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "zero_impedance_threshold": {
+              "description": "Branches with `|x|` below this are treated as zero impedance (`GENERAL THRSHZ`).",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "SourceDescriptorV1": {
+          "additionalProperties": false,
+          "properties": {
+            "byte_length": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "digest": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DigestV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "format": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "byte_length"
+          ],
+          "type": "object"
+        },
+        "SourceFormat": {
+          "description": "Which format a [`BalancedNetwork`] was read from. Drives the same format byte exact\necho on write.\n\nSerializes as the same lowercase token [`name`](SourceFormat::name) reports\nand every string entry point accepts, so the value a document carries is\nvalid input to `from`. Documents written before 0.9.0 spelled the bare\nvariant name (\"Matpower\"); the read side still accepts those spellings.",
+          "oneOf": [
+            {
+              "enum": [
+                "matpower",
+                "powermodels-json",
+                "egret-json",
+                "psse",
+                "powerworld",
+                "pandapower-json"
+              ],
+              "type": "string"
+            },
+            {
+              "const": "pslf",
+              "description": "Read from a GE PSLF `.epc` case. Same source text is retained, so a\nsame-format write echoes it byte-for-byte; a cross-format or\nsource-dropped write goes through the `.epc` serializer\n([`write_pslf`](crate::write_pslf)).",
+              "type": "string"
+            },
+            {
+              "const": "powerworld-pwb",
+              "description": "Read from a PowerWorld `.pwb` binary case. Read only: there is no\n`.pwb` writer and no retained source text, so writing goes through\nanother format's writer.",
+              "type": "string"
+            },
+            {
+              "const": "in-memory",
+              "description": "Built in memory, for example from synth or an edited case; no source text.",
+              "type": "string"
+            },
+            {
+              "const": "normalized",
+              "description": "A normalized derived form ([`BalancedNetwork::to_normalized`]): per unit, radians,\nfiltered, source bus ids preserved. Distinct from\n[`InMemory`](SourceFormat::InMemory) so consumers can tell a per unit\nproduct from a raw in memory network; it has no source text and a different\nunit basis than a parsed network.",
+              "type": "string"
+            },
+            {
+              "const": "gridfm",
+              "description": "Read back from a gridfm-datakit Parquet dataset (the ML→classical bridge,\n`powerio-matrix`'s `read_gridfm_dataset`). A lossy, power flow complete\nreconstruction with no retained source text: original bus ids are\nsynthesized `1..n`, per element load/shunt granularity is folded to one\nsynthetic element per bus, and HVDC/storage/piecewise costs are absent.",
+              "type": "string"
+            },
+            {
+              "const": "pypsa-csv",
+              "description": "Read from a PyPSA CSV folder. This is a folder format rather than a\nsingle retained text document, so same-format writes are canonicalized.",
+              "type": "string"
+            },
+            {
+              "const": "goc3-json",
+              "description": "Read from a DOE GO Challenge 3 JSON input document. The source is a\nunit commitment data set; the neutral transmission model keeps a static\nfirst interval network and retains the source text for the full data.",
+              "type": "string"
+            },
+            {
+              "const": "surge-json",
+              "description": "Read from a Surge native JSON document.",
+              "type": "string"
+            },
+            {
+              "const": "opfdata-json",
+              "description": "Read from one raw JSON document in a DeepMind OPFData release. The\nsource carries both solver initial values and a solution. The balanced\nmodel represents the solved snapshot and retains the source for an\nexact write back to the same format.",
+              "type": "string"
+            }
+          ]
+        },
+        "SourceMapEntryV1": {
+          "additionalProperties": false,
+          "properties": {
+            "relation": {
+              "$ref": "#/$defs/SourceRelationV1"
+            },
+            "spans": {
+              "description": "Empty only for `defaulted`, `synthetic`, or `transformed`.",
+              "items": {
+                "$ref": "#/$defs/SourceSpanV1"
+              },
+              "type": "array"
+            },
+            "target": {
+              "description": "RFC 6901 pointer into `value.data`.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "target",
+            "relation"
+          ],
+          "type": "object"
+        },
+        "SourceRelationV1": {
+          "enum": [
+            "exact",
+            "defaulted",
+            "inferred",
+            "converted_units",
+            "aggregated",
+            "split",
+            "synthetic",
+            "transformed",
+            "retained_extra"
+          ],
+          "type": "string"
+        },
+        "SourceSpanV1": {
+          "additionalProperties": false,
+          "properties": {
+            "byte_end": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "byte_start": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "byte_start",
+            "byte_end"
+          ],
+          "type": "object"
+        },
+        "Storage": {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "charge_efficiency": {
+              "format": "double",
+              "type": "number"
+            },
+            "charge_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "current_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "discharge_efficiency": {
+              "format": "double",
+              "type": "number"
+            },
+            "discharge_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "energy": {
+              "format": "double",
+              "type": "number"
+            },
+            "energy_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "p_loss": {
+              "format": "double",
+              "type": "number"
+            },
+            "ps": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_loss": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmax": {
+              "format": "double",
+              "type": "number"
+            },
+            "qmin": {
+              "format": "double",
+              "type": "number"
+            },
+            "qs": {
+              "format": "double",
+              "type": "number"
+            },
+            "r": {
+              "format": "double",
+              "type": "number"
+            },
+            "thermal_rating": {
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "x": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "ps",
+            "qs",
+            "energy",
+            "energy_rating",
+            "charge_rating",
+            "discharge_rating",
+            "charge_efficiency",
+            "discharge_efficiency",
+            "thermal_rating",
+            "qmin",
+            "qmax",
+            "r",
+            "x",
+            "p_loss",
+            "q_loss",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "StoredF64": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ]
+            }
+          ]
+        },
+        "StoredOperatingPointV1": {
+          "additionalProperties": false,
+          "description": "One stored operating point: the state quantities of a single point,\nkeyed by the instantaneous vocabulary, each with its resolved identity\norder and one row of values.",
+          "properties": {
+            "quantities": {
+              "additionalProperties": {
+                "$ref": "#/$defs/StoredQuantityV1"
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "quantities"
+          ],
+          "type": "object"
+        },
+        "StoredQuantityV1": {
+          "additionalProperties": false,
+          "description": "One state quantity's dense columns: the resolved identity order, then the\npoint major values (`time_points.len() × identities.len()`).",
+          "properties": {
+            "identities": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "values": {
+              "items": {
+                "$ref": "#/$defs/StoredF64"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "identities",
+            "values"
+          ],
+          "type": "object"
+        },
+        "StoredValueV1": {
+          "description": "The tagged value DTO. `data` is a typed record, never an untyped JSON\ncatchall; the network payloads are the typed serializations the network\ncrates own (which carry the nonfinite spellings themselves).",
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetwork"
+                },
+                "kind": {
+                  "const": "balanced_network",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/MulticonductorNetwork"
+                },
+                "kind": {
+                  "const": "multiconductor_network",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetworkTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "balanced_network_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedOperatingPointTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "balanced_operating_point_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/MulticonductorOperatingPointTimeSeriesV1"
+                },
+                "kind": {
+                  "const": "multiconductor_operating_point_time_series",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/BalancedNetworkScenarioSetV1"
+                },
+                "kind": {
+                  "const": "balanced_network_scenario_set",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "dc_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "dc_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcPfInstanceV1"
+                },
+                "kind": {
+                  "const": "mc_ac_pf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcOpfInstanceV1"
+                },
+                "kind": {
+                  "const": "mc_ac_opf_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcScucInstanceV1"
+                },
+                "kind": {
+                  "const": "ac_scuc_instance",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "dc_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/DcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "dc_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcPfSolutionV1"
+                },
+                "kind": {
+                  "const": "mc_ac_pf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/McAcOpfSolutionV1"
+                },
+                "kind": {
+                  "const": "mc_ac_opf_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/$defs/AcScucSolutionV1"
+                },
+                "kind": {
+                  "const": "ac_scuc_solution",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "Switch": {
+          "description": "A transmission switch. Closed switches are preserved as data; matrix builders\ndo not lower them into zero impedance branches.",
+          "properties": {
+            "closed": {
+              "type": "boolean"
+            },
+            "current_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "from": {
+              "$ref": "#/$defs/BusId"
+            },
+            "pf": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "pt": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "qf": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "qt": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "thermal_rating": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "to": {
+              "$ref": "#/$defs/BusId"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "from",
+            "to",
+            "closed",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "SwitchedShuntControl": {
+          "description": "Switching-control data for a switched shunt ([`Shunt::control`]): the mode,\nthe regulated voltage band and bus, the reactive-range percentage, and the\nadjustable susceptance blocks. The shunt's [`b`](Shunt::b) is the initial\nvalue within the blocks' total range.",
+          "properties": {
+            "blocks": {
+              "items": {
+                "$ref": "#/$defs/ShuntBlock"
+              },
+              "type": "array"
+            },
+            "control_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The regulated bus; `None` means the shunt regulates its own bus."
+            },
+            "mode": {
+              "$ref": "#/$defs/SwitchedShuntMode"
+            },
+            "rmpct": {
+              "description": "Percent of the controlled device's reactive range to apply (PSS/E `RMPCT`).",
+              "format": "double",
+              "type": "number"
+            },
+            "vhigh": {
+              "description": "Regulated voltage band (per unit).",
+              "format": "double",
+              "type": "number"
+            },
+            "vlow": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "mode",
+            "vhigh",
+            "vlow",
+            "rmpct",
+            "blocks"
+          ],
+          "type": "object"
+        },
+        "SwitchedShuntMode": {
+          "description": "How a switched shunt adjusts its susceptance. Maps to the PSS/E `MODSW` code.",
+          "oneOf": [
+            {
+              "const": "locked",
+              "description": "Fixed at its initial susceptance, no automatic switching (`MODSW` 0).",
+              "type": "string"
+            },
+            {
+              "const": "continuous",
+              "description": "Continuous adjustment within the block range (`MODSW` 1).",
+              "type": "string"
+            },
+            {
+              "const": "discrete",
+              "description": "Discrete adjustment in fixed steps (`MODSW` 2 and up).",
+              "type": "string"
+            }
+          ]
+        },
+        "Termination": {
+          "description": "How the producing calculation ended.",
+          "oneOf": [
+            {
+              "description": "The calculation converged to its stated tolerance.",
+              "properties": {
+                "kind": {
+                  "const": "converged",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The iteration limit ended the calculation before convergence.",
+              "properties": {
+                "kind": {
+                  "const": "iteration_limit",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The solver proved the constraints admit no solution. The optimization\noutcome an OPF consumer acts on differently from a numerical failure:\nthe case is overconstrained, and no retry or setting change fixes it.",
+              "properties": {
+                "kind": {
+                  "const": "infeasible",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The solver proved the objective unbounded over the feasible set.",
+              "properties": {
+                "kind": {
+                  "const": "unbounded",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The calculation failed.",
+              "properties": {
+                "kind": {
+                  "const": "failed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "The source records a solved calculation without termination\ninformation (DeepMind OPFData does).",
+              "properties": {
+                "kind": {
+                  "const": "not_reported",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "TimePointV1": {
+          "additionalProperties": false,
+          "properties": {
+            "duration": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/DurationV1"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "label": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "label"
+          ],
+          "type": "object"
+        },
+        "Transformer3W": {
+          "description": "A three winding transformer with three terminal buses joined at a star point.\n\nSeries impedance is stored for winding pairs 1-2, 2-3, and 3-1. The record\nalso retains star point voltage and per winding control data. PSS/E three\nwinding records and PSLF tertiary winding records map to this type.\n[`to_star_expansion`](Transformer3W::to_star_expansion) turns it into the synthetic\nstar bus plus three branches for a consumer that works in the bus-branch model;\n[`IndexedNetwork`](crate::IndexedNetwork) applies it before building any matrix,\nso a 3-winding transformer contributes to `Y_bus` and connectivity.",
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "in_service": {
+              "type": "boolean"
+            },
+            "mag_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "mag_g": {
+              "description": "Magnetizing shunt referred to the star point (p.u. on the system base).",
+              "format": "double",
+              "type": "number"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "star_va": {
+              "format": "double",
+              "type": "number"
+            },
+            "star_vm": {
+              "description": "Star-point voltage magnitude (p.u.) and angle (degrees), as solved.",
+              "format": "double",
+              "type": "number"
+            },
+            "uid": {
+              "description": "Stable row identity; see [`Bus::uid`].",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "windings": {
+              "description": "The three windings, in order (primary, secondary, tertiary).",
+              "items": {
+                "$ref": "#/$defs/Winding"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            "z": {
+              "description": "Pairwise series impedance `[z12, z23, z31]` (primary-secondary,\nsecondary-tertiary, tertiary-primary), each per unit on the system base\nwith its declared MVA base.",
+              "items": {
+                "$ref": "#/$defs/Impedance"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            }
+          },
+          "required": [
+            "windings",
+            "z",
+            "star_vm",
+            "star_va",
+            "mag_g",
+            "mag_b",
+            "in_service",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "TransformerControl": {
+          "description": "Automatic-control data for a regulating transformer ([`Branch::control`]).\n\nThe limits carry whatever the [`mode`](TransformerControl::mode) regulates:\n`tap_min`/`tap_max` bound the tap ratio (or the phase angle, for\n[`ActiveFlow`](TransformerControlMode::ActiveFlow)), and `band_min`/`band_max`\nbound the controlled quantity (the regulated voltage band, or the\nscheduled MW/MVAr). `ntp` is the number of discrete tap positions and\n`controlled_bus` is the regulated bus (`None` = the transformer's own\nterminal). `mva_base` is the winding MVA base the impedance is referred to.",
+          "properties": {
+            "band_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "band_min": {
+              "format": "double",
+              "type": "number"
+            },
+            "controlled_bus": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BusId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "mode": {
+              "$ref": "#/$defs/TransformerControlMode"
+            },
+            "mva_base": {
+              "format": "double",
+              "type": "number"
+            },
+            "ntp": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tap_max": {
+              "format": "double",
+              "type": "number"
+            },
+            "tap_min": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "mode",
+            "tap_min",
+            "tap_max",
+            "band_min",
+            "band_max",
+            "ntp",
+            "mva_base"
+          ],
+          "type": "object"
+        },
+        "TransformerControlMode": {
+          "description": "What a regulating transformer's tap (or phase shift) automatically controls.\nMaps to the PSS/E control code `COD` and the PSLF transformer `type`.",
+          "oneOf": [
+            {
+              "const": "fixed",
+              "description": "Fixed ratio, no automatic adjustment (PSS/E `COD` 0/±4, PSLF type 1).",
+              "type": "string"
+            },
+            {
+              "const": "voltage",
+              "description": "Bus voltage control via tap (LTC; PSS/E `COD` ±1, PSLF type 2).",
+              "type": "string"
+            },
+            {
+              "const": "reactive_flow",
+              "description": "Reactive power flow control via tap (PSS/E `COD` ±2).",
+              "type": "string"
+            },
+            {
+              "const": "active_flow",
+              "description": "Active power flow control via phase shift (PSS/E `COD` ±3, PSLF type 4).",
+              "type": "string"
+            }
+          ]
+        },
+        "UntypedObject": {
+          "description": "An object the reader recognized but does not type: preserved by class,\nname, and raw property text so conversions can warn precisely.",
+          "properties": {
+            "class": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "props": {
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "class",
+            "name",
+            "props"
+          ],
+          "type": "object"
+        },
+        "VoltVarControl": {
+          "properties": {
+            "breakpoints": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_min_for_q": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "p_min_for_q_max": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "q_limits": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "q_ref": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ReactivePowerReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "q_unit": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ReactivePowerUnit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "voltage_reference": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ControlVoltageReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "breakpoints",
+            "q_limits"
+          ],
+          "type": "object"
+        },
+        "VoltWattControl": {
+          "properties": {
+            "breakpoints": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_limits": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "p_ref": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActivePowerReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "p_unit": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActivePowerUnit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "voltage_reference": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ControlVoltageReference"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "breakpoints",
+            "p_limits"
+          ],
+          "type": "object"
+        },
+        "VoltageSource": {
+          "properties": {
+            "bus": {
+              "type": "string"
+            },
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "terminal_map": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "v_angle": {
+              "description": "Radians per terminal.",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "v_magnitude": {
+              "description": "Volts per terminal (0.0 on grounded terminals).",
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "bus",
+            "terminal_map",
+            "v_magnitude",
+            "v_angle",
+            "extras"
+          ],
+          "type": "object"
+        },
+        "Winding": {
+          "description": "One winding of a [`Transformer3W`]: its terminal bus, off-nominal ratio, phase\nshift, nominal voltage, and thermal ratings.",
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/BusId"
+            },
+            "nominal_kv": {
+              "description": "Winding nominal voltage (kV); 0 defers to the terminal bus base kV.",
+              "format": "double",
+              "type": "number"
+            },
+            "rate_a": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_b": {
+              "format": "double",
+              "type": "number"
+            },
+            "rate_c": {
+              "format": "double",
+              "type": "number"
+            },
+            "shift": {
+              "description": "Phase shift (degrees).",
+              "format": "double",
+              "type": "number"
+            },
+            "tap": {
+              "description": "Off-nominal turns ratio (1.0 = nominal); the PSS/E `WINDV`, `CW = 1`.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "bus",
+            "tap",
+            "shift",
+            "nominal_kv",
+            "rate_a",
+            "rate_b",
+            "rate_c"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "diagnostics": {
+          "items": {
+            "$ref": "#/$defs/DiagnosticV1"
+          },
+          "type": "array"
+        },
+        "extensions": {
+          "additionalProperties": true,
+          "description": "Nonsemantic third party annotations. Keys must be namespaced.",
+          "type": "object"
+        },
+        "history": {
+          "items": {
+            "$ref": "#/$defs/HistoryEntryV1"
+          },
+          "type": "array"
+        },
+        "producer": {
+          "$ref": "#/$defs/ProducerV1"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "source_map": {
+          "items": {
+            "$ref": "#/$defs/SourceMapEntryV1"
+          },
+          "type": "array"
+        },
+        "sources": {
+          "items": {
+            "$ref": "#/$defs/SourceDescriptorV1"
+          },
+          "type": "array"
+        },
+        "value": {
+          "$ref": "#/$defs/StoredValueV1"
+        },
+        "version": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "schema",
+        "version",
+        "producer",
+        "value"
+      ],
+      "title": "StoredModuleV1",
+      "type": "object"
+    }
+  },
+  "tellegen_version": "0.2.0"
+}

--- a/tellegen/tellegen_mcp.py
+++ b/tellegen/tellegen_mcp.py
@@ -1,0 +1,425 @@
+"""Expose Tellegen's PowerIO OPF boundary through MCP."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import mcp_types as types
+from mcp.server.lowlevel.server import Server
+from mcp.server.stdio import stdio_server
+
+_TIMEOUT_S = 120.0
+_TERMINATE_GRACE_S = 2.0
+_CONTRACT_ID = "tellegen.cli/1"
+_CONTRACT_PATH = Path(__file__).with_name("tellegen-contract.json")
+_SCHEMA_NAMES = (
+    "powerio_module",
+    "capacity_plan_spec",
+    "plan_request",
+    "plan_response",
+    "solve_response",
+    "capabilities_response",
+)
+_TOOL_NAMES = ("capabilities", "solve_dc_opf", "plan_capacity")
+
+
+class TellegenTimeout(RuntimeError):
+    """Raised when a Tellegen CLI command exceeds the configured timeout."""
+
+
+def _canonical_json(value: Any) -> bytes:
+    """Encode JSON without changing scalar types or depending on key order."""
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+
+
+def _load_contract_artifact() -> dict[str, Any]:
+    try:
+        artifact = json.loads(_CONTRACT_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"cannot read {_CONTRACT_PATH.name}: {exc}") from exc
+    if not isinstance(artifact, dict):
+        raise TypeError(f"{_CONTRACT_PATH.name} must contain a JSON object")
+    if artifact.get("contract") != _CONTRACT_ID:
+        raise RuntimeError(f"{_CONTRACT_PATH.name} does not declare {_CONTRACT_ID}")
+    for field in ("tellegen_version", "powerio_version"):
+        if not isinstance(artifact.get(field), str) or not artifact[field]:
+            raise TypeError(f"{_CONTRACT_PATH.name} has no {field}")
+    schemas = artifact.get("schemas")
+    if not isinstance(schemas, dict):
+        raise TypeError(f"{_CONTRACT_PATH.name} has no schemas object")
+    for name in _SCHEMA_NAMES:
+        schema = schemas.get(name)
+        if not isinstance(schema, dict):
+            raise TypeError(f"{_CONTRACT_PATH.name} has no {name} schema")
+        jsonschema.Draft202012Validator.check_schema(schema)
+    return artifact
+
+
+def _embed_schema(
+    schema: dict[str, Any], definition_name: str
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Move a generated document schema under one enclosing root."""
+    body = copy.deepcopy(schema)
+    body.pop("$schema", None)
+    definitions = body.pop("$defs", {})
+    if not isinstance(definitions, dict):
+        raise TypeError(f"{definition_name} schema has a non-object $defs")
+    if definition_name in definitions:
+        raise TypeError(f"{definition_name} collides with a generated definition")
+    definitions[definition_name] = body
+    return definitions, {"$ref": f"#/$defs/{definition_name}"}
+
+
+def _solve_input_schema(module_schema: dict[str, Any]) -> dict[str, Any]:
+    definitions, module_ref = _embed_schema(module_schema, "PowerIoModule")
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": definitions,
+        "type": "object",
+        "required": ["module"],
+        "properties": {"module": module_ref},
+        "additionalProperties": False,
+    }
+
+
+def _output_envelope_schema(
+    response_schema: dict[str, Any], definition_name: str
+) -> dict[str, Any]:
+    definitions, response_ref = _embed_schema(response_schema, definition_name)
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": definitions,
+        "type": "object",
+        "oneOf": [
+            {
+                "type": "object",
+                "required": ["status", "message", "results"],
+                "properties": {
+                    "status": {"const": "success"},
+                    "message": {"type": "string"},
+                    "results": response_ref,
+                },
+                "additionalProperties": False,
+            },
+            {
+                "type": "object",
+                "required": ["status", "message"],
+                "properties": {
+                    "status": {"const": "error"},
+                    "message": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+        ],
+    }
+
+
+def _tool_schemas() -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    schemas = _load_contract_artifact()["schemas"]
+    inputs = {
+        "capabilities": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        "solve_dc_opf": _solve_input_schema(schemas["powerio_module"]),
+        "plan_capacity": copy.deepcopy(schemas["plan_request"]),
+    }
+    outputs = {
+        "capabilities": _output_envelope_schema(
+            schemas["capabilities_response"], "CapabilitiesResponse"
+        ),
+        "solve_dc_opf": _output_envelope_schema(
+            schemas["solve_response"], "SolveResponse"
+        ),
+        "plan_capacity": _output_envelope_schema(
+            schemas["plan_response"], "PlanResponse"
+        ),
+    }
+    for schema in (*inputs.values(), *outputs.values()):
+        jsonschema.Draft202012Validator.check_schema(schema)
+    return inputs, outputs
+
+
+def _resolve_binary() -> str:
+    """Resolve the Tellegen CLI configured by PowerMCP or the environment."""
+    try:
+        from powermcp.config import get_path
+    except ImportError:
+        value = os.environ.get("POWERMCP_TELLEGEN_BINARY")
+        if not value:
+            raise RuntimeError(
+                "tellegen is not configured; set POWERMCP_TELLEGEN_BINARY"
+            ) from None
+        path = Path(value).expanduser()
+        if not path.exists():
+            raise RuntimeError(
+                f"POWERMCP_TELLEGEN_BINARY points at a path that does not exist: {path}"
+            )
+        return str(path)
+    return get_path("tellegen", "binary")
+
+
+async def _stop_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    try:
+        process.terminate()
+    except ProcessLookupError:
+        return
+    try:
+        await asyncio.wait_for(process.wait(), timeout=_TERMINATE_GRACE_S)
+    except asyncio.TimeoutError:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            return
+        await process.wait()
+
+
+async def _run_process(
+    binary: str,
+    args: list[str],
+    stdin_text: str,
+    *,
+    timeout_s: float = _TIMEOUT_S,
+) -> str:
+    """Run one CLI command and stop its child on timeout or cancellation."""
+    try:
+        process = await asyncio.create_subprocess_exec(
+            binary,
+            *args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"cannot launch tellegen: {exc}") from exc
+
+    command = " ".join(("tellegen", *args))
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            process.communicate(stdin_text.encode()),
+            timeout=timeout_s,
+        )
+    except asyncio.TimeoutError as exc:
+        await _stop_process(process)
+        raise TellegenTimeout(
+            f"{command} exceeded the {timeout_s:g} s timeout"
+        ) from exc
+    except asyncio.CancelledError:
+        await _stop_process(process)
+        raise
+
+    if process.returncode != 0:
+        message = stderr.decode(errors="replace").strip()
+        raise RuntimeError(
+            message or f"{command} exited with code {process.returncode}"
+        )
+    return stdout.decode(errors="strict")
+
+
+async def _verify_contract(binary: str, expected: dict[str, Any]) -> None:
+    """Require the CLI to match the bundled contract on every invocation."""
+    try:
+        actual = json.loads(await _run_process(binary, ["contract"], ""))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"tellegen contract returned invalid JSON: {exc}") from exc
+    if not isinstance(actual, dict):
+        raise TypeError("tellegen contract did not return an object")
+    if actual.get("contract") != _CONTRACT_ID:
+        raise RuntimeError(
+            "unsupported tellegen CLI contract: "
+            f"{actual.get('contract')!r}; expected {_CONTRACT_ID!r}"
+        )
+    expected_bytes = _canonical_json(expected)
+    actual_bytes = _canonical_json(actual)
+    if actual_bytes != expected_bytes:
+        expected_sha256 = hashlib.sha256(expected_bytes).hexdigest()
+        actual_sha256 = hashlib.sha256(actual_bytes).hexdigest()
+        raise RuntimeError(
+            "the configured tellegen binary does not match the bundled CLI contract "
+            f"(expected SHA-256 {expected_sha256}, got {actual_sha256})"
+        )
+
+
+async def _run_tellegen(args: list[str], stdin_text: str) -> str:
+    binary = _resolve_binary()
+    expected = _load_contract_artifact()
+    await _verify_contract(binary, expected)
+    return await _run_process(binary, args, stdin_text)
+
+
+def _ok(message: str, results: Any) -> dict[str, Any]:
+    return {"status": "success", "message": message, "results": results}
+
+
+def _err(message: str) -> dict[str, Any]:
+    return {"status": "error", "message": message}
+
+
+def _validation_message(prefix: str, error: jsonschema.ValidationError) -> str:
+    location = ".".join(str(part) for part in error.absolute_path)
+    where = f" at {location}" if location else ""
+    return f"{prefix}{where}: {error.message}"
+
+
+def _decode_response(
+    text: str,
+    schema_name: str,
+    operation: str,
+) -> Any:
+    value = json.loads(text)
+    schema = _load_contract_artifact()["schemas"][schema_name]
+    try:
+        jsonschema.Draft202012Validator(schema).validate(value)
+    except jsonschema.ValidationError as exc:
+        raise ValueError(
+            _validation_message(f"{operation} result schema mismatch", exc)
+        ) from exc
+    return value
+
+
+async def capabilities() -> dict[str, Any]:
+    """Return Tellegen's formulation and differentiation capabilities."""
+    try:
+        value = _decode_response(
+            await _run_tellegen(["capabilities"], ""),
+            "capabilities_response",
+            "capabilities",
+        )
+        return _ok("Returned Tellegen capabilities.", value)
+    except TellegenTimeout as exc:
+        return _err(str(exc))
+    except (json.JSONDecodeError, RuntimeError, TypeError, ValueError) as exc:
+        return _err(f"capabilities failed: {exc}")
+
+
+async def solve_dc_opf(module: dict[str, Any]) -> dict[str, Any]:
+    """Solve a PowerIO balanced network or DC OPF instance with Tellegen."""
+    try:
+        value = _decode_response(
+            await _run_tellegen(
+                ["solve-module"],
+                json.dumps(module, allow_nan=False),
+            ),
+            "solve_response",
+            "solve_dc_opf",
+        )
+        return _ok("Solved the DC OPF instance.", value)
+    except TellegenTimeout as exc:
+        return _err(str(exc))
+    except (json.JSONDecodeError, RuntimeError, TypeError, ValueError) as exc:
+        return _err(f"solve_dc_opf failed: {exc}")
+
+
+async def plan_capacity(module: dict[str, Any], spec: dict[str, Any]) -> dict[str, Any]:
+    """Use implicit gradients and exact solves to propose capacity increases.
+
+    The bounded search is heuristic. It returns Tellegen's proposal and the
+    exact solution module for the amended instance without changing the input.
+    """
+    try:
+        request = {"module": module, "spec": spec}
+        value = _decode_response(
+            await _run_tellegen(
+                ["plan"],
+                json.dumps(request, allow_nan=False),
+            ),
+            "plan_response",
+            "plan_capacity",
+        )
+        return _ok("Computed and checked a capacity proposal.", value)
+    except TellegenTimeout as exc:
+        return _err(str(exc))
+    except (json.JSONDecodeError, RuntimeError, TypeError, ValueError) as exc:
+        return _err(f"plan_capacity failed: {exc}")
+
+
+_TOOL_DESCRIPTIONS = {
+    "capabilities": capabilities.__doc__ or "",
+    "solve_dc_opf": solve_dc_opf.__doc__ or "",
+    "plan_capacity": plan_capacity.__doc__ or "",
+}
+
+
+async def _list_tools(
+    _context: Any, _params: types.PaginatedRequestParams | None
+) -> types.ListToolsResult:
+    inputs, outputs = _tool_schemas()
+    return types.ListToolsResult(
+        tools=[
+            types.Tool(
+                name=name,
+                description=_TOOL_DESCRIPTIONS[name],
+                inputSchema=copy.deepcopy(inputs[name]),
+                outputSchema=copy.deepcopy(outputs[name]),
+            )
+            for name in _TOOL_NAMES
+        ]
+    )
+
+
+def _call_result(payload: dict[str, Any]) -> types.CallToolResult:
+    text = json.dumps(payload, allow_nan=False)
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=text)],
+        structuredContent=payload,
+    )
+
+
+async def _call_tool(
+    _context: Any, params: types.CallToolRequestParams
+) -> types.CallToolResult:
+    inputs, _outputs = _tool_schemas()
+    schema = inputs.get(params.name)
+    if schema is None:
+        return _call_result(_err(f"unknown tool: {params.name}"))
+    arguments = params.arguments or {}
+    try:
+        jsonschema.Draft202012Validator(schema).validate(arguments)
+    except jsonschema.ValidationError as exc:
+        return _call_result(
+            _err(_validation_message(f"invalid {params.name} arguments", exc))
+        )
+
+    if params.name == "capabilities":
+        payload = await capabilities()
+    elif params.name == "solve_dc_opf":
+        payload = await solve_dc_opf(arguments["module"])
+    else:
+        payload = await plan_capacity(arguments["module"], arguments["spec"])
+    return _call_result(payload)
+
+
+mcp = Server(
+    "Tellegen MCP Server",
+    on_list_tools=_list_tools,
+    on_call_tool=_call_tool,
+)
+
+
+async def _serve_stdio() -> None:
+    async with stdio_server() as (read_stream, write_stream):
+        await mcp.run(
+            read_stream,
+            write_stream,
+            mcp.create_initialization_options(),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(_serve_stdio())

--- a/tests/server_entry_smoke.py
+++ b/tests/server_entry_smoke.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import runpy
 import sys
 import types
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -97,17 +97,31 @@ def _stub_engines(tool: str) -> None:
 def main(tool_name: str) -> None:
     _stub_engines(tool_name)
 
+    from mcp.server import stdio
+    from mcp.server.lowlevel.server import Server
     from mcp.server.mcpserver import MCPServer
+
     from powermcp import runner
     from powermcp.registry import get_tool
 
     calls = []
     real_run = MCPServer.run
+    real_lowlevel_run = Server.run
+    real_stdio_server = stdio.stdio_server
 
     def record_run(self, *args, **kwargs):
         calls.append((self, args, kwargs))
 
+    async def record_lowlevel_run(self, *args, **kwargs):
+        calls.append((self, args, kwargs))
+
+    @asynccontextmanager
+    async def stub_stdio_server(*_args, **_kwargs):
+        yield None, None
+
     MCPServer.run = record_run
+    Server.run = record_lowlevel_run
+    stdio.stdio_server = stub_stdio_server
     try:
         tool = get_tool(tool_name)
         if tool.run_kind == "package":
@@ -118,10 +132,17 @@ def main(tool_name: str) -> None:
             runner._launch_script(tool)
     finally:
         MCPServer.run = real_run
+        Server.run = real_lowlevel_run
+        stdio.stdio_server = real_stdio_server
 
     assert len(calls) == 1, f"{tool_name}: expected one run call, got {len(calls)}"
     server, _args, _kwargs = calls[0]
-    tools = asyncio.run(server.list_tools())
+    if isinstance(server, MCPServer):
+        tools = asyncio.run(server.list_tools())
+    else:
+        entry = server.get_request_handler("tools/list")
+        assert entry is not None
+        tools = asyncio.run(entry.handler(None, None)).tools
     assert tools, f"{tool_name}: server registered no tools"
 
 

--- a/tests/standalone_entry_smoke.py
+++ b/tests/standalone_entry_smoke.py
@@ -7,6 +7,7 @@ import importlib.abc
 import runpy
 import sys
 import types
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -86,18 +87,31 @@ class _RequireCloneBootstrap(importlib.abc.MetaPathFinder):
             raise ModuleNotFoundError(
                 "powermcp is unavailable until the clone entrypoint bootstraps it"
             )
-        return None
 
 
 def main(tool: str, relative_script: str, expect_run: bool = True) -> None:
     script = REPO / relative_script
     _stub_engines(tool)
 
+    from mcp.server import stdio
+    from mcp.server.lowlevel.server import Server
     from mcp.server.mcpserver import MCPServer
 
     calls = []
     real_run = MCPServer.run
+    real_lowlevel_run = Server.run
+    real_stdio_server = stdio.stdio_server
     MCPServer.run = lambda self, *args, **kwargs: calls.append((self, args, kwargs))
+
+    async def record_lowlevel_run(self, *args, **kwargs):
+        calls.append((self, args, kwargs))
+
+    @asynccontextmanager
+    async def stub_stdio_server(*_args, **_kwargs):
+        yield None, None
+
+    Server.run = record_lowlevel_run
+    stdio.stdio_server = stub_stdio_server
     sys.meta_path.insert(0, _RequireCloneBootstrap())
     sys.path[:] = [
         str(script.parent),
@@ -110,11 +124,19 @@ def main(tool: str, relative_script: str, expect_run: bool = True) -> None:
         runpy.run_path(str(script), run_name="__main__" if expect_run else "clone_smoke")
     finally:
         MCPServer.run = real_run
+        Server.run = real_lowlevel_run
+        stdio.stdio_server = real_stdio_server
 
     if not expect_run:
         return
     assert len(calls) == 1, f"{tool}: expected one run call, got {len(calls)}"
-    tools = asyncio.run(calls[0][0].list_tools())
+    server = calls[0][0]
+    if isinstance(server, MCPServer):
+        tools = asyncio.run(server.list_tools())
+    else:
+        entry = server.get_request_handler("tools/list")
+        assert entry is not None
+        tools = asyncio.run(entry.handler(None, None)).tools
     assert tools, f"{tool}: server registered no tools"
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -121,13 +121,14 @@ def test_the_floor_is_found_without_top_level_distribution_metadata(monkeypatch)
     monkeypatch.setattr(
         doctor,
         "requires",
-        lambda _distribution: ("powerio[mcp,matrix]>=0.9.0,<1",),
+        lambda _distribution: ("powerio[mcp,matrix]>=1.0.0,<2",),
     )
     req = doctor._declared_requirement("powerio")
     assert req is not None
     assert doctor._canonical(req.name) == "powerio"
-    assert Version("0.9.0") in req.specifier
-    assert Version("1.0.0") not in req.specifier
+    assert Version("1.0.0") in req.specifier
+    assert Version("0.9.0") not in req.specifier
+    assert Version("2.0.0") not in req.specifier
 
 
 def test_an_out_of_date_dependency_under_another_name_is_caught(monkeypatch):

--- a/tests/test_powerio_server.py
+++ b/tests/test_powerio_server.py
@@ -5,8 +5,8 @@ The server under test is powerio's own ``powerio.mcp.server``: this repo runs
 that module and keeps no copy of it, so these tests are the consumer suite over
 a dependency's surface. powerio is a core dependency, so it is normally present;
 the importorskip below stays as insurance for stripped-down environments.
-The decorated tools stay ordinary callables, so most cases exercise them
-in-process; ``test_transport.py`` covers what only a real MCP transport shows.
+The public in process helpers exercise the tool implementations;
+``test_transport.py`` covers what only a real MCP transport shows.
 The launch test lives here rather than in test_runner.py so it skips with the
 rest of the module.
 
@@ -28,10 +28,10 @@ import types
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
-pytest.importorskip("powerio", minversion="0.9.0")
-
-import powerio  # noqa: E402
+powerio = pytest.importorskip("powerio")
+assert Version("1.0.0") <= Version(powerio.__version__) < Version("2.0.0")
 from powerio.mcp import server as powerio_mcp  # noqa: E402
 
 from powermcp.registry import TOOLS  # noqa: E402
@@ -47,7 +47,9 @@ CASE9 = Path(__file__).resolve().parent / "data" / "case9.m"
 ACTIVSG200_PWD = (
     Path(__file__).resolve().parent / "data" / "powerworld" / "ACTIVSg200.pwd"
 )
-MINIMAL_BMOPF = '{"bus":{"a":{"terminal_names":["1"]}}}'
+OPENDSS_CASE = (
+    Path(__file__).resolve().parents[1] / "OpenDSS" / "13Bus" / "IEEE13Nodeckt.dss"
+)
 
 # 3-bus case with rating 0 branches, for the overwrite_zero_s_nom tests.
 ZERO_RATE_CASE = """function mpc = zero_rate
@@ -68,6 +70,52 @@ mpc.branch = [
 """
 
 
+def _diagnostic_codes(result):
+    return {item["code"] for item in result["diagnostics"]}
+
+
+def _module_json(module: powerio.PioModule) -> str:
+    return module.emit("pio-json").text
+
+
+def _parse_module(text: str) -> powerio.PioModule:
+    return powerio.parse_text(text, name="module.pio.json")
+
+
+def _diagnostic_module_json() -> str:
+    document = json.loads(_module_json(powerio.parse_file(CASE9)))
+    document["diagnostics"] = [
+        {
+            "id": "consumer-test",
+            "code": "READ.TEST.FIELD",
+            "severity": "warning",
+            "message": "consumer test diagnostic",
+            "target": "/buses/0",
+        }
+    ]
+    return json.dumps(document)
+
+
+def _assert_structured_adapter_response(result):
+    assert result["status"] == "success", result
+    assert "warnings" not in result
+    assert "package" not in result
+    assert "module" not in result
+    assert result["diagnostics"]
+    assert all(
+        {"code", "severity", "message"} <= diagnostic.keys()
+        for diagnostic in result["diagnostics"]
+    )
+    assert "READ.TEST.FIELD" in _diagnostic_codes(result)
+
+
+def _load_egret_mcp(tmp_path, monkeypatch):
+    pytest.importorskip("egret")
+    monkeypatch.setenv("POWERMCP_HOME", str(tmp_path / "powermcp-home"))
+    monkeypatch.syspath_prepend(str(TOOLS["egret"].resolve_server_dir()))
+    return importlib.import_module("egret_mcp")
+
+
 def test_parse_json_round_trips():
     r = powerio_mcp.parse(path=str(CASE9))
     assert r["schema"] == "powerio.parse"
@@ -76,7 +124,7 @@ def test_parse_json_round_trips():
     assert r["model"] == "balanced"
     assert r["json_format"] == "model-json"
     assert r["source_format"] == "matpower"
-    assert isinstance(r["warnings"], list)
+    assert isinstance(r["diagnostics"], list)
     assert r["summary"]["elements"]["buses"] == 9
     assert powerio.from_json(r["json"]).n_buses == 9
 
@@ -84,39 +132,52 @@ def test_parse_json_round_trips():
 def test_tool_surface_is_canonical():
     tools = {tool.name: tool for tool in asyncio.run(powerio_mcp.mcp.list_tools())}
     names = set(tools)
-    required_names = {
+    preferred_names = {
+        "emit",
+        "summarize",
+        "parse",
+        "to_normalized",
+        "calc_matrix",
+        "diagnostics",
+        "display",
+        "inspect",
+        "list_states",
+        "inspect_state",
+        "export_state",
+        "to_balanced_report",
+        "to_balanced",
+        "about",
+    }
+    obsolete_names = {
         "convert",
         "save",
         "summary",
-        "parse",
         "normalize",
         "matrix",
-        "diagnostics",
-        "display",
+        "state_inventory",
+        "select_state",
+        "to_balanced_inspect",
+        "dc_data",
     }
-    assert required_names <= names
-    for name in ("parse", "summary", "normalize", "matrix", "display"):
+    assert preferred_names <= names
+    assert names.isdisjoint(obsolete_names)
+    for name in ("parse", "summarize", "to_normalized", "calc_matrix", "display"):
         props = tools[name].input_schema["properties"]
         assert "from_format" in props
-        assert "format" not in props
     parse_props = tools["parse"].input_schema["properties"]
     assert "transport" in parse_props
-    convert_props = tools["convert"].input_schema["properties"]
-    assert "to_format" in convert_props and "from_format" in convert_props
-    assert "package_json" in convert_props
-    assert "to" not in convert_props and "format" not in convert_props
-    for name in ("summary", "normalize", "matrix"):
-        assert "package_json" in tools[name].input_schema["properties"]
-    save_schema = tools["save"].input_schema
-    assert save_schema["required"] == ["out_path"]
-    save_props = save_schema["properties"]
-    assert "to_format" in save_props and "from_format" in save_props
-    assert "package_json" in save_props
-    assert "to" not in save_props and "format" not in save_props
+    emit_schema = tools["emit"].input_schema
+    assert emit_schema["required"] == ["format"]
+    emit_props = emit_schema["properties"]
+    assert "format" in emit_props and "destination" in emit_props
+    assert "from_format" in emit_props and "module_json" in emit_props
+    assert "to_format" not in emit_props and "out_path" not in emit_props
+    for name in ("summarize", "to_normalized", "calc_matrix"):
+        assert "module_json" in tools[name].input_schema["properties"]
 
 
-def test_normalize_returns_dense_one_based_ids():
-    r = powerio_mcp.normalize(path=str(CASE9))
+def test_to_normalized_returns_dense_one_based_ids():
+    r = powerio_mcp.to_normalized(path=str(CASE9))
     case = powerio.from_json(r["json"])
     assert [b["id"] for b in case.buses] == list(range(1, 10))
 
@@ -126,15 +187,15 @@ def test_parse_transport_accepted_downstream():
     assert powerio.from_json(r["json"]).n_buses == 9
 
 
-def test_matrix_bprime():
-    m = powerio_mcp.matrix("bprime", path=str(CASE9))
-    assert m["schema"] == "powerio.matrix"
+def test_calc_matrix_bprime():
+    m = powerio_mcp.calc_matrix("bprime", path=str(CASE9))
+    assert m["schema"] == "powerio.calc_matrix"
     assert m["powerio_version"] == powerio.__version__
     assert m["domain"] == "transmission"
     assert m["model"] == "balanced"
     assert m["json_format"] == "model-json"
     assert m["source_format"] == "matpower"
-    assert isinstance(m["warnings"], list)
+    assert isinstance(m["diagnostics"], list)
     assert m["format"] == "coo"
     assert m["shape"] == [9, 9]
     assert m["nnz"] > 0
@@ -145,33 +206,34 @@ def test_matrix_bprime():
     assert type(m["col"][0]) is int
 
 
-def test_matrix_accepts_json_transport():
+def test_calc_matrix_accepts_json_transport():
     transport = powerio_mcp.parse(path=str(CASE9))["json"]
-    from_json = powerio_mcp.matrix("bprime", json=transport)
-    from_path = powerio_mcp.matrix("bprime", path=str(CASE9))
+    from_json = powerio_mcp.calc_matrix("bprime", json=transport)
+    from_path = powerio_mcp.calc_matrix("bprime", path=str(CASE9))
     assert from_json["shape"] == from_path["shape"]
     assert from_json["nnz"] == from_path["nnz"]
 
 
-def test_matrix_unknown_kind():
+def test_calc_matrix_unknown_kind():
     with pytest.raises(ValueError):
-        powerio_mcp.matrix("nope", path=str(CASE9))
+        powerio_mcp.calc_matrix("nope", path=str(CASE9))
 
 
-def test_convert_powermodels():
-    r = powerio_mcp.convert(to_format="powermodels-json", path=str(CASE9))
-    assert isinstance(r["warnings"], list)
+def test_emit_powermodels():
+    r = powerio_mcp.emit(format="powermodels-json", path=str(CASE9))
+    assert r["schema"] == "powerio.emit"
+    assert isinstance(r["diagnostics"], list)
     assert len(json.loads(r["text"])["bus"]) == 9
 
 
-def test_summary_fields():
-    s = powerio_mcp.summary(path=str(CASE9))
-    assert s["schema"] == "powerio.summary"
+def test_summarize_fields():
+    s = powerio_mcp.summarize(path=str(CASE9))
+    assert s["schema"] == "powerio.summarize"
     assert s["powerio_version"] == powerio.__version__
     assert s["domain"] == "transmission"
     assert s["model"] == "balanced"
     assert s["json_format"] == "model-json"
-    assert isinstance(s["warnings"], list)
+    assert isinstance(s["diagnostics"], list)
     assert s["elements"]["buses"] == 9
     assert s["base_mva"] == 100.0
     assert s["source_format"] == "matpower"
@@ -182,21 +244,21 @@ def test_summary_fields():
 
 def test_exactly_one_input_enforced():
     with pytest.raises(ValueError):
-        powerio_mcp.summary()
+        powerio_mcp.summarize()
     with pytest.raises(ValueError):
-        powerio_mcp.summary(path="x", content="y")
+        powerio_mcp.summarize(path="x", content="y")
     with pytest.raises(ValueError):
-        powerio_mcp.matrix("bprime")
+        powerio_mcp.calc_matrix("bprime")
     with pytest.raises(ValueError):
-        powerio_mcp.matrix("bprime", path=str(CASE9), json="{}")
+        powerio_mcp.calc_matrix("bprime", path=str(CASE9), json="{}")
 
 
 def test_inline_matpower_content_defaults_to_matpower():
-    assert powerio_mcp.convert(to_format="psse", content=CASE9.read_text())["text"]
+    assert powerio_mcp.emit(format="psse", content=CASE9.read_text())["text"]
 
 
-def test_matrix_lacpf():
-    m = powerio_mcp.matrix("lacpf", path=str(CASE9))
+def test_calc_matrix_lacpf():
+    m = powerio_mcp.calc_matrix("lacpf", path=str(CASE9))
     assert m["format"] == "coo"
     assert m["shape"] == [18, 18]
     assert m["nnz"] > 0
@@ -204,60 +266,65 @@ def test_matrix_lacpf():
     assert type(m["row"][0]) is int
 
 
-def test_save_writes_file(tmp_path):
+def test_emit_writes_file(tmp_path):
     out = tmp_path / "case9.json"
-    r = powerio_mcp.save(
-        to_format="powermodels-json", out_path=str(out), path=str(CASE9)
+    r = powerio_mcp.emit(
+        format="powermodels-json", destination=str(out), path=str(CASE9)
     )
     assert r["path"] == str(out)
     assert r["bytes_written"] == out.stat().st_size
-    assert isinstance(r["warnings"], list)
+    assert isinstance(r["diagnostics"], list)
     assert len(json.loads(out.read_text())["bus"]) == 9
 
 
-def test_save_refuses_overwrite(tmp_path):
+def test_emit_refuses_overwrite(tmp_path):
     out = tmp_path / "case9.m"
     out.write_text("existing")
     with pytest.raises(ValueError, match="overwrite"):
-        powerio_mcp.save(out_path=str(out), path=str(CASE9))
-    r = powerio_mcp.save(
-        out_path=str(out), path=str(CASE9), overwrite=True
+        powerio_mcp.emit(
+            format="matpower", destination=str(out), path=str(CASE9)
+        )
+    r = powerio_mcp.emit(
+        format="matpower", destination=str(out), path=str(CASE9), overwrite=True
     )
     assert r["bytes_written"] == out.stat().st_size
 
 
-def test_save_accepts_json_transport(tmp_path):
+def test_emit_accepts_json_transport(tmp_path):
     transport = powerio_mcp.parse(path=str(CASE9))["json"]
     out = tmp_path / "case9.m"
-    powerio_mcp.save(out_path=str(out), json=transport)
-    assert powerio.parse_file(out).n_buses == 9
+    powerio_mcp.emit(format="matpower", destination=str(out), json=transport)
+    assert powerio.parse_file(out).value.n_buses == 9
 
 
-def test_package_transport_flows_through_core_tools(tmp_path):
-    parsed = powerio_mcp.parse(path=str(CASE9), transport="package")
+def test_module_transport_flows_through_core_tools(tmp_path):
+    parsed = powerio_mcp.parse(path=str(CASE9), transport="module")
     assert parsed["schema"] == "powerio.parse"
-    assert parsed["transport"] == "package"
-    assert parsed["json_format"] == "package"
+    assert parsed["transport"] == "module"
+    assert parsed["json_format"] == "module"
     assert parsed["domain"] == "transmission"
     assert parsed["model"] == "balanced"
-    assert "package_json" in parsed
+    assert "module_json" in parsed
 
-    package = json.loads(parsed["package_json"])
-    assert package["model_kind"] == "balanced"
-    assert package["model"]["kind"] == "balanced"
+    module = json.loads(parsed["module_json"])
+    assert module["schema"] == "powerio.module"
+    assert module["version"] == 1
+    assert module["value"]["kind"] == "balanced_network"
 
-    package_json = parsed["package_json"]
-    assert powerio_mcp.summary(package_json=package_json)["elements"]["buses"] == 9
+    module_json = parsed["module_json"]
+    assert powerio_mcp.summarize(module_json=module_json)["elements"]["buses"] == 9
 
-    matrix = powerio_mcp.matrix("bprime", package_json=package_json)
+    matrix = powerio_mcp.calc_matrix("bprime", module_json=module_json)
     assert matrix["kind"] == "bprime"
     assert matrix["shape"] == [9, 9]
 
     out = tmp_path / "case9.m"
-    powerio_mcp.save(out_path=str(out), package_json=package_json)
-    assert powerio.parse_file(out).n_buses == 9
+    powerio_mcp.emit(
+        format="matpower", destination=str(out), module_json=module_json
+    )
+    assert powerio.parse_file(out).value.n_buses == 9
 
-    diag = powerio_mcp.diagnostics(package_json)
+    diag = powerio_mcp.diagnostics(module_json)
     assert diag["schema"] == "powerio.diagnostics"
     assert diag["model_kind"] == "balanced"
     assert diag["summary"]["status"] in {"ok", "info", "warning", "error", "fatal"}
@@ -265,108 +332,191 @@ def test_package_transport_flows_through_core_tools(tmp_path):
     assert isinstance(diag["diagnostics"], list)
 
 
-def test_pypsa_interchange_accepts_static_package(tmp_path):
-    package_json = powerio.Package.from_file(CASE9).to_json()
-    out = tmp_path / "case9-package.nc"
-    result = pypsa_mcp.import_case_from_json(package_json, str(out))
+def test_pypsa_interchange_accepts_static_module(tmp_path):
+    module_json = _diagnostic_module_json()
+    source_map = json.loads(module_json).get("source_map", [])
+    assert source_map
+    out = tmp_path / "case9-module.nc"
+    result = pypsa_mcp.import_case_from_json(module_json, str(out))
 
-    assert result["status"] == "success", result
-    assert result["package"]["model_kind"] == "balanced"
-    assert result["package"]["source_map_entries"] > 0
+    _assert_structured_adapter_response(result)
     assert len(pypsa.Network(str(out)).buses) == 9
 
 
-def test_pandapower_interchange_accepts_static_package():
+def test_pandapower_interchange_accepts_static_module():
     panda_dir = str(TOOLS["pandapower"].resolve_server_dir())
     if panda_dir not in sys.path:
         sys.path.insert(0, panda_dir)
     import panda_mcp  # noqa: E402
 
-    result = panda_mcp.load_network_from_json(
-        powerio.Package.from_file(CASE9).to_json()
-    )
+    result = panda_mcp.load_network_from_json(_diagnostic_module_json())
 
-    assert result["status"] == "success", result
-    assert result["package"]["model_kind"] == "balanced"
+    _assert_structured_adapter_response(result)
     assert len(panda_mcp._current_net.bus) == 9
 
 
-def test_solver_interchange_requires_explicit_package_state(tmp_path):
-    package = powerio.Package.from_file(CASE9)
-    package.set_operating_points(
+def test_core_solver_adapters_preserve_powerio_error_codes(tmp_path):
+    panda_dir = str(TOOLS["pandapower"].resolve_server_dir())
+    if panda_dir not in sys.path:
+        sys.path.insert(0, panda_dir)
+    import panda_mcp  # noqa: E402
+
+    results = (
+        panda_mcp.load_network_from_json("{not JSON"),
+        pypsa_mcp.import_case_from_json("{not JSON", str(tmp_path / "bad.nc")),
+    )
+
+    for result in results:
+        assert result["status"] == "error"
+        assert result["code"] == "REQUEST.FORMAT.UNKNOWN"
+        assert "REQUEST.FORMAT.UNKNOWN" in result["message"]
+
+
+def test_pandapower_export_uses_powerio_ppc_and_module_emit(monkeypatch):
+    panda_dir = str(TOOLS["pandapower"].resolve_server_dir())
+    if panda_dir not in sys.path:
+        sys.path.insert(0, panda_dir)
+    import panda_mcp  # noqa: E402
+
+    loaded = panda_mcp.load_network_from_any(str(CASE9))
+    assert loaded["status"] == "success", loaded
+
+    calls = []
+    original_from_ppc = powerio.from_ppc
+
+    def recording_from_ppc(ppc):
+        calls.append(ppc)
+        return original_from_ppc(ppc)
+
+    monkeypatch.setattr(powerio, "from_ppc", recording_from_ppc)
+    result = panda_mcp.export_network_to_format("matpower")
+
+    assert result["status"] == "success", result
+    assert len(calls) == 1
+    assert "mpc.baseMVA" in result["text"]
+    assert isinstance(result["diagnostics"], list)
+    assert "warnings" not in result
+
+
+def test_egret_interchange_accepts_static_module(tmp_path, monkeypatch):
+    egret_mcp = _load_egret_mcp(tmp_path, monkeypatch)
+
+    result = egret_mcp.load_model_from_json(_diagnostic_module_json())
+
+    _assert_structured_adapter_response(result)
+    assert Path(result["case_file"]).is_file()
+
+
+def test_egret_preserves_powerio_error_codes(tmp_path, monkeypatch):
+    egret_mcp = _load_egret_mcp(tmp_path, monkeypatch)
+
+    result = egret_mcp.load_model_from_json("{not JSON")
+
+    assert result["status"] == "error"
+    assert result["code"] == "REQUEST.FORMAT.UNKNOWN"
+    assert "REQUEST.FORMAT.UNKNOWN" in result["message"]
+
+
+def test_egret_interchange_accepts_case_file(tmp_path, monkeypatch):
+    egret_mcp = _load_egret_mcp(tmp_path, monkeypatch)
+
+    result = egret_mcp.load_model_from_any(str(CASE9))
+
+    assert result["status"] == "success", result
+    assert Path(result["case_file"]).is_file()
+    assert result["model_info"]["bus"] == 9
+    assert isinstance(result["diagnostics"], list)
+    assert "module" not in result
+    assert "warnings" not in result
+    assert "package" not in result
+
+
+def test_solver_interchange_requires_powerio_collection_export(tmp_path):
+    parsed = json.loads(_module_json(powerio.parse_file(CASE9)))
+    collection_json = json.dumps(
         {
-            "time_axis": {"periods": 1, "labels": ["dispatch"]},
-            "points": [
-                {
-                    "index": 0,
-                    "updates": [
+            "schema": "powerio.module",
+            "version": 1,
+            "producer": parsed["producer"],
+            "value": {
+                "kind": "balanced_network_scenario_set",
+                "data": {
+                    "scenarios": [
                         {
-                            "element": {
-                                "table": "generators",
-                                "source_uid": "generators:0",
-                            },
-                            "fields": {"pg": 123.0},
+                            "id": "base",
+                            "probability": 1.0,
+                            "value": parsed["value"]["data"],
                         }
-                    ],
-                }
-            ],
+                    ]
+                },
+            },
         }
     )
 
     rejected = pypsa_mcp.import_case_from_json(
-        package.to_json(), str(tmp_path / "unselected.nc")
+        collection_json, str(tmp_path / "unselected.nc")
     )
     assert rejected["status"] == "error"
-    assert "operating_point from [0]" in rejected["message"]
+    assert "list_states" in rejected["message"]
+    assert "export_state" in rejected["message"]
 
+    panda_dir = str(TOOLS["pandapower"].resolve_server_dir())
+    if panda_dir not in sys.path:
+        sys.path.insert(0, panda_dir)
+    import panda_mcp  # noqa: E402
+
+    panda_rejected = panda_mcp.load_network_from_json(collection_json)
+    assert panda_rejected["status"] == "error"
+    assert "list_states" in panda_rejected["message"]
+    assert "export_state" in panda_rejected["message"]
+
+    collection = _parse_module(collection_json)
+    exported = collection.export_state(scenario="base")
     out = tmp_path / "selected.nc"
-    selected = pypsa_mcp.import_case_from_json(
-        package.to_json(), str(out), operating_point=0
-    )
+    selected = pypsa_mcp.import_case_from_json(_module_json(exported), str(out))
     assert selected["status"] == "success", selected
-    assert selected["package"]["materialized"] == {
-        "kind": "operating_point",
-        "index": 0,
-    }
-    assert pypsa.Network(str(out)).generators.iloc[0].p_set == pytest.approx(123.0)
+    assert "module" not in selected
+    assert len(pypsa.Network(str(out)).buses) == 9
 
 
-def test_solver_interchange_materializes_study_commit(tmp_path):
-    package = powerio.Package.from_file(CASE9)
-    document = json.loads(package.to_json())
-    document["study"] = {
-        "label": "load study",
-        "commits": [
-            {
-                "label": "add load",
-                "edits": [
-                    {
-                        "kind": "demand_delta",
-                        "bus": {"table": "buses", "source_uid": "buses:0"},
-                        "p_mw": 7.0,
-                        "q_mvar": 3.0,
-                    }
-                ],
-            }
-        ],
-    }
-
-    out = tmp_path / "study.nc"
-    result = pypsa_mcp.import_case_from_json(
-        json.dumps(document), str(out), study_commit=0
+def test_egret_requires_powerio_collection_export(tmp_path, monkeypatch):
+    egret_mcp = _load_egret_mcp(tmp_path, monkeypatch)
+    parsed = json.loads(_module_json(powerio.parse_file(CASE9)))
+    collection_json = json.dumps(
+        {
+            "schema": "powerio.module",
+            "version": 1,
+            "producer": parsed["producer"],
+            "value": {
+                "kind": "balanced_network_scenario_set",
+                "data": {
+                    "scenarios": [
+                        {
+                            "id": "base",
+                            "probability": 1.0,
+                            "value": parsed["value"]["data"],
+                        }
+                    ]
+                },
+            },
+        }
     )
 
-    assert result["status"] == "success", result
-    assert result["package"]["materialized"] == {"kind": "study_commit", "index": 0}
-    assert (pypsa.Network(str(out)).loads.p_set == 7.0).any()
+    rejected = egret_mcp.load_model_from_json(collection_json)
+
+    assert rejected["status"] == "error"
+    assert "list_states" in rejected["message"]
+    assert "export_state" in rejected["message"]
 
 
-def test_save_exactly_one_input(tmp_path):
+def test_emit_requires_exactly_one_input(tmp_path):
     out = tmp_path / "x.m"
     with pytest.raises(ValueError):
-        powerio_mcp.save(out_path=str(out))
+        powerio_mcp.emit(format="matpower", destination=str(out))
     with pytest.raises(ValueError):
-        powerio_mcp.save(out_path=str(out), path="a", json="{}")
+        powerio_mcp.emit(
+            format="matpower", destination=str(out), path="a", json="{}"
+        )
 
 
 def test_pypsa_import_case_from_any(tmp_path):
@@ -394,7 +544,7 @@ def test_pypsa_import_preserves_supported_generator_costs(tmp_path):
     generators = pypsa.Network(str(out)).generators
     assert (generators.marginal_cost != 0).all()
     assert generators.start_up_cost.tolist() == pytest.approx([1500, 2000, 3000])
-    assert any("constant polynomial cost" in warning for warning in result["warnings"])
+    assert "POWERMCP.PYPSA.CONSTANT_COST_DROPPED" in _diagnostic_codes(result)
 
 
 def test_pypsa_import_applies_generator_voltage_targets_to_buses(tmp_path):
@@ -478,11 +628,12 @@ def test_pypsa_import_overwrite_zero_s_nom(tmp_path):
     src.write_text(ZERO_RATE_CASE)
 
     bare = pypsa_mcp.import_case_from_any(str(src), str(tmp_path / "bare.nc"))
-    assert any("rating 0" in w for w in bare["warnings"]), bare["warnings"]
+    assert "POWERMCP.PYPSA.ZERO_BRANCH_RATING" in _diagnostic_codes(bare), bare
 
     out = tmp_path / "set.nc"
     r = pypsa_mcp.import_case_from_any(str(src), str(out), overwrite_zero_s_nom=100.0)
-    assert not any("rating 0" in w for w in r["warnings"]), r["warnings"]
+    assert "POWERMCP.PYPSA.ZERO_BRANCH_RATING_REPLACED" in _diagnostic_codes(r), r
+    assert "POWERMCP.PYPSA.ZERO_BRANCH_RATING" not in _diagnostic_codes(r), r
     assert (pypsa.Network(str(out)).lines.s_nom == 100.0).all()
 
 
@@ -615,9 +766,8 @@ def test_launch_powerio_runs_once(record_mcp_run):
     assert transport == "stdio"
 
 
-def test_inline_convert_stages_no_temp_files(monkeypatch):
-    # Inline conversion goes through powerio.convert_str entirely in memory;
-    # touching tempfile would be a regression to the old staging path.
+def test_inline_emit_stages_no_temp_files(monkeypatch):
+    # Text emission stays in memory when no destination is supplied.
     import tempfile
 
     def boom(*args, **kwargs):
@@ -625,8 +775,8 @@ def test_inline_convert_stages_no_temp_files(monkeypatch):
 
     monkeypatch.setattr(tempfile, "mkstemp", boom)
     monkeypatch.setattr(tempfile, "NamedTemporaryFile", boom)
-    r = powerio_mcp.convert(
-        to_format="psse", content=CASE9.read_text(), from_format="matpower"
+    r = powerio_mcp.emit(
+        format="psse", content=CASE9.read_text(), from_format="matpower"
     )
     assert r["text"]
 
@@ -711,26 +861,20 @@ def test_pandapower_pickle_input_is_rejected_without_execution(tmp_path):
     assert not marker.exists()
 
 
-def test_matrix_laplacian():
-    m = powerio_mcp.matrix("laplacian", path=str(CASE9))
+def test_calc_matrix_laplacian():
+    m = powerio_mcp.calc_matrix("laplacian", path=str(CASE9))
     assert m["format"] == "coo"
     assert m["shape"] == [9, 9]
 
 
-def test_matrix_bad_json_raises_valueerror():
+def test_calc_matrix_bad_json_raises_valueerror():
     with pytest.raises(ValueError):
-        powerio_mcp.matrix("bprime", json="{not valid json")
+        powerio_mcp.calc_matrix("bprime", json="{not valid json")
 
 
-def test_convert_oserror_normalizes_to_valueerror(monkeypatch):
-    # An OSError from convert_str (e.g. disk full) must surface as ValueError,
-    # not leak as a raw OSError.
-    def boom(content, to, from_):
-        raise OSError("disk full")
-
-    monkeypatch.setattr(powerio, "convert_str", boom)
+def test_emit_unknown_format_maps_cleanly():
     with pytest.raises(ValueError):
-        powerio_mcp.convert(to_format="psse", content="x", from_format="matpower")
+        powerio_mcp.emit(format="no-such-format", path=str(CASE9))
 
 
 def test_allowed_roots_rejects_read_outside_root(tmp_path, monkeypatch):
@@ -764,8 +908,8 @@ def test_allowed_roots_rejects_write_outside_root(tmp_path, monkeypatch):
     outside_out.parent.mkdir()
     monkeypatch.setenv("POWERIO_MCP_ALLOWED_ROOTS", str(root))
     with pytest.raises(ValueError, match="outside allowed MCP roots"):
-        powerio_mcp.save(
-            out_path=str(outside_out), content=CASE9.read_text(), to_format="psse"
+        powerio_mcp.emit(
+            destination=str(outside_out), content=CASE9.read_text(), format="psse"
         )
 
 
@@ -774,7 +918,7 @@ def test_allowed_roots_admits_write_inside_root(tmp_path, monkeypatch):
     root.mkdir()
     monkeypatch.setenv("POWERIO_MCP_ALLOWED_ROOTS", str(root))
     out = root / "case9.raw"
-    r = powerio_mcp.save(out_path=str(out), content=CASE9.read_text(), to_format="psse")
+    r = powerio_mcp.emit(destination=str(out), content=CASE9.read_text(), format="psse")
     assert r["path"] == str(out)
     assert out.exists()
 
@@ -792,27 +936,26 @@ def test_unreadable_file_maps_cleanly(tmp_path):
     locked.chmod(0o000)
     try:
         with pytest.raises(ValueError, match="cannot read input"):
-            powerio_mcp.convert(to_format="psse", path=str(locked))
+            powerio_mcp.emit(format="psse", path=str(locked))
         with pytest.raises(ValueError, match="cannot read input"):
-            powerio_mcp.summary(path=str(locked))
+            powerio_mcp.summarize(path=str(locked))
     finally:
         locked.chmod(0o644)
 
 
 def test_wrong_schema_json_maps_cleanly():
-    # Wrong-schema (but well-formed) JSON keeps the one error shape too; the
-    # malformed-JSON case is covered above. Pinned to the diagnostic code, since
-    # powerio 0.9.0 replaced the old "parse failed" prose with coded messages.
+    # Wrong schema but well formed JSON keeps the same coded ValueError shape;
+    # malformed JSON is covered above.
     for bad in ("{}", "[]", "null", '{"buses": "nope"}'):
         with pytest.raises(ValueError, match=r"PARSE\.SOURCE\.MALFORMED"):
-            powerio_mcp.matrix("bprime", json=bad, json_format="model-json")
+            powerio_mcp.calc_matrix("bprime", json=bad, json_format="model-json")
 
 
-def test_legacy_json_format_token_still_accepted():
-    # Responses state `model-json` since powerio 0.9, but the old `powerio-json`
-    # spelling stays valid as an input so an older client keeps working.
+def test_model_json_format_token_is_explicitly_accepted():
     transport = powerio_mcp.parse(path=str(CASE9))["json"]
-    m = powerio_mcp.matrix("bprime", json=transport, json_format="powerio-json")
+    m = powerio_mcp.calc_matrix(
+        "bprime", json=transport, json_format="model-json"
+    )
     assert m["shape"] == [9, 9]
 
 
@@ -842,6 +985,54 @@ def test_andes_load_network_from_json(tmp_path, andes_mcp):
     assert r["info"]["buses"] == 9
 
 
+def test_andes_preserves_powerio_error_codes(tmp_path, andes_mcp):
+    result = andes_mcp.load_network_from_json("{not JSON", str(tmp_path / "bad.m"))
+
+    assert result["status"] == "error"
+    assert result["code"] == "REQUEST.FORMAT.UNKNOWN"
+    assert "REQUEST.FORMAT.UNKNOWN" in result["message"]
+
+
+def test_andes_interchange_accepts_static_module(tmp_path, andes_mcp):
+    out = tmp_path / "case9_module.m"
+
+    result = andes_mcp.load_network_from_json(_diagnostic_module_json(), str(out))
+
+    _assert_structured_adapter_response(result)
+    assert out.is_file()
+
+
+def test_andes_requires_powerio_collection_export(tmp_path, andes_mcp):
+    parsed = json.loads(_module_json(powerio.parse_file(CASE9)))
+    collection_json = json.dumps(
+        {
+            "schema": "powerio.module",
+            "version": 1,
+            "producer": parsed["producer"],
+            "value": {
+                "kind": "balanced_network_scenario_set",
+                "data": {
+                    "scenarios": [
+                        {
+                            "id": "base",
+                            "probability": 1.0,
+                            "value": parsed["value"]["data"],
+                        }
+                    ]
+                },
+            },
+        }
+    )
+
+    rejected = andes_mcp.load_network_from_json(
+        collection_json, str(tmp_path / "unselected.m")
+    )
+
+    assert rejected["status"] == "error"
+    assert "list_states" in rejected["message"]
+    assert "export_state" in rejected["message"]
+
+
 def test_andes_load_missing_file(tmp_path, andes_mcp):
     r = andes_mcp.load_network_from_any("/nope/missing.m", str(tmp_path / "x.m"))
     assert r["status"] == "error"
@@ -852,18 +1043,17 @@ def test_andes_load_missing_file(tmp_path, andes_mcp):
 # pandapower-json plus folder and Parquet formats routed through generic verbs.
 # ---------------------------------------------------------------------------
 
-def test_convert_to_pandapower_json():
-    r = powerio_mcp.convert(to_format="pandapower-json", path=str(CASE9))
+def test_emit_to_pandapower_json():
+    r = powerio_mcp.emit(format="pandapower-json", path=str(CASE9))
     assert r["text"]
     assert json.loads(r["text"])  # well-formed JSON
 
 
 def test_pandapower_json_round_trips_through_transport():
-    # pandapower-json is a plain text format, so it flows through the existing
-    # save/parse tools with no dedicated tool.
+    # pandapower-json is a plain text format, so it flows through emit and parse.
     transport = powerio_mcp.parse(path=str(CASE9))["json"]
     out = powerio_mcp.parse(
-        content=powerio_mcp.convert(to_format="pandapower-json", path=str(CASE9))[
+        content=powerio_mcp.emit(format="pandapower-json", path=str(CASE9))[
             "text"
         ],
         from_format="pandapower-json",
@@ -873,11 +1063,9 @@ def test_pandapower_json_round_trips_through_transport():
 
 
 def test_pypsa_csv_folder_round_trip(tmp_path):
-    # pypsa-csv is a directory format: write through save(to_format="pypsa-csv"), read
-    # back through parse via a folder path (powerio 0.3.3 folded the dedicated
-    # read/write_pypsa_csv_folder tools into the bare verbs).
+    # pypsa-csv is a directory format: emit to a folder, then parse the folder.
     out_dir = tmp_path / "pypsa_csv"
-    w = powerio_mcp.save(to_format="pypsa-csv", out_path=str(out_dir), path=str(CASE9))
+    w = powerio_mcp.emit(format="pypsa-csv", destination=str(out_dir), path=str(CASE9))
     assert w["files"], w
     assert (out_dir / "buses.csv").exists()
     r = powerio_mcp.parse(path=str(out_dir))
@@ -888,7 +1076,7 @@ def test_pypsa_csv_folder_round_trip(tmp_path):
 def test_pypsa_csv_folder_accepts_transport(tmp_path):
     transport = powerio_mcp.parse(path=str(CASE9))["json"]
     out_dir = tmp_path / "from_json"
-    w = powerio_mcp.save(to_format="pypsa-csv", out_path=str(out_dir), json=transport)
+    w = powerio_mcp.emit(format="pypsa-csv", destination=str(out_dir), json=transport)
     assert (out_dir / "generators.csv").exists(), w
 
 
@@ -899,7 +1087,7 @@ def test_read_pypsa_csv_missing_folder_maps_cleanly(tmp_path):
 
 def test_gridfm_round_trip(tmp_path):
     out_dir = tmp_path / "gfm"
-    w = powerio_mcp.save(to_format="gridfm", out_path=str(out_dir), path=str(CASE9))
+    w = powerio_mcp.emit(format="gridfm", destination=str(out_dir), path=str(CASE9))
     assert w["files"], w
     r = powerio_mcp.parse(
         path=str(out_dir), from_format="gridfm", options={"scenario": 0}
@@ -996,10 +1184,10 @@ def test_powerio_to_opendss_composition(monkeypatch, tmp_path):
     configuration = _load_opendss_configuration(monkeypatch)
 
     dss_path = tmp_path / "feeder.dss"
-    save_result = powerio_mcp.save(
-        out_path=str(dss_path),
-        json=MINIMAL_BMOPF,
-        json_format="bmopf-json",
+    save_result = powerio_mcp.emit(
+        format="dss",
+        destination=str(dss_path),
+        path=str(OPENDSS_CASE),
     )
     assert save_result["path"] == str(dss_path)
     assert dss_path.exists()

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -5,10 +5,20 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
 
-WORKFLOW = (
-    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "publish.yml"
-).read_text(encoding="utf-8")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = (ROOT / ".github" / "workflows" / "publish.yml").read_text(
+    encoding="utf-8"
+)
+TEST_WORKFLOW = (ROOT / ".github" / "workflows" / "test.yml").read_text(
+    encoding="utf-8"
+)
+POWERIO_CANDIDATE = "e39afc9d669349df5133ff6140598010a498cdb1"
 
 
 def test_publish_workflow_actions_use_full_commit_shas():
@@ -29,3 +39,24 @@ def test_publish_requires_matching_version_and_published_release():
     assert '[[ "$TAG" != "v$version" ]]' in WORKFLOW
     assert "releases/tags/$TAG" in WORKFLOW
     assert "select(.draft == false and .prerelease == false)" in WORKFLOW
+
+
+def test_sdist_excludes_local_virtual_environments_and_build_caches():
+    with (ROOT / "pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle)
+    excluded = project["tool"]["hatch"]["build"]["targets"]["sdist"]["exclude"]
+    assert {".venv*", "**/.venv*", ".uv-build-cache", "**/.uv-build-cache"} <= set(
+        excluded
+    )
+
+
+def test_ci_installs_the_exact_powerio_candidate_before_powermcp():
+    direct_reference = (
+        "powerio[mcp,matrix] @ git+https://github.com/eigenergy/powerio.git@"
+        f"{POWERIO_CANDIDATE}"
+    )
+    candidate_install = TEST_WORKFLOW.index(direct_reference)
+    editable_install = TEST_WORKFLOW.index("python -m pip install -e . pytest")
+
+    assert candidate_install < editable_install
+    assert "Remove this step once PowerIO 1.0.0 is published on PyPI." in TEST_WORKFLOW

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+
 try:
     import tomllib
 except ModuleNotFoundError:  # Python 3.10
@@ -10,9 +11,8 @@ except ModuleNotFoundError:  # Python 3.10
 
 import pytest
 
-from powermcp import registry
-from powermcp import __version__
-from powermcp.registry import CORE, TOOLS, Tool
+from powermcp import __version__, registry
+from powermcp.registry import CORE, TOOLS
 
 
 def test_package_versions_match():
@@ -55,7 +55,17 @@ def test_closed_source_path_tools_declare_config_keys():
 def test_windows_only_flags():
     for name in ("psse", "pslf", "powerfactory", "pscad", "powerworld"):
         assert TOOLS[name].windows_only is True
-    for name in ("pandapower", "pypsa", "andes", "egret", "surge", "opendss", "hope", "ltspice"):
+    for name in (
+        "pandapower",
+        "pypsa",
+        "andes",
+        "egret",
+        "surge",
+        "opendss",
+        "hope",
+        "ltspice",
+        "tellegen",
+    ):
         assert TOOLS[name].windows_only is False
 
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -298,6 +298,7 @@ def test_staged_directory_write_preserves_unrelated_files(tmp_path):
     (output / "buses.csv").write_text("old")
 
     def write(staging):
+        pathlib.Path(staging).mkdir()
         path = pathlib.Path(staging) / "buses.csv"
         path.write_text("new")
         return {"dir": staging, "files": [str(path)]}

--- a/tests/test_solver_case.py
+++ b/tests/test_solver_case.py
@@ -1,30 +1,100 @@
-"""PowerIO's package model is the single case boundary used by solver tools."""
+"""The PowerIO module is the single case boundary used by solver tools."""
 
 from __future__ import annotations
 
+import ast
+import inspect
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import powerio
 import pytest
 
 from powermcp.sandbox import PathNotAllowed
-from powermcp.solver_case import _available_indexes, _index_inventory, resolve_solver_case
+from powermcp.solver_case import (
+    _available_positions,
+    diagnostic_record,
+    resolve_solver_case,
+)
 
 CASE9 = Path(__file__).parent / "data" / "case9.m"
+DSS_CASE = Path(__file__).parents[1] / "OpenDSS" / "13Bus" / "IEEE13Nodeckt.dss"
 
 
-def test_case_file_uses_powerio_package_validation(monkeypatch):
-    monkeypatch.setattr(
-        powerio,
-        "parse_file",
-        lambda *args, **kwargs: pytest.fail("use Package.from_file for case inputs"),
+def _module_json(module: powerio.PioModule) -> str:
+    return module.emit("pio-json").text
+
+
+def _parse_module(text: str) -> powerio.PioModule:
+    return powerio.parse_text(text, name="module.pio.json")
+
+
+def _scenario_module_json() -> str:
+    parsed = json.loads(_module_json(powerio.parse_file(CASE9)))
+    return json.dumps(
+        {
+            "schema": "powerio.module",
+            "version": 1,
+            "producer": parsed["producer"],
+            "value": {
+                "kind": "balanced_network_scenario_set",
+                "data": {
+                    "scenarios": [
+                        {
+                            "id": "base",
+                            "probability": 0.75,
+                            "value": parsed["value"]["data"],
+                        },
+                        {
+                            "id": "peak",
+                            "probability": 0.25,
+                            "value": parsed["value"]["data"],
+                        },
+                    ]
+                },
+            },
+        }
     )
+
+
+def _legacy_09_module_json() -> str:
+    """The published 0.9 wire that PowerIO upgrades one way on read."""
+    network = json.loads(powerio.parse_file(CASE9).value.to_json())
+    return json.dumps(
+        {
+            "powerio_version": "0.9.0",
+            "producer": {"tool": "powerio", "version": "0.9.0"},
+            "model_kind": "balanced",
+            "model": {"kind": "balanced", "balanced_network": network},
+            "origin": {"kind": "in_memory"},
+            "validation": {"status": "ok", "counts": {}},
+        }
+    )
+
+
+def test_case_file_uses_parse_file_and_keeps_the_module(monkeypatch):
+    original = powerio.parse_file
+    calls = []
+
+    def recording_parse_file(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(powerio, "parse_file", recording_parse_file)
     resolved = resolve_solver_case(file_path=str(CASE9))
 
+    assert calls == [((str(CASE9),), {"format": None})]
+    assert resolved.module.kind == "balanced_network"
+    assert resolved.module.value.n_buses == 9
     assert resolved.network.n_buses == 9
-    assert resolved.package is None
+
+
+def test_retained_module_emits_the_original_source():
+    resolved = resolve_solver_case(file_path=str(CASE9))
+
+    assert resolved.module.emit("matpower").text.encode() == CASE9.read_bytes()
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
@@ -34,7 +104,7 @@ def test_directory_case_refuses_a_symlinked_descendant_outside_roots(
     root = tmp_path / "allowed"
     root.mkdir()
     dataset = root / "dataset"
-    powerio.parse_file(CASE9).write_pypsa_csv_folder(dataset)
+    powerio.parse_file(CASE9).emit("pypsa-csv", dataset)
     outside = tmp_path / "outside-buses.csv"
     (dataset / "buses.csv").replace(outside)
     (dataset / "buses.csv").symlink_to(outside)
@@ -44,49 +114,189 @@ def test_directory_case_refuses_a_symlinked_descendant_outside_roots(
         resolve_solver_case(file_path=str(dataset), source_format="pypsa-csv")
 
 
-def test_package_file_preserves_auditable_context(tmp_path):
-    package = powerio.Package.from_file(CASE9)
-    document = json.loads(package.to_json())
-    document["package_id"] = "dispatch-input"
+def test_stored_module_file_preserves_auditable_context(tmp_path):
     source = tmp_path / "case.pio.json"
+    document = json.loads(_module_json(powerio.parse_file(CASE9)))
     source.write_text(json.dumps(document))
 
     resolved = resolve_solver_case(file_path=str(source))
 
     assert resolved.network.n_buses == 9
-    assert resolved.package["package_id"] == "dispatch-input"
-    assert resolved.package["validation"]["status"] == "ok"
-    assert resolved.package["source_map_entries"] > 0
+    emitted = json.loads(_module_json(resolved.module))
+    assert emitted["schema"] == "powerio.module"
+    assert emitted["version"] == 1
+    assert resolved.module.kind == "balanced_network"
+    assert emitted["sources"]
+    assert document.get("source_map")
+    assert any(entry.get("target") == "" for entry in document["source_map"])
+    assert emitted["source_map"] == document["source_map"]
 
 
-def test_package_validation_is_recomputed_after_deserialization():
-    document = json.loads(powerio.Package.from_file(CASE9).to_json())
-    network = document["model"]["balanced_network"]
+def test_explicit_pio_json_format_preserves_context_without_json_suffix(tmp_path):
+    source = tmp_path / "case.data"
+    source.write_text(_module_json(powerio.parse_file(CASE9)))
+
+    resolved = resolve_solver_case(file_path=str(source), source_format="pio-json")
+
+    assert resolved.network.n_buses == 9
+    assert resolved.module.kind == "balanced_network"
+    assert json.loads(_module_json(resolved.module))["schema"] == "powerio.module"
+
+
+def test_stored_module_validation_runs_while_decoding():
+    document = json.loads(_module_json(powerio.parse_file(CASE9)))
+    network = document["value"]["data"]
     network["buses"][1]["id"] = network["buses"][0]["id"]
-    assert document["validation"]["status"] == "ok"
 
     with pytest.raises(ValueError, match="fails validation"):
         resolve_solver_case(network_json=json.dumps(document))
 
 
-@pytest.mark.parametrize(
-    ("field", "empty_value"),
-    [
-        (
-            "operating_points",
-            {"time_axis": {"periods": 0, "labels": []}, "points": []},
-        ),
-        ("study", {"label": "empty study", "commits": []}),
-    ],
-)
-def test_empty_package_state_metadata_remains_a_static_case(field, empty_value):
-    document = json.loads(powerio.Package.from_file(CASE9).to_json())
-    document[field] = empty_value
+def test_module_diagnostics_remain_structured_and_ordered():
+    document = json.loads(_module_json(powerio.parse_file(CASE9)))
+    document["diagnostics"] = [
+        {
+            "id": "d0",
+            "code": "READ.TEST.FIELD",
+            "severity": "warning",
+            "message": "test finding",
+            "target": "/buses/0",
+            "details": {"field": "vm"},
+        }
+    ]
 
     resolved = resolve_solver_case(network_json=json.dumps(document))
 
+    assert resolved.diagnostics == (
+        {
+            "code": "READ.TEST.FIELD",
+            "severity": "warning",
+            "message": "test finding",
+            "id": "d0",
+            "target": "/buses/0",
+            "details": {"field": "vm"},
+        },
+    )
+    assert len(resolved.module.diagnostics) == 1
+
+
+def test_diagnostic_record_keeps_spans_related_and_details():
+    diagnostic = SimpleNamespace(
+        code="READ.TEST.SPAN",
+        severity="remark",
+        message="located finding",
+        id="d1",
+        target=None,
+        suggested_action="inspect the source",
+        related=["d0"],
+        spans=[SimpleNamespace(source="s0", byte_start=4, byte_end=9)],
+        details={"column": 3},
+    )
+
+    assert diagnostic_record(diagnostic) == {
+        "code": "READ.TEST.SPAN",
+        "severity": "remark",
+        "message": "located finding",
+        "id": "d1",
+        "suggested_action": "inspect the source",
+        "related": ["d0"],
+        "spans": [{"source": "s0", "byte_start": 4, "byte_end": 9}],
+        "details": {"column": 3},
+    }
+
+
+def test_collection_requires_powerio_list_and_export():
+    module_json = _scenario_module_json()
+
+    with pytest.raises(ValueError) as excinfo:
+        resolve_solver_case(network_json=module_json)
+
+    message = str(excinfo.value)
+    assert "list_states" in message
+    assert "export_state" in message
+    assert "['base', 'peak']" in message
+
+
+def test_exported_collection_state_crosses_the_solver_boundary():
+    collection = _parse_module(_scenario_module_json())
+    exported = collection.export_state(scenario="peak")
+
+    resolved = resolve_solver_case(network_json=_module_json(exported))
+
+    assert resolved.module.kind == "balanced_network"
     assert resolved.network.n_buses == 9
-    assert "materialized" not in resolved.package
+    assert json.loads(_module_json(resolved.module))["history"]
+
+
+def test_published_09_wire_upgrades_without_the_removed_package_api():
+    resolved = resolve_solver_case(network_json=_legacy_09_module_json())
+
+    assert resolved.module.kind == "balanced_network"
+    emitted = json.loads(_module_json(resolved.module))
+    assert emitted["schema"] == "powerio.module"
+    assert emitted["version"] == 1
+
+
+def test_powerio_owns_rejection_of_pre_09_stored_documents():
+    legacy = json.dumps(
+        {
+            "schema_version": "0.2.1",
+            "model_kind": "balanced",
+            "model": {"kind": "balanced"},
+        }
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        resolve_solver_case(network_json=legacy)
+
+    message = str(excinfo.value)
+    assert "powerio_version" in message
+    assert "pre 0.9 lineage" in message
+
+
+def test_model_json_uses_the_same_public_parse_route():
+    model_json = powerio.parse_file(CASE9).value.to_json()
+
+    resolved = resolve_solver_case(network_json=model_json)
+
+    assert resolved.module.kind == "balanced_network"
+
+
+def test_json_inputs_are_not_classified_by_powermcp(monkeypatch):
+    original = powerio.parse_text
+    calls = []
+
+    def recording_parse_text(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(powerio, "parse_text", recording_parse_text)
+    inputs = (
+        _module_json(powerio.parse_file(CASE9)),
+        _legacy_09_module_json(),
+        powerio.parse_file(CASE9).value.to_json(),
+    )
+
+    for text in inputs:
+        assert resolve_solver_case(network_json=text).module.kind == "balanced_network"
+
+    assert calls == [
+        ((text,), {"format": None, "name": "solver-input.json"}) for text in inputs
+    ]
+
+
+def test_powerio_parse_error_type_crosses_the_solver_boundary():
+    with pytest.raises(powerio.PowerIOError) as error:
+        resolve_solver_case(network_json="{not JSON")
+
+    assert error.value.code == "REQUEST.FORMAT.UNKNOWN"
+
+
+def test_multiconductor_module_requires_explicit_powerio_lowering():
+    module_json = _module_json(powerio.parse_file(DSS_CASE))
+
+    with pytest.raises(ValueError, match=r"PioModule\.to_balanced\(\)"):
+        resolve_solver_case(network_json=module_json)
 
 
 def test_exactly_one_interchange_input_is_required():
@@ -96,23 +306,58 @@ def test_exactly_one_interchange_input_is_required():
         resolve_solver_case(file_path="case.m", network_json="{}")
 
 
-def test_large_state_inventory_is_compact():
-    indexes = list(range(8760))
+def test_solver_boundary_exposes_no_collection_selector_aliases():
+    parameters = inspect.signature(resolve_solver_case).parameters
 
-    assert _available_indexes(indexes) == "0..8759 (8760 available)"
-    assert _index_inventory(indexes) == {
-        "count": 8760,
-        "first": 0,
-        "last": 8759,
+    assert "operating_point" not in parameters
+    assert "study_commit" not in parameters
+    assert "time_position" not in parameters
+    assert "scenario" not in parameters
+
+
+def test_solver_adapter_schemas_expose_no_collection_selector_aliases():
+    root = Path(__file__).parents[1]
+    adapters = {
+        "PyPSA/pypsa_mcp.py": {"import_case_from_any", "import_case_from_json"},
+        "pandapower/panda_mcp.py": {
+            "load_network_from_any",
+            "load_network_from_json",
+        },
+        "ANDES/andes_mcp.py": {"load_network_from_any", "load_network_from_json"},
+        "Egret/egret_mcp.py": {"load_model_from_any", "load_model_from_json"},
     }
+    retired = {"operating_point", "study_commit", "time_position", "scenario"}
+
+    for relative, names in adapters.items():
+        tree = ast.parse((root / relative).read_text(encoding="utf-8"))
+        functions = {
+            node.name: node
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        assert names <= functions.keys()
+        for name in names:
+            arguments = functions[name].args
+            parameters = {
+                arg.arg
+                for arg in [
+                    *arguments.posonlyargs,
+                    *arguments.args,
+                    *arguments.kwonlyargs,
+                ]
+            }
+            assert parameters.isdisjoint(retired), (relative, name, parameters)
 
 
-def test_sparse_large_state_indexes_do_not_materialize_the_range():
-    indexes = [*range(20), 1_000_000_000]
+def test_large_time_position_inventory_is_compact():
+    assert _available_positions(list(range(8760))) == "0..8759 (8760 available)"
 
-    assert _available_indexes(indexes) == (
-        "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...] "
-        "(21 available; last 1000000000)"
+
+def test_sparse_large_time_positions_do_not_materialize_the_range():
+    positions = [*range(20), 1_000_000_000]
+
+    assert _available_positions(positions) == (
+        "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...] (21 available; last 1000000000)"
     )
 
 

--- a/tests/test_tellegen_server.py
+++ b/tests/test_tellegen_server.py
@@ -1,0 +1,362 @@
+"""Tellegen's three tool PowerIO module adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import powerio
+import pytest
+
+from powermcp import config as cfg
+from powermcp.registry import TOOLS
+
+_TELLEGEN_DIR = str(TOOLS["tellegen"].resolve_server_dir())
+if _TELLEGEN_DIR not in sys.path:
+    sys.path.insert(0, _TELLEGEN_DIR)
+
+import tellegen_mcp
+
+CASE9 = Path(__file__).with_name("data") / "case9.m"
+BINARY = os.environ.get("POWERMCP_TELLEGEN_BINARY")
+needs_binary = pytest.mark.skipif(not BINARY, reason="POWERMCP_TELLEGEN_BINARY not set")
+
+
+def _contract() -> dict[str, Any]:
+    module_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["schema", "version", "producer", "value"],
+        "properties": {
+            "schema": {"const": "powerio.module"},
+            "version": {"const": 1},
+            "producer": {"type": "object"},
+            "value": {"type": "object"},
+        },
+        "additionalProperties": True,
+    }
+    spec_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["objective", "candidates", "exact_solve_budget"],
+        "properties": {
+            "objective": {"type": "object"},
+            "candidates": {"type": "array", "items": {"type": "string"}},
+            "exact_solve_budget": {"type": "integer", "minimum": 1},
+        },
+        "additionalProperties": True,
+    }
+    plan_request = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "StoredModuleV1": module_schema,
+            "CapacityPlanSpec": spec_schema,
+        },
+        "type": "object",
+        "required": ["module", "spec"],
+        "properties": {
+            "module": {"$ref": "#/$defs/StoredModuleV1"},
+            "spec": {"$ref": "#/$defs/CapacityPlanSpec"},
+        },
+        "additionalProperties": False,
+    }
+    plan_response = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {"StoredModuleV1": module_schema},
+        "type": "object",
+        "required": ["plan", "solution_module"],
+        "properties": {
+            "plan": {"type": "object"},
+            "solution_module": {"$ref": "#/$defs/StoredModuleV1"},
+        },
+        "additionalProperties": False,
+    }
+    return {
+        "contract": "tellegen.cli/1",
+        "tellegen_version": "0.1.0-test",
+        "powerio_version": "1.0.0-test",
+        "schemas": {
+            "powerio_module": module_schema,
+            "capacity_plan_spec": spec_schema,
+            "plan_request": plan_request,
+            "plan_response": plan_response,
+            "solve_response": module_schema,
+            "capabilities_response": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "array",
+                "items": {"type": "object"},
+            },
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def generated_contract(tmp_path, monkeypatch):
+    path = tmp_path / "tellegen-contract.json"
+    path.write_text(json.dumps(_contract()), encoding="utf-8")
+    monkeypatch.setattr(tellegen_mcp, "_CONTRACT_PATH", path)
+
+
+def _module(kind: str = "balanced_network") -> dict[str, Any]:
+    return {
+        "schema": "powerio.module",
+        "version": 1,
+        "producer": {"name": "test", "version": "1"},
+        "value": {"kind": kind, "data": {}},
+    }
+
+
+def _spec() -> dict[str, Any]:
+    return {
+        "objective": {
+            "kind": "weighted_lmp",
+            "weights": [{"bus": 1, "weight": 1.0}],
+        },
+        "candidates": ["branches:0"],
+        "exact_solve_budget": 1,
+    }
+
+
+async def _listed_tools():
+    entry = tellegen_mcp.mcp.get_request_handler("tools/list")
+    assert entry is not None
+    return (await entry.handler(None, None)).tools
+
+
+def test_registry_entry():
+    tool = TOOLS["tellegen"]
+    assert tool.kind == "open-source"
+    assert tool.windows_only is False
+    assert tool.run_kind == "script"
+    assert tool.resolve_entry_script().is_file()
+    assert tool.extra == "tellegen"
+    assert [key.key for key in tool.config_keys] == ["binary"]
+    assert tool.config_keys[0].validate == "file"
+
+
+def test_env_var_resolves_binary(isolated_config, monkeypatch, tmp_path):
+    binary = tmp_path / "tellegen"
+    binary.write_text("", encoding="utf-8")
+    monkeypatch.setenv("POWERMCP_TELLEGEN_BINARY", str(binary))
+    assert cfg.get_path("tellegen", "binary") == str(binary)
+
+
+def test_unconfigured_binary_raises_config_error(isolated_config):
+    with pytest.raises(cfg.ConfigError, match="tellegen.binary"):
+        cfg.get_path("tellegen", "binary")
+
+
+def test_server_registers_only_the_three_contract_tools():
+    tools = asyncio.run(_listed_tools())
+    assert [tool.name for tool in tools] == [
+        "capabilities",
+        "solve_dc_opf",
+        "plan_capacity",
+    ]
+    assert not {"replay_experiment", "approve_experiment"} & {
+        tool.name for tool in tools
+    }
+
+    solve = next(tool for tool in tools if tool.name == "solve_dc_opf")
+    assert set(solve.input_schema["properties"]) == {"module"}
+    plan = next(tool for tool in tools if tool.name == "plan_capacity")
+    assert plan.input_schema == _contract()["schemas"]["plan_request"]
+
+    for tool in tools:
+        assert tool.output_schema is not None
+        jsonschema.Draft202012Validator(tool.output_schema).validate(
+            {"status": "error", "message": "failed"}
+        )
+
+
+def test_contract_comparison_preserves_json_scalar_types():
+    assert tellegen_mcp._canonical_json({"default": True}) != (
+        tellegen_mcp._canonical_json({"default": 1})
+    )
+    assert tellegen_mcp._canonical_json({"default": 60}) != (
+        tellegen_mcp._canonical_json({"default": 60.0})
+    )
+
+
+def test_contract_is_checked_again_for_the_same_binary(monkeypatch):
+    calls = []
+
+    async def fake_run(binary, args, stdin_text, **_kwargs):
+        calls.append((binary, args, stdin_text))
+        return json.dumps(_contract())
+
+    monkeypatch.setattr(tellegen_mcp, "_run_process", fake_run)
+    asyncio.run(tellegen_mcp._verify_contract("tellegen", _contract()))
+    asyncio.run(tellegen_mcp._verify_contract("tellegen", _contract()))
+    assert calls == [
+        ("tellegen", ["contract"], ""),
+        ("tellegen", ["contract"], ""),
+    ]
+
+
+def test_contract_mismatch_is_refused(monkeypatch):
+    actual = _contract()
+    actual["powerio_version"] = "different"
+
+    async def fake_run(_binary, _args, _stdin, **_kwargs):
+        return json.dumps(actual)
+
+    monkeypatch.setattr(tellegen_mcp, "_run_process", fake_run)
+    with pytest.raises(RuntimeError, match="does not match"):
+        asyncio.run(tellegen_mcp._verify_contract("tellegen", _contract()))
+
+
+def test_success_results_are_the_raw_generated_values(monkeypatch):
+    solution = _module("dc_opf_solution")
+    capability_rows = [{"formulation": "dcopf", "available": True}]
+    planned = {"plan": {"proposal": []}, "solution_module": solution}
+
+    async def fake_run(args, _stdin):
+        if args == ["capabilities"]:
+            return json.dumps(capability_rows)
+        if args == ["solve-module"]:
+            return json.dumps(solution)
+        if args == ["plan"]:
+            return json.dumps(planned)
+        raise AssertionError(args)
+
+    monkeypatch.setattr(tellegen_mcp, "_run_tellegen", fake_run)
+
+    capabilities = asyncio.run(tellegen_mcp.capabilities())
+    solved = asyncio.run(tellegen_mcp.solve_dc_opf(_module()))
+    plan = asyncio.run(tellegen_mcp.plan_capacity(_module(), _spec()))
+
+    assert capabilities["results"] == capability_rows
+    assert solved["results"] == solution
+    assert plan["results"] == planned
+    assert "capabilities" not in capabilities["results"][0]
+    assert "solution_module" not in solved["results"]
+
+
+def test_cli_powerio_error_text_is_not_reclassified(monkeypatch):
+    message = "tellegen: invalid stored module: STORE.VERSION_UNSUPPORTED"
+
+    async def fake_run(_args, _stdin):
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(tellegen_mcp, "_run_tellegen", fake_run)
+    result = asyncio.run(tellegen_mcp.solve_dc_opf(_module()))
+    assert result == {"status": "error", "message": f"solve_dc_opf failed: {message}"}
+
+
+def test_cancelled_process_is_terminated(monkeypatch):
+    processes = []
+    create = asyncio.create_subprocess_exec
+
+    async def recording_create(*args, **kwargs):
+        process = await create(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", recording_create)
+
+    async def run():
+        task = asyncio.create_task(
+            tellegen_mcp._run_process(
+                sys.executable,
+                ["-c", "import time; time.sleep(30)"],
+                "",
+            )
+        )
+        while not processes:
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert processes[0].returncode is not None
+
+    asyncio.run(run())
+
+
+def test_timed_out_process_is_terminated(monkeypatch):
+    processes = []
+    create = asyncio.create_subprocess_exec
+
+    async def recording_create(*args, **kwargs):
+        process = await create(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", recording_create)
+
+    async def run():
+        with pytest.raises(tellegen_mcp.TellegenTimeout, match="0.05 s timeout"):
+            await tellegen_mcp._run_process(
+                sys.executable,
+                ["-c", "import time; time.sleep(30)"],
+                "",
+                timeout_s=0.05,
+            )
+        assert processes[0].returncode is not None
+
+    asyncio.run(run())
+
+
+@needs_binary
+def test_runtime_contract_matches_the_bundled_artifact(monkeypatch):
+    monkeypatch.setattr(
+        tellegen_mcp,
+        "_CONTRACT_PATH",
+        Path(tellegen_mcp.__file__).with_name("tellegen-contract.json"),
+    )
+    assert BINARY is not None
+    asyncio.run(
+        tellegen_mcp._verify_contract(
+            BINARY,
+            tellegen_mcp._load_contract_artifact(),
+        )
+    )
+
+
+@needs_binary
+def test_runtime_commands_return_the_generated_raw_shapes(monkeypatch):
+    monkeypatch.setattr(
+        tellegen_mcp,
+        "_CONTRACT_PATH",
+        Path(tellegen_mcp.__file__).with_name("tellegen-contract.json"),
+    )
+    module = json.loads(powerio.parse_file(CASE9).emit("pio-json").text)
+    spec = {
+        "objective": {
+            "kind": "weighted_lmp",
+            "weights": [{"bus": 1, "weight": 1.0}],
+        },
+        "candidates": ["branches:0"],
+        "max_increase_per_branch_mw": 10.0,
+        "budget_mw": 10.0,
+        "increment_mw": 5.0,
+        "max_changed_lines": 1,
+        "exact_solve_budget": 1,
+    }
+
+    capability_result = asyncio.run(tellegen_mcp.capabilities())
+    solve_result = asyncio.run(tellegen_mcp.solve_dc_opf(module))
+    plan_result = asyncio.run(tellegen_mcp.plan_capacity(module, spec))
+
+    assert capability_result["status"] == "success"
+    assert isinstance(capability_result["results"], list)
+    assert solve_result["status"] == "success", solve_result["message"]
+    assert solve_result["results"]["value"]["kind"] == "dc_opf_solution"
+    assert plan_result["status"] == "success", plan_result["message"]
+    assert set(plan_result["results"]) == {"plan", "solution_module"}
+    assert plan_result["results"]["solution_module"]["value"]["kind"] == (
+        "dc_opf_solution"
+    )
+
+    _inputs, outputs = tellegen_mcp._tool_schemas()
+    for name, result in (
+        ("capabilities", capability_result),
+        ("solve_dc_opf", solve_result),
+        ("plan_capacity", plan_result),
+    ):
+        jsonschema.Draft202012Validator(outputs[name]).validate(result)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,18 +1,7 @@
-"""The powerio server driven the way a model drives it: over stdio, through
-the MCP SDK.
+"""Exercise PowerIO's MCP server through the real stdio transport.
 
-Every other powerio test calls the tool functions in process, which skips the
-SDK's argument handling entirely. That gap hid a real defect: the SDK rewrites
-a string argument whose text parses as JSON into the parsed object before
-validation, which destroyed every `json` / `content` / `package_json` argument
-carrying JSON before the tool saw it. powerio 0.9.0 annotates those arguments as
-bare `str` on its registered tools, which is what stops the rewriting, and the
-tests below are what hold it closed. Nothing in an in-process suite can see any
-of this, which is why this file drives the real transport.
-
-Launching through `python -m powermcp run powerio` also covers the runner and
-registry wiring end to end, so a broken launch fails here rather than only for
-a user.
+The in process consumer tests bypass SDK argument handling. These tests cover
+the runner, registry entry, MCP schemas, and JSON text transport together.
 """
 
 from __future__ import annotations
@@ -24,24 +13,27 @@ import sys
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
-pytest.importorskip("powerio", minversion="0.9.0")
+powerio = pytest.importorskip("powerio")
+assert Version("1.0.0") <= Version(powerio.__version__) < Version("2.0.0")
 
 from mcp import ClientSession, StdioServerParameters  # noqa: E402
 from mcp.client.stdio import stdio_client  # noqa: E402
 
 CASE9 = Path(__file__).resolve().parent / "data" / "case9.m"
-
-# The SDK waits forever by default, so a server that starts and then blocks
-# would hang the suite with nothing to fail it.
 TIMEOUT = 60.0
+LOWERABLE_DSS = """Clear
+Set DefaultBaseFrequency=60
+New Circuit.tiny basekv=12.47 pu=1.0 phases=3 bus1=src MVAsc3=2000 MVAsc1=2100
+New Transformer.t1 phases=3 windings=2 buses=(src, sec) conns=(delta, wye) kvs=(12.47, 0.416) kvas=(500, 300) %Rs=(0.5, 0.5) xhl=6
+New Load.l1 bus1=sec phases=3 conn=wye kv=0.416 kw=90 pf=0.95 model=1
+Set VoltageBases=[12.47, 0.416]
+"""
 
 
 def _run(steps):
-    """Drive one stdio session, returning whatever ``steps`` returns.
-
-    ``steps`` is an async callable taking the initialized session.
-    """
+    """Drive one initialized stdio session and return the step result."""
 
     async def go():
         params = StdioServerParameters(
@@ -51,7 +43,6 @@ def _run(steps):
         )
         async with stdio_client(params) as (read, write):
             async with ClientSession(read, write, read_timeout_seconds=TIMEOUT) as session:
-                # wait_for rather than asyncio.timeout: this runs on 3.10 too.
                 await asyncio.wait_for(session.initialize(), TIMEOUT)
                 return await steps(session)
 
@@ -63,82 +54,212 @@ def _payload(result):
     return json.loads(result.content[0].text)
 
 
-def test_launch_serves_the_canonical_tool_surface():
+def test_launch_serves_the_powerio_1_tool_surface():
     async def steps(session):
-        return sorted(t.name for t in (await session.list_tools()).tools)
+        return sorted(tool.name for tool in (await session.list_tools()).tools)
 
-    required = {
-        "convert",
+    assert set(_run(steps)) == {
+        "about",
+        "calc_matrix",
         "diagnostics",
         "display",
-        "matrix",
-        "normalize",
+        "emit",
+        "export_state",
+        "inspect",
+        "inspect_state",
+        "list_states",
         "parse",
-        "save",
-        "summary",
+        "summarize",
+        "to_balanced",
+        "to_balanced_report",
+        "to_normalized",
     }
-    assert required <= set(_run(steps))
 
 
 def test_a_path_argument_survives_the_transport():
     async def steps(session):
-        return _payload(await session.call_tool("summary", {"path": str(CASE9)}))
+        return _payload(await session.call_tool("summarize", {"path": str(CASE9)}))
 
     summary = _run(steps)
-    assert summary["schema"] == "powerio.summary"
+    assert summary["schema"] == "powerio.summarize"
     assert summary["elements"]["buses"] == 9
+    assert isinstance(summary["diagnostics"], list)
 
 
 def test_non_json_content_survives_the_transport():
-    # MATPOWER text does not parse as JSON, so the SDK leaves it alone. This is
-    # the control for the two JSON carrying cases below.
     async def steps(session):
         return _payload(
             await session.call_tool(
-                "convert",
+                "emit",
                 {
-                    "to_format": "psse",
+                    "format": "psse",
                     "content": CASE9.read_text(),
                     "from_format": "matpower",
                 },
             )
         )
 
-    assert _run(steps)["text"]
+    result = _run(steps)
+    assert result["text"]
+    assert isinstance(result["diagnostics"], list)
 
 
-def test_the_json_transport_round_trips_over_the_transport():
-    # Recorded the SDK rewriting a string that parses as JSON, which made every
-    # argument not annotated exactly `str` unusable. powerio 0.9.0's bare `str`
-    # annotations close it for every mcp 2.x, so this now asserts the round trip.
+def test_model_json_round_trips_over_the_transport():
     async def steps(session):
         parsed = _payload(await session.call_tool("parse", {"path": str(CASE9)}))
         assert parsed["json_format"] == "model-json"
         return _payload(
             await session.call_tool(
-                "summary", {"json": parsed["json"], "json_format": "model-json"}
+                "summarize",
+                {"json": parsed["json"], "json_format": "model-json"},
             )
         )
 
     assert _run(steps)["elements"]["buses"] == 9
 
 
-def test_the_package_transport_reaches_summary_over_the_transport():
-    # Same SDK rewriting as above. `diagnostics` always took `package_json` as a
-    # required bare `str`, so it kept working while `summary` refused the same
-    # package text; both take it now.
+def test_json_shaped_content_survives_the_transport():
+    async def steps(session):
+        emitted = _payload(
+            await session.call_tool(
+                "emit", {"format": "pandapower-json", "path": str(CASE9)}
+            )
+        )
+        return _payload(
+            await session.call_tool(
+                "parse",
+                {
+                    "content": emitted["text"],
+                    "from_format": "pandapower-json",
+                    "transport": "module",
+                },
+            )
+        )
+
+    parsed = _run(steps)
+    assert parsed["transport"] == "module"
+    assert parsed["summary"]["elements"]["buses"] == 9
+
+
+def test_module_transport_reaches_module_tools_and_emit():
     async def steps(session):
         parsed = _payload(
             await session.call_tool(
-                "parse", {"path": str(CASE9), "transport": "package"}
+                "parse", {"path": str(CASE9), "transport": "module"}
             )
         )
-        package = parsed["package_json"]
-        assert not (
-            await session.call_tool("diagnostics", {"package_json": package})
-        ).is_error
-        return _payload(
-            await session.call_tool("summary", {"package_json": package})
+        module_json = parsed["module_json"]
+        inspected = _payload(
+            await session.call_tool("inspect", {"module_json": module_json})
         )
+        diagnosed = _payload(
+            await session.call_tool("diagnostics", {"module_json": module_json})
+        )
+        emitted = _payload(
+            await session.call_tool(
+                "emit", {"format": "matpower", "module_json": module_json}
+            )
+        )
+        return parsed, inspected, diagnosed, emitted
 
-    assert _run(steps)["elements"]["buses"] == 9
+    parsed, inspected, diagnosed, emitted = _run(steps)
+    assert parsed["transport"] == "module"
+    assert parsed["json_format"] == "module"
+    assert inspected["kind"] == "balanced_network"
+    assert diagnosed["model_kind"] == "balanced"
+    assert isinstance(diagnosed["diagnostics"], list)
+    assert emitted["text"]
+
+
+def test_collection_discovery_and_export_round_trip_over_transport():
+    async def steps(session):
+        parsed = _payload(
+            await session.call_tool(
+                "parse", {"path": str(CASE9), "transport": "module"}
+            )
+        )
+        base = json.loads(parsed["module_json"])
+        collection_json = json.dumps(
+            {
+                "schema": "powerio.module",
+                "version": 1,
+                "producer": base["producer"],
+                "value": {
+                    "kind": "balanced_network_scenario_set",
+                    "data": {
+                        "scenarios": [
+                            {
+                                "id": "base",
+                                "probability": 1.0,
+                                "value": base["value"]["data"],
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+        listed = _payload(
+            await session.call_tool(
+                "list_states", {"module_json": collection_json}
+            )
+        )
+        inspected = _payload(
+            await session.call_tool(
+                "inspect_state",
+                {"module_json": collection_json, "scenario": "base"},
+            )
+        )
+        exported = _payload(
+            await session.call_tool(
+                "export_state",
+                {"module_json": collection_json, "scenario": "base"},
+            )
+        )
+        summary = _payload(
+            await session.call_tool(
+                "summarize", {"module_json": exported["module_json"]}
+            )
+        )
+        return listed, inspected, exported, summary
+
+    listed, inspected, exported, summary = _run(steps)
+    assert listed["keyed_by"] == "scenario"
+    assert listed["scenarios"] == [{"id": "base", "probability": 1.0}]
+    assert inspected["selected"]["item"] == "balanced_network"
+    assert exported["kind"] == "balanced_network"
+    assert summary["elements"]["buses"] == 9
+
+
+def test_balanced_lowering_round_trips_over_transport():
+    async def steps(session):
+        parsed = _payload(
+            await session.call_tool(
+                "parse",
+                {
+                    "content": LOWERABLE_DSS,
+                    "from_format": "dss",
+                    "transport": "module",
+                },
+            )
+        )
+        module_json = parsed["module_json"]
+        report = _payload(
+            await session.call_tool(
+                "to_balanced_report", {"module_json": module_json}
+            )
+        )
+        lowered = _payload(
+            await session.call_tool("to_balanced", {"module_json": module_json})
+        )
+        summary = _payload(
+            await session.call_tool(
+                "summarize", {"module_json": lowered["module_json"]}
+            )
+        )
+        return report, lowered, summary
+
+    report, lowered, summary = _run(steps)
+    assert report["ready"] is True
+    assert isinstance(report["diagnostics"], list)
+    assert lowered["kind"] == "balanced_network"
+    assert summary["domain"] == "transmission"

--- a/tests/test_vendor_import.py
+++ b/tests/test_vendor_import.py
@@ -46,11 +46,11 @@ def test_psse_import_side_effect_free_then_inits_once(monkeypatch):
 
 
 def test_plexosdb_import_side_effect_free(monkeypatch):
-    """plexosdb_mcp.main is an always-imports thin re-export (like powerio_mcp.py),
-    not a lazy _ensure_*() style module -- so "side-effect-free" here means the
-    module builds its FastMCP server using only the (mocked) upstream
-    plexosdb_mcp.server factory, with no real plexosdb database opened, no
-    PLEXOS XML touched, and no PLEXOS license required.
+    """plexosdb_mcp.main is an eager thin re-export, not a lazy _ensure_*()
+    style module -- so "side-effect-free" here means the module builds its
+    FastMCP server using only the (mocked) upstream plexosdb_mcp.server factory,
+    with no real plexosdb database opened, no PLEXOS XML touched, and no PLEXOS
+    license required.
 
     plexosdb_mcp is a package name shared with the upstream ``plexosdb-mcp``
     distribution PowerMCP re-exports (see the registry's "plexosdb" entry


### PR DESCRIPTION
## Summary

PowerMCP now accepts PowerIO 1.0 modules at its solver boundaries and requires `powerio[mcp,matrix]>=1.0.0,<2`. Module diagnostics and typed values remain intact through the supported adapter paths.

The Tellegen adapter exposes three tools: `capabilities`, `solve_dc_opf`, and `plan_capacity`. It uses the generated `tellegen.cli/1` contract and exchanges PowerIO modules plus the shared capacity planning request and result types. Browser approval and experiment replay semantics are not part of the headless adapter.

Source checkout and packaged launcher behavior now agree. Subprocess decoding is fixed to UTF-8, and wheel and source archives include the Tellegen server and generated contract.

## Reviewed companions

- PowerIO 1.0 candidate: `e39afc9d669349df5133ff6140598010a498cdb1`
- Tellegen PR #97: `23b69643e3c3d32fdecc4296099e40f42354d308`
- Generated Tellegen contract SHA-256: `76563999b750cd61c7f110a1034b4fc9bc5575df8de6a8f7a20729d062b64327`

CI installs the exact PowerIO review commit until PowerIO 1.0.0 is published. The release line goes directly from PowerIO 0.10.0 to 1.0.0.

## Validation

- Full PowerMCP suite: 373 passed, 24 skipped.
- Final PowerIO source pin and Tellegen contract checks: 52 passed.
- Generated contract parity passed.
- Wheel and source archive builds passed Twine and content checks.
- Ruff, compile checks, conflict marker scans, stale release reference scans, and `git diff --check` passed.

This PR remains draft and unmerged. It does not tag or publish a release.
